### PR TITLE
fix(moqtail-ts): use strict undefined check for trackAlias

### DIFF
--- a/libs/moqtail-ts/src/client/client.ts
+++ b/libs/moqtail-ts/src/client/client.ts
@@ -1111,7 +1111,7 @@ export class MOQtailClient {
         const request = this.requests.get(subscriptionRequestId)!
         if (request instanceof SubscribeRequest) {
           const trackAlias = this.subscriptionAliasMap.get(subscriptionRequestId)
-          if (!trackAlias)
+          if (trackAlias === undefined)
             throw new InternalError('MOQtailClient.subscribeUpdate', 'Request exists but track alias mapping does not')
           const subscription = this.subscriptions.get(trackAlias)
           if (!subscription)
@@ -1175,7 +1175,7 @@ export class MOQtailClient {
         throw new ProtocolViolationError('MOQtailClient.switch', 'Request id is not a subscription')
 
       const trackAlias = this.subscriptionAliasMap.get(subscriptionRequestId)
-      if (!trackAlias)
+      if (trackAlias === undefined)
         throw new InternalError('MOQtailClient.switch', 'Request exists but track alias mapping does not')
       const subscription = this.subscriptions.get(trackAlias)
       if (!subscription) throw new InternalError('MOQtailClient.switch', 'Request exists but subscription does not')

--- a/libs/moqtail-ts/src/client/handler/subscribe.ts
+++ b/libs/moqtail-ts/src/client/handler/subscribe.ts
@@ -41,7 +41,7 @@ export const handlerSubscribe: ControlMessageHandler<Subscribe> = async (client,
     return
   }
   let subscribeOk: SubscribeOk
-  if (!track.trackAlias) throw new Error('Expected track alias to be set')
+  if (track.trackAlias === undefined) throw new Error('Expected track alias to be set')
   if (track.trackSource.live.largestLocation) {
     subscribeOk = SubscribeOk.newAscendingWithContent(
       msg.requestId,


### PR DESCRIPTION
## Description

Several methods use `if (!trackAlias)` to check whether a `Map.get()` returned a value. Since `trackAlias` is a `BigInt`, and `0n` is falsy in JavaScript (`!0n === true`), this incorrectly treats `trackAlias = 0n` as a missing entry.

The relay assigns `trackAlias = 0` to the first subscription on every connection, so this bug reliably triggers whenever `subscribeUpdate()` or `switch()` is called on the first subscription.

Because the error handler calls `this.disconnect()` before re-throwing, the entire MOQT session is killed.

## Reproduction

1. Connect to a relay and subscribe to any track (gets `trackAlias = 0`)
2. Call `client.subscribeUpdate()` on that subscription's `requestId`
3. Result: throws InternalError and disconnects the session