### PR TITLE
Feature/draft16 subgroup header

### DIFF
--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -347,7 +347,7 @@ async fn send_via_streams(
     let stream = connection.open_uni().await?.await?;
 
     let sub_header =
-      SubgroupHeader::new_with_explicit_id(track_alias, group_id, 1u64, 1u8, true, true);
+      SubgroupHeader::new_with_explicit_id(track_alias, group_id, 1u64, Some(1u8), true, true);
     let header_info = HeaderInfo::Subgroup { header: sub_header };
     let stream = Arc::new(Mutex::new(stream));
     let mut handler = SendDataStream::new(stream, header_info).await?;
@@ -363,7 +363,7 @@ async fn send_via_streams(
         payload: Some(Bytes::from(payload)),
       };
       let object =
-        Object::try_from_subgroup(subgroup_obj, track_alias, group_id, Some(group_id), 1)?;
+        Object::try_from_subgroup(subgroup_obj, track_alias, group_id, Some(group_id), Some(1))?;
 
       match handler.send_object(&object, prev_object_id).await {
         Ok(_) => {

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -298,7 +298,7 @@ impl Subscription {
                               relay_track_id,
                               object.group_id,
                               object.subgroup_id,
-                              object.publisher_priority,
+                              Some(object.publisher_priority),
                               has_extensions,
                               false,
                             ),

--- a/libs/moqtail-rs/src/model/data/constant.rs
+++ b/libs/moqtail-rs/src/model/data/constant.rs
@@ -20,7 +20,7 @@ pub enum FetchHeaderType {
   Type0x05 = 0x05,
 }
 
-/// Subgroup Header Type (Draft-16)
+/// Subgroup Header Type
 ///
 /// Type bit layout (0b00X1XXXX):
 /// - Bit 0 (0x01): EXTENSIONS - Extensions present in all objects
@@ -35,113 +35,105 @@ pub enum FetchHeaderType {
 ///
 /// Valid ranges: 0x10-0x15, 0x18-0x1D (bit 5=0), 0x30-0x35, 0x38-0x3D (bit 5=1)
 /// Invalid: 0x16, 0x17, 0x1E, 0x1F, 0x36, 0x37, 0x3E, 0x3F (SUBGROUP_ID_MODE=0b11)
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum SubgroupHeaderType {
-  // Bit 5 = 0 (priority present)
-  /// Subgroup ID = 0, No Extensions, No End of Group (0x10)
-  Type0x10 = 0x10,
-  /// Subgroup ID = 0, Extensions Present, No End of Group (0x11)
-  Type0x11 = 0x11,
-  /// Subgroup ID = First Object ID, No Extensions, No End of Group (0x12)
-  Type0x12 = 0x12,
-  /// Subgroup ID = First Object ID, Extensions Present, No End of Group (0x13)
-  Type0x13 = 0x13,
-  /// Explicit Subgroup ID, No Extensions, No End of Group (0x14)
-  Type0x14 = 0x14,
-  /// Explicit Subgroup ID, Extensions Present, No End of Group (0x15)
-  Type0x15 = 0x15,
-  /// Subgroup ID = 0, No Extensions, Contains End of Group (0x18)
-  Type0x18 = 0x18,
-  /// Subgroup ID = 0, Extensions Present, Contains End of Group (0x19)
-  Type0x19 = 0x19,
-  /// Subgroup ID = First Object ID, No Extensions, Contains End of Group (0x1A)
-  Type0x1A = 0x1A,
-  /// Subgroup ID = First Object ID, Extensions Present, Contains End of Group (0x1B)
-  Type0x1B = 0x1B,
-  /// Explicit Subgroup ID, No Extensions, Contains End of Group (0x1C)
-  Type0x1C = 0x1C,
-  /// Explicit Subgroup ID, Extensions Present, Contains End of Group (0x1D)
-  Type0x1D = 0x1D,
-  // Bit 5 = 1 (default priority)
-  /// Subgroup ID = 0, No Extensions, No End of Group, Default Priority (0x30)
-  Type0x30 = 0x30,
-  /// Subgroup ID = 0, Extensions Present, No End of Group, Default Priority (0x31)
-  Type0x31 = 0x31,
-  /// Subgroup ID = First Object ID, No Extensions, No End of Group, Default Priority (0x32)
-  Type0x32 = 0x32,
-  /// Subgroup ID = First Object ID, Extensions Present, No End of Group, Default Priority (0x33)
-  Type0x33 = 0x33,
-  /// Explicit Subgroup ID, No Extensions, No End of Group, Default Priority (0x34)
-  Type0x34 = 0x34,
-  /// Explicit Subgroup ID, Extensions Present, No End of Group, Default Priority (0x35)
-  Type0x35 = 0x35,
-  /// Subgroup ID = 0, No Extensions, Contains End of Group, Default Priority (0x38)
-  Type0x38 = 0x38,
-  /// Subgroup ID = 0, Extensions Present, Contains End of Group, Default Priority (0x39)
-  Type0x39 = 0x39,
-  /// Subgroup ID = First Object ID, No Extensions, Contains End of Group, Default Priority (0x3A)
-  Type0x3A = 0x3A,
-  /// Subgroup ID = First Object ID, Extensions Present, Contains End of Group, Default Priority (0x3B)
-  Type0x3B = 0x3B,
-  /// Explicit Subgroup ID, No Extensions, Contains End of Group, Default Priority (0x3C)
-  Type0x3C = 0x3C,
-  /// Explicit Subgroup ID, Extensions Present, Contains End of Group, Default Priority (0x3D)
-  Type0x3D = 0x3D,
-}
+#[derive(Debug, PartialEq, Clone, Copy, Eq)]
+pub struct SubgroupHeaderType(u8);
 
 impl SubgroupHeaderType {
+  /// Extensions present in all objects (bit 0)
+  pub const EXTENSIONS: u8 = 0x01;
+  /// Mask for SUBGROUP_ID_MODE (bits 1-2)
+  pub const SUBGROUP_ID_MODE_MASK: u8 = 0x06;
+  /// This subgroup contains the final object in the group (bit 3)
+  pub const END_OF_GROUP: u8 = 0x08;
+  /// Required bit that must always be set (bit 4)
+  pub const REQUIRED_BIT: u8 = 0x10;
+  /// Publisher priority field omitted, inherited from subscription (bit 5)
+  pub const DEFAULT_PRIORITY: u8 = 0x20;
+  /// Mask for bits that must be zero: bits 6-7
+  const INVALID_BITS_MASK: u8 = 0xC0;
+  /// Reserved SUBGROUP_ID_MODE value (0b11)
+  const RESERVED_SUBGROUP_MODE: u8 = 0x06;
+
+  /// Validate and create from a raw value.
+  pub fn try_new(value: u64) -> Result<Self, ParseError> {
+    if value > u8::MAX as u64 || (value as u8) & Self::INVALID_BITS_MASK != 0 {
+      return Err(ParseError::InvalidType {
+        context: "SubgroupHeaderType::try_new",
+        details: format!("invalid bits set, got {value:#x}"),
+      });
+    }
+    let v = value as u8;
+    if v & Self::REQUIRED_BIT == 0 {
+      return Err(ParseError::InvalidType {
+        context: "SubgroupHeaderType::try_new",
+        details: format!("bit 4 not set, got {value:#x}"),
+      });
+    }
+    if v & Self::SUBGROUP_ID_MODE_MASK == Self::RESERVED_SUBGROUP_MODE {
+      return Err(ParseError::InvalidType {
+        context: "SubgroupHeaderType::try_new",
+        details: format!("reserved SUBGROUP_ID_MODE 0b11, got {value:#x}"),
+      });
+    }
+    Ok(Self(v))
+  }
+
+  /// Get the raw u8 value.
+  pub fn value(&self) -> u8 {
+    self.0
+  }
+
   /// Check if extensions are present (bit 0 set)
   pub fn has_extensions(&self) -> bool {
-    (*self as u64) & 0x01 != 0
+    self.0 & Self::EXTENSIONS != 0
   }
 
-  /// Check if subgroup ID is explicit in header (bits 1-2 = 0b10)
+  /// Check if subgroup ID is explicit in header (SUBGROUP_ID_MODE = 0b10)
   pub fn has_explicit_subgroup_id(&self) -> bool {
-    (*self as u64) & 0x06 == 0x04
+    self.0 & Self::SUBGROUP_ID_MODE_MASK == 0x04
   }
 
-  /// Check if subgroup ID = 0 (bits 1-2 = 0b00)
+  /// Check if subgroup ID = 0 (SUBGROUP_ID_MODE = 0b00)
   pub fn subgroup_id_is_zero(&self) -> bool {
-    (*self as u64) & 0x06 == 0x00
+    self.0 & Self::SUBGROUP_ID_MODE_MASK == 0x00
   }
 
-  /// Check if subgroup ID = first Object ID (bits 1-2 = 0b01)
+  /// Check if subgroup ID = first Object ID (SUBGROUP_ID_MODE = 0b01)
   pub fn subgroup_id_is_first_object_id(&self) -> bool {
-    (*self as u64) & 0x06 == 0x02
+    self.0 & Self::SUBGROUP_ID_MODE_MASK == 0x02
   }
 
   /// Check if this subgroup contains end of group (bit 3 set)
   pub fn contains_end_of_group(&self) -> bool {
-    (*self as u64) & 0x08 != 0
+    self.0 & Self::END_OF_GROUP != 0
   }
 
   /// Check if using default publisher priority (bit 5 set).
   /// When true, publisher_priority field is omitted from header.
   pub fn has_default_priority(&self) -> bool {
-    (*self as u64) & 0x20 != 0
+    self.0 & Self::DEFAULT_PRIORITY != 0
   }
 
-  /// Create type from properties.
+  /// Create type from property flags.
   /// subgroup_id_mode: 0=zero, 1=firstObjId, 2=explicit
   pub fn from_properties(
     has_extensions: bool,
-    subgroup_id_mode: u64,
+    subgroup_id_mode: u8,
     contains_end_of_group: bool,
     has_default_priority: bool,
   ) -> Self {
-    let mut type_val: u64 = 0x10; // bit 4 always set
+    let mut v: u8 = Self::REQUIRED_BIT;
     if has_extensions {
-      type_val |= 0x01;
+      v |= Self::EXTENSIONS;
     }
-    type_val |= (subgroup_id_mode & 0x03) << 1; // bits 1-2
+    v |= (subgroup_id_mode & 0x03) << 1; // bits 1-2
     if contains_end_of_group {
-      type_val |= 0x08;
+      v |= Self::END_OF_GROUP;
     }
     if has_default_priority {
-      type_val |= 0x20;
+      v |= Self::DEFAULT_PRIORITY;
     }
-    // Safe because we construct valid patterns
-    Self::try_from(type_val).unwrap()
+    Self(v)
   }
 }
 
@@ -149,69 +141,13 @@ impl TryFrom<u64> for SubgroupHeaderType {
   type Error = ParseError;
 
   fn try_from(value: u64) -> Result<Self, Self::Error> {
-    // Validate bit layout before matching
-    // Bit 4 (0x10) must be set to distinguish from other header types
-    if (value & 0x10) == 0 {
-      return Err(ParseError::InvalidType {
-        context: "SubgroupHeaderType::try_from(u64)",
-        details: format!("bit 4 not set, got {value:#x}"),
-      });
-    }
-
-    // SUBGROUP_ID_MODE (bits 1-2) must not be 0b11 (reserved for future use)
-    if (value & 0x06) == 0x06 {
-      return Err(ParseError::InvalidType {
-        context: "SubgroupHeaderType::try_from(u64)",
-        details: format!("reserved SUBGROUP_ID_MODE 0b11, got {value:#x}"),
-      });
-    }
-
-    // Must be in valid range [0x10, 0x3F]
-    if value < 0x10 || value > 0x3F {
-      return Err(ParseError::InvalidType {
-        context: "SubgroupHeaderType::try_from(u64)",
-        details: format!("out of valid range, got {value:#x}"),
-      });
-    }
-
-    match value {
-      // Bit 5 = 0 (priority present)
-      0x10 => Ok(SubgroupHeaderType::Type0x10),
-      0x11 => Ok(SubgroupHeaderType::Type0x11),
-      0x12 => Ok(SubgroupHeaderType::Type0x12),
-      0x13 => Ok(SubgroupHeaderType::Type0x13),
-      0x14 => Ok(SubgroupHeaderType::Type0x14),
-      0x15 => Ok(SubgroupHeaderType::Type0x15),
-      0x18 => Ok(SubgroupHeaderType::Type0x18),
-      0x19 => Ok(SubgroupHeaderType::Type0x19),
-      0x1A => Ok(SubgroupHeaderType::Type0x1A),
-      0x1B => Ok(SubgroupHeaderType::Type0x1B),
-      0x1C => Ok(SubgroupHeaderType::Type0x1C),
-      0x1D => Ok(SubgroupHeaderType::Type0x1D),
-      // Bit 5 = 1 (default priority)
-      0x30 => Ok(SubgroupHeaderType::Type0x30),
-      0x31 => Ok(SubgroupHeaderType::Type0x31),
-      0x32 => Ok(SubgroupHeaderType::Type0x32),
-      0x33 => Ok(SubgroupHeaderType::Type0x33),
-      0x34 => Ok(SubgroupHeaderType::Type0x34),
-      0x35 => Ok(SubgroupHeaderType::Type0x35),
-      0x38 => Ok(SubgroupHeaderType::Type0x38),
-      0x39 => Ok(SubgroupHeaderType::Type0x39),
-      0x3A => Ok(SubgroupHeaderType::Type0x3A),
-      0x3B => Ok(SubgroupHeaderType::Type0x3B),
-      0x3C => Ok(SubgroupHeaderType::Type0x3C),
-      0x3D => Ok(SubgroupHeaderType::Type0x3D),
-      _ => Err(ParseError::InvalidType {
-        context: "SubgroupHeaderType::try_from(u64)",
-        details: format!("Invalid type value, got {value:#x}"),
-      }),
-    }
+    Self::try_new(value)
   }
 }
 
 impl From<SubgroupHeaderType> for u64 {
-  fn from(header_type: SubgroupHeaderType) -> Self {
-    header_type as u64
+  fn from(t: SubgroupHeaderType) -> Self {
+    t.0 as u64
   }
 }
 

--- a/libs/moqtail-rs/src/model/data/constant.rs
+++ b/libs/moqtail-rs/src/model/data/constant.rs
@@ -20,78 +20,128 @@ pub enum FetchHeaderType {
   Type0x05 = 0x05,
 }
 
+/// Subgroup Header Type (Draft-16)
+///
+/// Type bit layout (0b00X1XXXX):
+/// - Bit 0 (0x01): EXTENSIONS - Extensions present in all objects
+/// - Bits 1-2 (0x06): SUBGROUP_ID_MODE - How subgroup ID is encoded
+///   - 0b00 (0x00): Subgroup ID = 0 (absent from header)
+///   - 0b01 (0x02): Subgroup ID = First Object ID (absent from header)
+///   - 0b10 (0x04): Subgroup ID = explicit (present in header)
+///   - 0b11 (0x06): Reserved for future use (invalid, triggers PROTOCOL_VIOLATION)
+/// - Bit 3 (0x08): END_OF_GROUP - This subgroup contains the final object in the group
+/// - Bit 4 (0x10): Always set (distinguishes subgroup from other header types)
+/// - Bit 5 (0x20): DEFAULT_PRIORITY - Publisher priority field omitted, inherited from subscription
+///
+/// Valid ranges: 0x10-0x15, 0x18-0x1D (bit 5=0), 0x30-0x35, 0x38-0x3D (bit 5=1)
+/// Invalid: 0x16, 0x17, 0x1E, 0x1F, 0x36, 0x37, 0x3E, 0x3F (SUBGROUP_ID_MODE=0b11)
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum SubgroupHeaderType {
-  /// No Subgroup ID field (Subgroup ID = 0), No Extensions, No End of Group
+  // Bit 5 = 0 (priority present)
+  /// Subgroup ID = 0, No Extensions, No End of Group (0x10)
   Type0x10 = 0x10,
-  /// No Subgroup ID field (Subgroup ID = 0), Extensions Present, No End of Group
+  /// Subgroup ID = 0, Extensions Present, No End of Group (0x11)
   Type0x11 = 0x11,
-  /// No Subgroup ID field (Subgroup ID = First Object ID), No Extensions, No End of Group
+  /// Subgroup ID = First Object ID, No Extensions, No End of Group (0x12)
   Type0x12 = 0x12,
-  /// No Subgroup ID field (Subgroup ID = First Object ID), Extensions Present, No End of Group
+  /// Subgroup ID = First Object ID, Extensions Present, No End of Group (0x13)
   Type0x13 = 0x13,
-  /// Explicit Subgroup ID field, No Extensions, No End of Group
+  /// Explicit Subgroup ID, No Extensions, No End of Group (0x14)
   Type0x14 = 0x14,
-  /// Explicit Subgroup ID field, Extensions Present, No End of Group
+  /// Explicit Subgroup ID, Extensions Present, No End of Group (0x15)
   Type0x15 = 0x15,
-  /// No Subgroup ID field (Subgroup ID = 0), No Extensions, Contains End of Group
+  /// Subgroup ID = 0, No Extensions, Contains End of Group (0x18)
   Type0x18 = 0x18,
-  /// No Subgroup ID field (Subgroup ID = 0), Extensions Present, Contains End of Group
+  /// Subgroup ID = 0, Extensions Present, Contains End of Group (0x19)
   Type0x19 = 0x19,
-  /// No Subgroup ID field (Subgroup ID = First Object ID), No Extensions, Contains End of Group
+  /// Subgroup ID = First Object ID, No Extensions, Contains End of Group (0x1A)
   Type0x1A = 0x1A,
-  /// No Subgroup ID field (Subgroup ID = First Object ID), Extensions Present, Contains End of Group
+  /// Subgroup ID = First Object ID, Extensions Present, Contains End of Group (0x1B)
   Type0x1B = 0x1B,
-  /// Explicit Subgroup ID field, No Extensions, Contains End of Group
+  /// Explicit Subgroup ID, No Extensions, Contains End of Group (0x1C)
   Type0x1C = 0x1C,
-  /// Explicit Subgroup ID field, Extensions Present, Contains End of Group
+  /// Explicit Subgroup ID, Extensions Present, Contains End of Group (0x1D)
   Type0x1D = 0x1D,
+  // Bit 5 = 1 (default priority)
+  /// Subgroup ID = 0, No Extensions, No End of Group, Default Priority (0x30)
+  Type0x30 = 0x30,
+  /// Subgroup ID = 0, Extensions Present, No End of Group, Default Priority (0x31)
+  Type0x31 = 0x31,
+  /// Subgroup ID = First Object ID, No Extensions, No End of Group, Default Priority (0x32)
+  Type0x32 = 0x32,
+  /// Subgroup ID = First Object ID, Extensions Present, No End of Group, Default Priority (0x33)
+  Type0x33 = 0x33,
+  /// Explicit Subgroup ID, No Extensions, No End of Group, Default Priority (0x34)
+  Type0x34 = 0x34,
+  /// Explicit Subgroup ID, Extensions Present, No End of Group, Default Priority (0x35)
+  Type0x35 = 0x35,
+  /// Subgroup ID = 0, No Extensions, Contains End of Group, Default Priority (0x38)
+  Type0x38 = 0x38,
+  /// Subgroup ID = 0, Extensions Present, Contains End of Group, Default Priority (0x39)
+  Type0x39 = 0x39,
+  /// Subgroup ID = First Object ID, No Extensions, Contains End of Group, Default Priority (0x3A)
+  Type0x3A = 0x3A,
+  /// Subgroup ID = First Object ID, Extensions Present, Contains End of Group, Default Priority (0x3B)
+  Type0x3B = 0x3B,
+  /// Explicit Subgroup ID, No Extensions, Contains End of Group, Default Priority (0x3C)
+  Type0x3C = 0x3C,
+  /// Explicit Subgroup ID, Extensions Present, Contains End of Group, Default Priority (0x3D)
+  Type0x3D = 0x3D,
 }
 
 impl SubgroupHeaderType {
-  pub fn has_explicit_subgroup_id(&self) -> bool {
-    matches!(
-      self,
-      Self::Type0x14 | Self::Type0x15 | Self::Type0x1C | Self::Type0x1D
-    )
-  }
-
+  /// Check if extensions are present (bit 0 set)
   pub fn has_extensions(&self) -> bool {
-    matches!(
-      self,
-      Self::Type0x11
-        | Self::Type0x13
-        | Self::Type0x15
-        | Self::Type0x19
-        | Self::Type0x1B
-        | Self::Type0x1D
-    )
+    (*self as u64) & 0x01 != 0
   }
 
-  pub fn contains_end_of_group(&self) -> bool {
-    matches!(
-      self,
-      Self::Type0x18
-        | Self::Type0x19
-        | Self::Type0x1A
-        | Self::Type0x1B
-        | Self::Type0x1C
-        | Self::Type0x1D
-    )
+  /// Check if subgroup ID is explicit in header (bits 1-2 = 0b10)
+  pub fn has_explicit_subgroup_id(&self) -> bool {
+    (*self as u64) & 0x06 == 0x04
   }
 
+  /// Check if subgroup ID = 0 (bits 1-2 = 0b00)
   pub fn subgroup_id_is_zero(&self) -> bool {
-    matches!(
-      self,
-      Self::Type0x10 | Self::Type0x11 | Self::Type0x18 | Self::Type0x19
-    )
+    (*self as u64) & 0x06 == 0x00
   }
 
+  /// Check if subgroup ID = first Object ID (bits 1-2 = 0b01)
   pub fn subgroup_id_is_first_object_id(&self) -> bool {
-    matches!(
-      self,
-      Self::Type0x12 | Self::Type0x13 | Self::Type0x1A | Self::Type0x1B
-    )
+    (*self as u64) & 0x06 == 0x02
+  }
+
+  /// Check if this subgroup contains end of group (bit 3 set)
+  pub fn contains_end_of_group(&self) -> bool {
+    (*self as u64) & 0x08 != 0
+  }
+
+  /// Check if using default publisher priority (bit 5 set).
+  /// When true, publisher_priority field is omitted from header.
+  pub fn has_default_priority(&self) -> bool {
+    (*self as u64) & 0x20 != 0
+  }
+
+  /// Create type from properties.
+  /// subgroup_id_mode: 0=zero, 1=firstObjId, 2=explicit
+  pub fn from_properties(
+    has_extensions: bool,
+    subgroup_id_mode: u64,
+    contains_end_of_group: bool,
+    has_default_priority: bool,
+  ) -> Self {
+    let mut type_val: u64 = 0x10; // bit 4 always set
+    if has_extensions {
+      type_val |= 0x01;
+    }
+    type_val |= (subgroup_id_mode & 0x03) << 1; // bits 1-2
+    if contains_end_of_group {
+      type_val |= 0x08;
+    }
+    if has_default_priority {
+      type_val |= 0x20;
+    }
+    // Safe because we construct valid patterns
+    Self::try_from(type_val).unwrap()
   }
 }
 
@@ -99,7 +149,33 @@ impl TryFrom<u64> for SubgroupHeaderType {
   type Error = ParseError;
 
   fn try_from(value: u64) -> Result<Self, Self::Error> {
+    // Validate bit layout before matching
+    // Bit 4 (0x10) must be set to distinguish from other header types
+    if (value & 0x10) == 0 {
+      return Err(ParseError::InvalidType {
+        context: "SubgroupHeaderType::try_from(u64)",
+        details: format!("bit 4 not set, got {value:#x}"),
+      });
+    }
+
+    // SUBGROUP_ID_MODE (bits 1-2) must not be 0b11 (reserved for future use)
+    if (value & 0x06) == 0x06 {
+      return Err(ParseError::InvalidType {
+        context: "SubgroupHeaderType::try_from(u64)",
+        details: format!("reserved SUBGROUP_ID_MODE 0b11, got {value:#x}"),
+      });
+    }
+
+    // Must be in valid range [0x10, 0x3F]
+    if value < 0x10 || value > 0x3F {
+      return Err(ParseError::InvalidType {
+        context: "SubgroupHeaderType::try_from(u64)",
+        details: format!("out of valid range, got {value:#x}"),
+      });
+    }
+
     match value {
+      // Bit 5 = 0 (priority present)
       0x10 => Ok(SubgroupHeaderType::Type0x10),
       0x11 => Ok(SubgroupHeaderType::Type0x11),
       0x12 => Ok(SubgroupHeaderType::Type0x12),
@@ -112,9 +188,22 @@ impl TryFrom<u64> for SubgroupHeaderType {
       0x1B => Ok(SubgroupHeaderType::Type0x1B),
       0x1C => Ok(SubgroupHeaderType::Type0x1C),
       0x1D => Ok(SubgroupHeaderType::Type0x1D),
+      // Bit 5 = 1 (default priority)
+      0x30 => Ok(SubgroupHeaderType::Type0x30),
+      0x31 => Ok(SubgroupHeaderType::Type0x31),
+      0x32 => Ok(SubgroupHeaderType::Type0x32),
+      0x33 => Ok(SubgroupHeaderType::Type0x33),
+      0x34 => Ok(SubgroupHeaderType::Type0x34),
+      0x35 => Ok(SubgroupHeaderType::Type0x35),
+      0x38 => Ok(SubgroupHeaderType::Type0x38),
+      0x39 => Ok(SubgroupHeaderType::Type0x39),
+      0x3A => Ok(SubgroupHeaderType::Type0x3A),
+      0x3B => Ok(SubgroupHeaderType::Type0x3B),
+      0x3C => Ok(SubgroupHeaderType::Type0x3C),
+      0x3D => Ok(SubgroupHeaderType::Type0x3D),
       _ => Err(ParseError::InvalidType {
         context: "SubgroupHeaderType::try_from(u64)",
-        details: format!("Invalid type, got {value}"),
+        details: format!("Invalid type value, got {value:#x}"),
       }),
     }
   }

--- a/libs/moqtail-rs/src/model/data/object.rs
+++ b/libs/moqtail-rs/src/model/data/object.rs
@@ -93,10 +93,10 @@ impl Object {
 
   pub fn try_from_subgroup(
     subgroup_obj: SubgroupObject,
-    track_alias: u64,         // Context from SubgroupHeader
-    group_id: u64,            // Context from SubgroupHeader
-    subgroup_id: Option<u64>, // Context from SubgroupHeader
-    publisher_priority: u8,   // Context from SubgroupHeader
+    track_alias: u64,            // Context from SubgroupHeader
+    group_id: u64,               // Context from SubgroupHeader
+    subgroup_id: Option<u64>,    // Context from SubgroupHeader
+    publisher_priority: Option<u8>, // Context from SubgroupHeader; None when using DEFAULT_PRIORITY
   ) -> Result<Self, ParseError> {
     Ok(Object {
       track_alias,
@@ -104,7 +104,7 @@ impl Object {
         group: group_id,
         object: subgroup_obj.object_id,
       },
-      publisher_priority,
+      publisher_priority: publisher_priority.unwrap_or(0), // Default to 0 if not specified
       forwarding_preference: ObjectForwardingPreference::Subgroup,
       subgroup_id,
       status: subgroup_obj.object_status.unwrap_or(ObjectStatus::Normal),

--- a/libs/moqtail-rs/src/model/data/subgroup_header.rs
+++ b/libs/moqtail-rs/src/model/data/subgroup_header.rs
@@ -24,7 +24,8 @@ pub struct SubgroupHeader {
   pub track_alias: u64,
   pub group_id: u64,
   pub subgroup_id: Option<u64>,
-  pub publisher_priority: u8,
+  /// Publisher priority. None when header_type has DEFAULT_PRIORITY bit set.
+  pub publisher_priority: Option<u8>,
 }
 
 impl SubgroupHeader {
@@ -32,15 +33,20 @@ impl SubgroupHeader {
   pub fn new_fixed_zero_id(
     track_alias: u64,
     group_id: u64,
-    publisher_priority: u8,
+    publisher_priority: Option<u8>,
     has_extensions: bool,
     contains_end_of_group: bool,
   ) -> Self {
-    let header_type = match (has_extensions, contains_end_of_group) {
-      (false, false) => SubgroupHeaderType::Type0x10,
-      (true, false) => SubgroupHeaderType::Type0x11,
-      (false, true) => SubgroupHeaderType::Type0x18,
-      (true, true) => SubgroupHeaderType::Type0x19,
+    let has_default_priority = publisher_priority.is_none();
+    let header_type = match (has_extensions, contains_end_of_group, has_default_priority) {
+      (false, false, false) => SubgroupHeaderType::Type0x10,
+      (true, false, false) => SubgroupHeaderType::Type0x11,
+      (false, true, false) => SubgroupHeaderType::Type0x18,
+      (true, true, false) => SubgroupHeaderType::Type0x19,
+      (false, false, true) => SubgroupHeaderType::Type0x30,
+      (true, false, true) => SubgroupHeaderType::Type0x31,
+      (false, true, true) => SubgroupHeaderType::Type0x38,
+      (true, true, true) => SubgroupHeaderType::Type0x39,
     };
 
     Self {
@@ -56,15 +62,20 @@ impl SubgroupHeader {
   pub fn new_first_object_id(
     track_alias: u64,
     group_id: u64,
-    publisher_priority: u8,
+    publisher_priority: Option<u8>,
     has_extensions: bool,
     contains_end_of_group: bool,
   ) -> Self {
-    let header_type = match (has_extensions, contains_end_of_group) {
-      (false, false) => SubgroupHeaderType::Type0x12,
-      (true, false) => SubgroupHeaderType::Type0x13,
-      (false, true) => SubgroupHeaderType::Type0x1A,
-      (true, true) => SubgroupHeaderType::Type0x1B,
+    let has_default_priority = publisher_priority.is_none();
+    let header_type = match (has_extensions, contains_end_of_group, has_default_priority) {
+      (false, false, false) => SubgroupHeaderType::Type0x12,
+      (true, false, false) => SubgroupHeaderType::Type0x13,
+      (false, true, false) => SubgroupHeaderType::Type0x1A,
+      (true, true, false) => SubgroupHeaderType::Type0x1B,
+      (false, false, true) => SubgroupHeaderType::Type0x32,
+      (true, false, true) => SubgroupHeaderType::Type0x33,
+      (false, true, true) => SubgroupHeaderType::Type0x3A,
+      (true, true, true) => SubgroupHeaderType::Type0x3B,
     };
 
     Self {
@@ -81,15 +92,20 @@ impl SubgroupHeader {
     track_alias: u64,
     group_id: u64,
     subgroup_id: u64,
-    publisher_priority: u8,
+    publisher_priority: Option<u8>,
     has_extensions: bool,
     contains_end_of_group: bool,
   ) -> Self {
-    let header_type = match (has_extensions, contains_end_of_group) {
-      (false, false) => SubgroupHeaderType::Type0x14,
-      (true, false) => SubgroupHeaderType::Type0x15,
-      (false, true) => SubgroupHeaderType::Type0x1C,
-      (true, true) => SubgroupHeaderType::Type0x1D,
+    let has_default_priority = publisher_priority.is_none();
+    let header_type = match (has_extensions, contains_end_of_group, has_default_priority) {
+      (false, false, false) => SubgroupHeaderType::Type0x14,
+      (true, false, false) => SubgroupHeaderType::Type0x15,
+      (false, true, false) => SubgroupHeaderType::Type0x1C,
+      (true, true, false) => SubgroupHeaderType::Type0x1D,
+      (false, false, true) => SubgroupHeaderType::Type0x34,
+      (true, false, true) => SubgroupHeaderType::Type0x35,
+      (false, true, true) => SubgroupHeaderType::Type0x3C,
+      (true, true, true) => SubgroupHeaderType::Type0x3D,
     };
 
     Self {
@@ -129,8 +145,18 @@ impl SubgroupHeader {
       }
     }
 
-    // Publisher Priority
-    buf.put_u8(self.publisher_priority);
+    // Publisher Priority (omitted when DEFAULT_PRIORITY bit is set)
+    if !self.header_type.has_default_priority() {
+      if let Some(priority) = self.publisher_priority {
+        buf.put_u8(priority);
+      } else {
+        return Err(ParseError::ProtocolViolation {
+          context: "SubgroupHeader::serialize(publisher_priority)",
+          details: "Publisher_priority field is required when DEFAULT_PRIORITY bit is not set"
+            .to_string(),
+        });
+      }
+    }
 
     Ok(buf.freeze())
   }
@@ -156,14 +182,19 @@ impl SubgroupHeader {
       None // For types where Subgroup ID = first object ID
     };
 
-    if bytes.remaining() < 1 {
-      return Err(ParseError::NotEnoughBytes {
-        context: "SubgroupHeader::deserialize(publisher_priority)",
-        needed: 1,
-        available: bytes.remaining(),
-      });
-    }
-    let publisher_priority = bytes.get_u8();
+    // Parse Publisher Priority (omitted when DEFAULT_PRIORITY bit is set)
+    let publisher_priority = if !header_type.has_default_priority() {
+      if bytes.remaining() < 1 {
+        return Err(ParseError::NotEnoughBytes {
+          context: "SubgroupHeader::deserialize(publisher_priority)",
+          needed: 1,
+          available: bytes.remaining(),
+        });
+      }
+      Some(bytes.get_u8())
+    } else {
+      None
+    };
 
     Ok(Self {
       header_type,
@@ -187,7 +218,28 @@ mod tests {
     let track_alias = 87;
     let group_id = 9;
     let subgroup_id = Some(11);
-    let publisher_priority = 255;
+    let publisher_priority = Some(255);
+    let subgroup_header = SubgroupHeader {
+      header_type,
+      track_alias,
+      group_id,
+      subgroup_id,
+      publisher_priority,
+    };
+
+    let mut buf = subgroup_header.serialize(None).unwrap();
+    let deserialized = SubgroupHeader::deserialize(&mut buf).unwrap();
+    assert_eq!(deserialized, subgroup_header);
+    assert!(!buf.has_remaining());
+  }
+
+  #[test]
+  fn test_roundtrip_default_priority() {
+    let header_type = SubgroupHeaderType::Type0x30; // DEFAULT_PRIORITY bit set
+    let track_alias = 87;
+    let group_id = 9;
+    let subgroup_id = Some(0);
+    let publisher_priority = None; // Not included in wire format
     let subgroup_header = SubgroupHeader {
       header_type,
       track_alias,
@@ -208,7 +260,7 @@ mod tests {
     let track_alias = 87;
     let group_id = 9;
     let subgroup_id = Some(11);
-    let publisher_priority = 255;
+    let publisher_priority = Some(255);
     let subgroup_header = SubgroupHeader {
       header_type,
       track_alias,
@@ -234,7 +286,7 @@ mod tests {
     let track_alias = 87;
     let group_id = 9;
     let subgroup_id = Some(11);
-    let publisher_priority = 255;
+    let publisher_priority = Some(255);
     let subgroup_header = SubgroupHeader {
       header_type,
       track_alias,
@@ -271,7 +323,7 @@ mod tests {
     for (header_type, has_explicit_id, expected_subgroup_id) in test_cases {
       let track_alias = 87;
       let group_id = 9;
-      let publisher_priority = 255;
+      let publisher_priority = Some(255);
 
       let subgroup_header = SubgroupHeader {
         header_type,
@@ -338,11 +390,16 @@ mod tests {
   fn test_constructor_methods() {
     let track_alias = 87;
     let group_id = 9;
-    let publisher_priority = 255;
+    let publisher_priority = Some(255);
 
     // Test new_fixed_zero_id
-    let header =
-      SubgroupHeader::new_fixed_zero_id(track_alias, group_id, publisher_priority, false, false);
+    let header = SubgroupHeader::new_fixed_zero_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      false,
+      false,
+    );
     assert_eq!(header.header_type, SubgroupHeaderType::Type0x10);
     assert_eq!(header.subgroup_id, Some(0));
 
@@ -362,13 +419,23 @@ mod tests {
     assert_eq!(header.subgroup_id, Some(0));
 
     // Test new_first_object_id
-    let header =
-      SubgroupHeader::new_first_object_id(track_alias, group_id, publisher_priority, false, false);
+    let header = SubgroupHeader::new_first_object_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      false,
+      false,
+    );
     assert_eq!(header.header_type, SubgroupHeaderType::Type0x12);
     assert_eq!(header.subgroup_id, None);
 
-    let header =
-      SubgroupHeader::new_first_object_id(track_alias, group_id, publisher_priority, true, false);
+    let header = SubgroupHeader::new_first_object_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      true,
+      false,
+    );
     assert_eq!(header.header_type, SubgroupHeaderType::Type0x13);
     assert_eq!(header.subgroup_id, None);
 
@@ -438,7 +505,7 @@ mod tests {
 
     let track_alias = 87;
     let group_id = 9;
-    let publisher_priority = 255;
+    let publisher_priority = Some(255);
 
     // Test a header type with fixed subgroup ID = 0
     let header =

--- a/libs/moqtail-rs/src/model/data/subgroup_header.rs
+++ b/libs/moqtail-rs/src/model/data/subgroup_header.rs
@@ -38,16 +38,9 @@ impl SubgroupHeader {
     contains_end_of_group: bool,
   ) -> Self {
     let has_default_priority = publisher_priority.is_none();
-    let header_type = match (has_extensions, contains_end_of_group, has_default_priority) {
-      (false, false, false) => SubgroupHeaderType::Type0x10,
-      (true, false, false) => SubgroupHeaderType::Type0x11,
-      (false, true, false) => SubgroupHeaderType::Type0x18,
-      (true, true, false) => SubgroupHeaderType::Type0x19,
-      (false, false, true) => SubgroupHeaderType::Type0x30,
-      (true, false, true) => SubgroupHeaderType::Type0x31,
-      (false, true, true) => SubgroupHeaderType::Type0x38,
-      (true, true, true) => SubgroupHeaderType::Type0x39,
-    };
+    let header_type = SubgroupHeaderType::from_properties(
+      has_extensions, 0, contains_end_of_group, has_default_priority,
+    );
 
     Self {
       header_type,
@@ -67,16 +60,9 @@ impl SubgroupHeader {
     contains_end_of_group: bool,
   ) -> Self {
     let has_default_priority = publisher_priority.is_none();
-    let header_type = match (has_extensions, contains_end_of_group, has_default_priority) {
-      (false, false, false) => SubgroupHeaderType::Type0x12,
-      (true, false, false) => SubgroupHeaderType::Type0x13,
-      (false, true, false) => SubgroupHeaderType::Type0x1A,
-      (true, true, false) => SubgroupHeaderType::Type0x1B,
-      (false, false, true) => SubgroupHeaderType::Type0x32,
-      (true, false, true) => SubgroupHeaderType::Type0x33,
-      (false, true, true) => SubgroupHeaderType::Type0x3A,
-      (true, true, true) => SubgroupHeaderType::Type0x3B,
-    };
+    let header_type = SubgroupHeaderType::from_properties(
+      has_extensions, 1, contains_end_of_group, has_default_priority,
+    );
 
     Self {
       header_type,
@@ -97,16 +83,9 @@ impl SubgroupHeader {
     contains_end_of_group: bool,
   ) -> Self {
     let has_default_priority = publisher_priority.is_none();
-    let header_type = match (has_extensions, contains_end_of_group, has_default_priority) {
-      (false, false, false) => SubgroupHeaderType::Type0x14,
-      (true, false, false) => SubgroupHeaderType::Type0x15,
-      (false, true, false) => SubgroupHeaderType::Type0x1C,
-      (true, true, false) => SubgroupHeaderType::Type0x1D,
-      (false, false, true) => SubgroupHeaderType::Type0x34,
-      (true, false, true) => SubgroupHeaderType::Type0x35,
-      (false, true, true) => SubgroupHeaderType::Type0x3C,
-      (true, true, true) => SubgroupHeaderType::Type0x3D,
-    };
+    let header_type = SubgroupHeaderType::from_properties(
+      has_extensions, 2, contains_end_of_group, has_default_priority,
+    );
 
     Self {
       header_type,
@@ -121,7 +100,7 @@ impl SubgroupHeader {
     let mut buf = BytesMut::new();
 
     // Type field
-    buf.put_vi(self.header_type as u64)?;
+    buf.put_vi(u64::from(self.header_type))?;
 
     // Track Alias may be set by the subscription for multi-publisher cases
     if track_alias.is_none() {
@@ -214,7 +193,7 @@ mod tests {
 
   #[test]
   fn test_roundtrip() {
-    let header_type = SubgroupHeaderType::Type0x14;
+    let header_type = SubgroupHeaderType::try_new(0x14).unwrap();
     let track_alias = 87;
     let group_id = 9;
     let subgroup_id = Some(11);
@@ -235,7 +214,7 @@ mod tests {
 
   #[test]
   fn test_roundtrip_default_priority() {
-    let header_type = SubgroupHeaderType::Type0x30; // DEFAULT_PRIORITY bit set
+    let header_type = SubgroupHeaderType::try_new(0x30).unwrap(); // DEFAULT_PRIORITY bit set
     let track_alias = 87;
     let group_id = 9;
     let subgroup_id = Some(0);
@@ -256,7 +235,7 @@ mod tests {
 
   #[test]
   fn test_excess_roundtrip() {
-    let header_type = SubgroupHeaderType::Type0x14;
+    let header_type = SubgroupHeaderType::try_new(0x14).unwrap();
     let track_alias = 87;
     let group_id = 9;
     let subgroup_id = Some(11);
@@ -282,7 +261,7 @@ mod tests {
 
   #[test]
   fn test_partial_message() {
-    let header_type = SubgroupHeaderType::Type0x14;
+    let header_type = SubgroupHeaderType::try_new(0x14).unwrap();
     let track_alias = 87;
     let group_id = 9;
     let subgroup_id = Some(11);
@@ -306,18 +285,18 @@ mod tests {
     // Test all new header types (0x10-0x1D)
     let test_cases = vec![
       // (header_type, has_explicit_id, expected_subgroup_id)
-      (SubgroupHeaderType::Type0x10, false, Some(0)),
-      (SubgroupHeaderType::Type0x11, false, Some(0)),
-      (SubgroupHeaderType::Type0x12, false, None),
-      (SubgroupHeaderType::Type0x13, false, None),
-      (SubgroupHeaderType::Type0x14, true, Some(42)),
-      (SubgroupHeaderType::Type0x15, true, Some(42)),
-      (SubgroupHeaderType::Type0x18, false, Some(0)),
-      (SubgroupHeaderType::Type0x19, false, Some(0)),
-      (SubgroupHeaderType::Type0x1A, false, None),
-      (SubgroupHeaderType::Type0x1B, false, None),
-      (SubgroupHeaderType::Type0x1C, true, Some(42)),
-      (SubgroupHeaderType::Type0x1D, true, Some(42)),
+      (SubgroupHeaderType::try_new(0x10).unwrap(), false, Some(0)),
+      (SubgroupHeaderType::try_new(0x11).unwrap(), false, Some(0)),
+      (SubgroupHeaderType::try_new(0x12).unwrap(), false, None),
+      (SubgroupHeaderType::try_new(0x13).unwrap(), false, None),
+      (SubgroupHeaderType::try_new(0x14).unwrap(), true, Some(42)),
+      (SubgroupHeaderType::try_new(0x15).unwrap(), true, Some(42)),
+      (SubgroupHeaderType::try_new(0x18).unwrap(), false, Some(0)),
+      (SubgroupHeaderType::try_new(0x19).unwrap(), false, Some(0)),
+      (SubgroupHeaderType::try_new(0x1A).unwrap(), false, None),
+      (SubgroupHeaderType::try_new(0x1B).unwrap(), false, None),
+      (SubgroupHeaderType::try_new(0x1C).unwrap(), true, Some(42)),
+      (SubgroupHeaderType::try_new(0x1D).unwrap(), true, Some(42)),
     ];
 
     for (header_type, has_explicit_id, expected_subgroup_id) in test_cases {
@@ -352,38 +331,38 @@ mod tests {
   #[test]
   fn test_header_type_classification() {
     // Test subgroup_id_is_zero
-    assert!(SubgroupHeaderType::Type0x10.subgroup_id_is_zero());
-    assert!(SubgroupHeaderType::Type0x11.subgroup_id_is_zero());
-    assert!(SubgroupHeaderType::Type0x18.subgroup_id_is_zero());
-    assert!(SubgroupHeaderType::Type0x19.subgroup_id_is_zero());
+    assert!(SubgroupHeaderType::try_new(0x10).unwrap().subgroup_id_is_zero());
+    assert!(SubgroupHeaderType::try_new(0x11).unwrap().subgroup_id_is_zero());
+    assert!(SubgroupHeaderType::try_new(0x18).unwrap().subgroup_id_is_zero());
+    assert!(SubgroupHeaderType::try_new(0x19).unwrap().subgroup_id_is_zero());
 
     // Test subgroup_id_is_first_object_id
-    assert!(SubgroupHeaderType::Type0x12.subgroup_id_is_first_object_id());
-    assert!(SubgroupHeaderType::Type0x13.subgroup_id_is_first_object_id());
-    assert!(SubgroupHeaderType::Type0x1A.subgroup_id_is_first_object_id());
-    assert!(SubgroupHeaderType::Type0x1B.subgroup_id_is_first_object_id());
+    assert!(SubgroupHeaderType::try_new(0x12).unwrap().subgroup_id_is_first_object_id());
+    assert!(SubgroupHeaderType::try_new(0x13).unwrap().subgroup_id_is_first_object_id());
+    assert!(SubgroupHeaderType::try_new(0x1A).unwrap().subgroup_id_is_first_object_id());
+    assert!(SubgroupHeaderType::try_new(0x1B).unwrap().subgroup_id_is_first_object_id());
 
     // Test has_explicit_subgroup_id
-    assert!(SubgroupHeaderType::Type0x14.has_explicit_subgroup_id());
-    assert!(SubgroupHeaderType::Type0x15.has_explicit_subgroup_id());
-    assert!(SubgroupHeaderType::Type0x1C.has_explicit_subgroup_id());
-    assert!(SubgroupHeaderType::Type0x1D.has_explicit_subgroup_id());
+    assert!(SubgroupHeaderType::try_new(0x14).unwrap().has_explicit_subgroup_id());
+    assert!(SubgroupHeaderType::try_new(0x15).unwrap().has_explicit_subgroup_id());
+    assert!(SubgroupHeaderType::try_new(0x1C).unwrap().has_explicit_subgroup_id());
+    assert!(SubgroupHeaderType::try_new(0x1D).unwrap().has_explicit_subgroup_id());
 
     // Test contains_end_of_group
-    assert!(SubgroupHeaderType::Type0x18.contains_end_of_group());
-    assert!(SubgroupHeaderType::Type0x19.contains_end_of_group());
-    assert!(SubgroupHeaderType::Type0x1A.contains_end_of_group());
-    assert!(SubgroupHeaderType::Type0x1B.contains_end_of_group());
-    assert!(SubgroupHeaderType::Type0x1C.contains_end_of_group());
-    assert!(SubgroupHeaderType::Type0x1D.contains_end_of_group());
+    assert!(SubgroupHeaderType::try_new(0x18).unwrap().contains_end_of_group());
+    assert!(SubgroupHeaderType::try_new(0x19).unwrap().contains_end_of_group());
+    assert!(SubgroupHeaderType::try_new(0x1A).unwrap().contains_end_of_group());
+    assert!(SubgroupHeaderType::try_new(0x1B).unwrap().contains_end_of_group());
+    assert!(SubgroupHeaderType::try_new(0x1C).unwrap().contains_end_of_group());
+    assert!(SubgroupHeaderType::try_new(0x1D).unwrap().contains_end_of_group());
 
     // Test has_extensions
-    assert!(SubgroupHeaderType::Type0x11.has_extensions());
-    assert!(SubgroupHeaderType::Type0x13.has_extensions());
-    assert!(SubgroupHeaderType::Type0x15.has_extensions());
-    assert!(SubgroupHeaderType::Type0x19.has_extensions());
-    assert!(SubgroupHeaderType::Type0x1B.has_extensions());
-    assert!(SubgroupHeaderType::Type0x1D.has_extensions());
+    assert!(SubgroupHeaderType::try_new(0x11).unwrap().has_extensions());
+    assert!(SubgroupHeaderType::try_new(0x13).unwrap().has_extensions());
+    assert!(SubgroupHeaderType::try_new(0x15).unwrap().has_extensions());
+    assert!(SubgroupHeaderType::try_new(0x19).unwrap().has_extensions());
+    assert!(SubgroupHeaderType::try_new(0x1B).unwrap().has_extensions());
+    assert!(SubgroupHeaderType::try_new(0x1D).unwrap().has_extensions());
   }
 
   #[test]
@@ -400,22 +379,22 @@ mod tests {
       false,
       false,
     );
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x10);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x10).unwrap());
     assert_eq!(header.subgroup_id, Some(0));
 
     let header =
       SubgroupHeader::new_fixed_zero_id(track_alias, group_id, publisher_priority, true, false);
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x11);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x11).unwrap());
     assert_eq!(header.subgroup_id, Some(0));
 
     let header =
       SubgroupHeader::new_fixed_zero_id(track_alias, group_id, publisher_priority, false, true);
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x18);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x18).unwrap());
     assert_eq!(header.subgroup_id, Some(0));
 
     let header =
       SubgroupHeader::new_fixed_zero_id(track_alias, group_id, publisher_priority, true, true);
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x19);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x19).unwrap());
     assert_eq!(header.subgroup_id, Some(0));
 
     // Test new_first_object_id
@@ -426,7 +405,7 @@ mod tests {
       false,
       false,
     );
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x12);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x12).unwrap());
     assert_eq!(header.subgroup_id, None);
 
     let header = SubgroupHeader::new_first_object_id(
@@ -436,17 +415,17 @@ mod tests {
       true,
       false,
     );
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x13);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x13).unwrap());
     assert_eq!(header.subgroup_id, None);
 
     let header =
       SubgroupHeader::new_first_object_id(track_alias, group_id, publisher_priority, false, true);
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x1A);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x1A).unwrap());
     assert_eq!(header.subgroup_id, None);
 
     let header =
       SubgroupHeader::new_first_object_id(track_alias, group_id, publisher_priority, true, true);
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x1B);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x1B).unwrap());
     assert_eq!(header.subgroup_id, None);
 
     // Test new_with_explicit_id
@@ -459,7 +438,7 @@ mod tests {
       false,
       false,
     );
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x14);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x14).unwrap());
     assert_eq!(header.subgroup_id, Some(subgroup_id));
 
     let header = SubgroupHeader::new_with_explicit_id(
@@ -470,7 +449,7 @@ mod tests {
       true,
       false,
     );
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x15);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x15).unwrap());
     assert_eq!(header.subgroup_id, Some(subgroup_id));
 
     let header = SubgroupHeader::new_with_explicit_id(
@@ -481,7 +460,7 @@ mod tests {
       false,
       true,
     );
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x1C);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x1C).unwrap());
     assert_eq!(header.subgroup_id, Some(subgroup_id));
 
     let header = SubgroupHeader::new_with_explicit_id(
@@ -492,7 +471,7 @@ mod tests {
       true,
       true,
     );
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x1D);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x1D).unwrap());
     assert_eq!(header.subgroup_id, Some(subgroup_id));
   }
 
@@ -510,7 +489,7 @@ mod tests {
     // Test a header type with fixed subgroup ID = 0
     let header =
       SubgroupHeader::new_fixed_zero_id(track_alias, group_id, publisher_priority, false, false);
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x10);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x10).unwrap());
     assert_eq!(header.subgroup_id, Some(0));
 
     // Create a subgroup object
@@ -546,7 +525,7 @@ mod tests {
       true,
       false,
     );
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x15);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x15).unwrap());
     assert_eq!(header.subgroup_id, Some(123));
 
     let object = Object::try_from_subgroup(
@@ -569,7 +548,7 @@ mod tests {
     // Test a header type where subgroup ID = first object ID
     let header =
       SubgroupHeader::new_first_object_id(track_alias, group_id, publisher_priority, false, true);
-    assert_eq!(header.header_type, SubgroupHeaderType::Type0x1A);
+    assert_eq!(header.header_type, SubgroupHeaderType::try_new(0x1A).unwrap());
     assert_eq!(header.subgroup_id, None);
 
     let object = Object::try_from_subgroup(

--- a/libs/moqtail-rs/src/transport/data_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/data_stream_handler.rs
@@ -696,7 +696,7 @@ mod tests {
         MessageParameter::new_forward(true),
       ],
     );
-    let header_type = SubgroupHeaderType::Type0x15;
+    let header_type = SubgroupHeaderType::try_new(0x15).unwrap();
     let track_alias = 999;
     let group_id = 9;
     let subgroup_id = Some(11);

--- a/libs/moqtail-rs/src/transport/data_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/data_stream_handler.rs
@@ -700,7 +700,7 @@ mod tests {
     let track_alias = 999;
     let group_id = 9;
     let subgroup_id = Some(11);
-    let publisher_priority = 255;
+    let publisher_priority = Some(255);
     let subgroup_header = SubgroupHeader {
       header_type,
       track_alias,

--- a/libs/moqtail-ts/src/client/client.ts
+++ b/libs/moqtail-ts/src/client/client.ts
@@ -1874,18 +1874,30 @@ export class MOQtailClient {
                   case SubgroupHeaderType.Type0x11:
                   case SubgroupHeaderType.Type0x18:
                   case SubgroupHeaderType.Type0x19:
+                  case SubgroupHeaderType.Type0x30:
+                  case SubgroupHeaderType.Type0x31:
+                  case SubgroupHeaderType.Type0x38:
+                  case SubgroupHeaderType.Type0x39:
                     subgroupId = 0n
                     break
                   case SubgroupHeaderType.Type0x12:
                   case SubgroupHeaderType.Type0x13:
                   case SubgroupHeaderType.Type0x1A:
                   case SubgroupHeaderType.Type0x1B:
+                  case SubgroupHeaderType.Type0x32:
+                  case SubgroupHeaderType.Type0x33:
+                  case SubgroupHeaderType.Type0x3A:
+                  case SubgroupHeaderType.Type0x3B:
                     subgroupId = firstObjectId
                     break
                   case SubgroupHeaderType.Type0x14:
                   case SubgroupHeaderType.Type0x15:
                   case SubgroupHeaderType.Type0x1C:
                   case SubgroupHeaderType.Type0x1D:
+                  case SubgroupHeaderType.Type0x34:
+                  case SubgroupHeaderType.Type0x35:
+                  case SubgroupHeaderType.Type0x3C:
+                  case SubgroupHeaderType.Type0x3D:
                     subgroupId = header.subgroupId!
                 }
 

--- a/libs/moqtail-ts/src/client/client.ts
+++ b/libs/moqtail-ts/src/client/client.ts
@@ -1868,37 +1868,13 @@ export class MOQtailClient {
                 if (!firstObjectId) {
                   firstObjectId = nextObject.objectId
                 }
-                let subgroupId = header.subgroupId
-                switch (header.type) {
-                  case SubgroupHeaderType.Type0x10:
-                  case SubgroupHeaderType.Type0x11:
-                  case SubgroupHeaderType.Type0x18:
-                  case SubgroupHeaderType.Type0x19:
-                  case SubgroupHeaderType.Type0x30:
-                  case SubgroupHeaderType.Type0x31:
-                  case SubgroupHeaderType.Type0x38:
-                  case SubgroupHeaderType.Type0x39:
-                    subgroupId = 0n
-                    break
-                  case SubgroupHeaderType.Type0x12:
-                  case SubgroupHeaderType.Type0x13:
-                  case SubgroupHeaderType.Type0x1A:
-                  case SubgroupHeaderType.Type0x1B:
-                  case SubgroupHeaderType.Type0x32:
-                  case SubgroupHeaderType.Type0x33:
-                  case SubgroupHeaderType.Type0x3A:
-                  case SubgroupHeaderType.Type0x3B:
-                    subgroupId = firstObjectId
-                    break
-                  case SubgroupHeaderType.Type0x14:
-                  case SubgroupHeaderType.Type0x15:
-                  case SubgroupHeaderType.Type0x1C:
-                  case SubgroupHeaderType.Type0x1D:
-                  case SubgroupHeaderType.Type0x34:
-                  case SubgroupHeaderType.Type0x35:
-                  case SubgroupHeaderType.Type0x3C:
-                  case SubgroupHeaderType.Type0x3D:
-                    subgroupId = header.subgroupId!
+                let subgroupId: bigint | null = null
+                if (SubgroupHeaderType.isSubgroupIdZero(header.type)) {
+                  subgroupId = 0n
+                } else if (SubgroupHeaderType.isSubgroupIdFirstObjectId(header.type)) {
+                  subgroupId = firstObjectId ?? null
+                } else if (SubgroupHeaderType.hasExplicitSubgroupId(header.type)) {
+                  subgroupId = header.subgroupId ?? null
                 }
 
                 const fullTrackName = this.aliasFullTrackNameMap.get(header.trackAlias)

--- a/libs/moqtail-ts/src/client/data_stream.ts
+++ b/libs/moqtail-ts/src/client/data_stream.ts
@@ -283,7 +283,7 @@ if (import.meta.vitest) {
 
     describe('Subgroup', () => {
       beforeEach(async () => {
-        testSubgroupHeader = Header.newSubgroup(SubgroupHeaderType.Type0x10, 0n, 0n, 0, 0)
+        testSubgroupHeader = Header.newSubgroup(SubgroupHeaderType.fromProperties(false, 0, false), 0n, 0n, 0, 0)
         const transport = new TransformStream<Uint8Array, Uint8Array>()
         const sendStreamPromise = SendStream.new(transport.writable, testSubgroupHeader)
         const recvStreamPromise = RecvStream.new(transport.readable)

--- a/libs/moqtail-ts/src/model/data/constant.ts
+++ b/libs/moqtail-ts/src/model/data/constant.ts
@@ -217,7 +217,7 @@ export namespace FetchHeaderType {
 
 /**
  * @public
- * Subgroup header types for MOQT subgroups (Draft-16).
+ * Subgroup header types for MOQT subgroups.
  *
  * Type bit layout (0b00X1XXXX):
  * - Bit 0 (0x01): EXTENSIONS - Extensions present in all objects
@@ -259,81 +259,65 @@ export enum SubgroupHeaderType {
 }
 
 /**
- * Namespace for SubgroupHeaderType utilities.
+ * Namespace for SubgroupHeaderType utilities and bit constants.
  */
 export namespace SubgroupHeaderType {
-  /**
-   * Returns true if the header type has extensions (bit 0 set).
-   * @param t - The SubgroupHeaderType.
-   */
+  /** Extensions present in all objects (bit 0) */
+  export const EXTENSIONS = 0x01
+  /** Mask for SUBGROUP_ID_MODE (bits 1-2) */
+  export const SUBGROUP_ID_MODE_MASK = 0x06
+  /** This subgroup contains the final object in the group (bit 3) */
+  export const END_OF_GROUP = 0x08
+  /** Required bit that must always be set (bit 4) */
+  export const REQUIRED_BIT = 0x10
+  /** Publisher priority field omitted, inherited from subscription (bit 5) */
+  export const DEFAULT_PRIORITY = 0x20
+  /** Mask for bits that must be zero: bits 6-7 */
+  const INVALID_BITS_MASK = 0xc0
+  /** Reserved SUBGROUP_ID_MODE value (0b11) */
+  const RESERVED_SUBGROUP_MODE = 0x06
+
   export function hasExtensions(t: SubgroupHeaderType): boolean {
-    return (t & 0x01) !== 0
+    return (t & EXTENSIONS) !== 0
   }
 
-  /**
-   * Returns true if the header type has an explicit subgroup ID (bits 1-2 = 0b10).
-   * @param t - The SubgroupHeaderType.
-   */
   export function hasExplicitSubgroupId(t: SubgroupHeaderType): boolean {
-    return (t & 0x06) === 0x04
+    return (t & SUBGROUP_ID_MODE_MASK) === 0x04
   }
 
-  /**
-   * Returns true if the header type implies a subgroup ID of zero (bits 1-2 = 0b00).
-   * @param t - The SubgroupHeaderType.
-   */
   export function isSubgroupIdZero(t: SubgroupHeaderType): boolean {
-    return (t & 0x06) === 0x00
+    return (t & SUBGROUP_ID_MODE_MASK) === 0x00
   }
 
-  /**
-   * Returns true if the header type implies subgroup ID is the first Object ID (bits 1-2 = 0b01).
-   * @param t - The SubgroupHeaderType.
-   */
   export function isSubgroupIdFirstObjectId(t: SubgroupHeaderType): boolean {
-    return (t & 0x06) === 0x02
+    return (t & SUBGROUP_ID_MODE_MASK) === 0x02
   }
 
-  /**
-   * Returns true if the header type indicates End of Group (bit 3 set).
-   * @param t - The SubgroupHeaderType.
-   */
   export function containsEndOfGroup(t: SubgroupHeaderType): boolean {
-    return (t & 0x08) !== 0
+    return (t & END_OF_GROUP) !== 0
   }
 
-  /**
-   * Returns true if the header type uses default publisher priority (bit 5 set).
-   * When true, the publisher_priority field is omitted from the header.
-   * @param t - The SubgroupHeaderType.
-   */
   export function hasDefaultPriority(t: SubgroupHeaderType): boolean {
-    return (t & 0x20) !== 0
+    return (t & DEFAULT_PRIORITY) !== 0
   }
 
   /**
    * Converts a number or bigint to SubgroupHeaderType.
-   * Validates per MOQ draft-16: bit 4 must be set, SUBGROUP_ID_MODE must not be 0b11.
-   * @param value - The value to convert.
-   * @returns The corresponding SubgroupHeaderType.
-   * @throws Error if the value is not valid.
+   * Validates bit 4 must be set, SUBGROUP_ID_MODE must not be 0b11.
    */
   export function tryFrom(value: number | bigint): SubgroupHeaderType {
     const v = typeof value === 'bigint' ? Number(value) : value
 
-    // Bit 4 (0x10) must be set
-    if ((v & 0x10) === 0) {
+    if ((v & INVALID_BITS_MASK) !== 0) {
+      throw new Error(`Invalid SubgroupHeaderType: 0x${v.toString(16)} (invalid bits set)`)
+    }
+
+    if ((v & REQUIRED_BIT) === 0) {
       throw new Error(`Invalid SubgroupHeaderType: 0x${v.toString(16)} (bit 4 not set)`)
     }
 
-    // SUBGROUP_ID_MODE (bits 1-2) must not be 0b11 (0x06)
-    if ((v & 0x06) === 0x06) {
+    if ((v & SUBGROUP_ID_MODE_MASK) === RESERVED_SUBGROUP_MODE) {
       throw new Error(`Invalid SubgroupHeaderType: 0x${v.toString(16)} (reserved SUBGROUP_ID_MODE)`)
-    }
-
-    // Must be in valid range
-    if (v < 0 || v > 0x3f) {
-      throw new Error(`Invalid SubgroupHeaderType: 0x${v.toString(16)} (out of range)`)
     }
 
     return v as SubgroupHeaderType
@@ -341,11 +325,7 @@ export namespace SubgroupHeaderType {
 
   /**
    * Determines the appropriate type for given properties.
-   * Bits 1-2 encode SUBGROUP_ID_MODE: 0b00=zero, 0b01=firstObjId, 0b10=explicit.
-   * @param hasExtensions - Whether extensions are present (bit 0).
-   * @param subgroupIdMode - SUBGROUP_ID_MODE (0, 1, or 2; represents 0b00, 0b01, 0b10).
-   * @param containsEndOfGroup - Whether this is end of group (bit 3).
-   * @param hasDefaultPriority - Whether to use default publisher priority (bit 5).
+   * @param subgroupIdMode - SUBGROUP_ID_MODE (0=zero, 1=firstObjId, 2=explicit).
    */
   export function fromProperties(
     hasExtensions: boolean,
@@ -353,12 +333,12 @@ export namespace SubgroupHeaderType {
     containsEndOfGroup: boolean,
     hasDefaultPriority: boolean = false,
   ): SubgroupHeaderType {
-    let type = 0x10 // bit 4 always set
-    if (hasExtensions) type |= 0x01
-    type |= (subgroupIdMode & 0x03) << 1 // bits 1-2
-    if (containsEndOfGroup) type |= 0x08
-    if (hasDefaultPriority) type |= 0x20
-    return type as SubgroupHeaderType
+    let t = REQUIRED_BIT
+    if (hasExtensions) t |= EXTENSIONS
+    t |= (subgroupIdMode & 0x03) << 1
+    if (containsEndOfGroup) t |= END_OF_GROUP
+    if (hasDefaultPriority) t |= DEFAULT_PRIORITY
+    return t as SubgroupHeaderType
   }
 }
 

--- a/libs/moqtail-ts/src/model/data/constant.ts
+++ b/libs/moqtail-ts/src/model/data/constant.ts
@@ -217,9 +217,20 @@ export namespace FetchHeaderType {
 
 /**
  * @public
- * Subgroup header types for MOQT subgroups.
+ * Subgroup header types for MOQT subgroups (Draft-16).
+ *
+ * Type bit layout (0b00X1XXXX):
+ * - Bit 0 (0x01): EXTENSIONS - Extensions present in all objects
+ * - Bits 1-2 (0x06): SUBGROUP_ID_MODE - How subgroup ID is encoded (0b00=zero, 0b01=firstObjId, 0b10=explicit, 0b11=invalid)
+ * - Bit 3 (0x08): END_OF_GROUP - This subgroup contains the final object in the group
+ * - Bit 4 (0x10): Always set (distinguishes subgroup from other header types)
+ * - Bit 5 (0x20): DEFAULT_PRIORITY - Publisher priority field omitted, inherited from subscription
+ *
+ * Valid ranges: 0x10-0x15, 0x18-0x1D (bit 5=0), 0x30-0x35, 0x38-0x3D (bit 5=1)
+ * Invalid: 0x16, 0x17, 0x1E, 0x1F, 0x36, 0x37, 0x3E, 0x3F (SUBGROUP_ID_MODE=0b11)
  */
 export enum SubgroupHeaderType {
+  // Bit 5 = 0 (priority present)
   Type0x10 = 0x10,
   Type0x11 = 0x11,
   Type0x12 = 0x12,
@@ -232,6 +243,19 @@ export enum SubgroupHeaderType {
   Type0x1B = 0x1b,
   Type0x1C = 0x1c,
   Type0x1D = 0x1d,
+  // Bit 5 = 1 (default priority)
+  Type0x30 = 0x30,
+  Type0x31 = 0x31,
+  Type0x32 = 0x32,
+  Type0x33 = 0x33,
+  Type0x34 = 0x34,
+  Type0x35 = 0x35,
+  Type0x38 = 0x38,
+  Type0x39 = 0x39,
+  Type0x3A = 0x3a,
+  Type0x3B = 0x3b,
+  Type0x3C = 0x3c,
+  Type0x3D = 0x3d,
 }
 
 /**
@@ -239,88 +263,102 @@ export enum SubgroupHeaderType {
  */
 export namespace SubgroupHeaderType {
   /**
-   * Returns true if the header type has an explicit subgroup ID.
-   * @param t - The SubgroupHeaderType.
-   */
-  export function hasExplicitSubgroupId(t: SubgroupHeaderType): boolean {
-    switch (t) {
-      case SubgroupHeaderType.Type0x14:
-      case SubgroupHeaderType.Type0x15:
-      case SubgroupHeaderType.Type0x1C:
-      case SubgroupHeaderType.Type0x1D:
-        return true
-      default:
-        return false
-    }
-  }
-  /**
-   * Returns true if the header type implies a subgroup ID of zero.
-   * @param t - The SubgroupHeaderType.
-   */
-  export function isSubgroupIdZero(t: SubgroupHeaderType): boolean {
-    switch (t) {
-      case SubgroupHeaderType.Type0x10:
-      case SubgroupHeaderType.Type0x11:
-      case SubgroupHeaderType.Type0x18:
-      case SubgroupHeaderType.Type0x19:
-        return true
-      default:
-        return false
-    }
-  }
-  /**
-   * Returns true if the header type has extensions.
+   * Returns true if the header type has extensions (bit 0 set).
    * @param t - The SubgroupHeaderType.
    */
   export function hasExtensions(t: SubgroupHeaderType): boolean {
-    switch (t) {
-      case SubgroupHeaderType.Type0x11:
-      case SubgroupHeaderType.Type0x13:
-      case SubgroupHeaderType.Type0x15:
-      case SubgroupHeaderType.Type0x19:
-      case SubgroupHeaderType.Type0x1B:
-      case SubgroupHeaderType.Type0x1D:
-        return true
-      default:
-        return false
-    }
+    return (t & 0x01) !== 0
   }
+
+  /**
+   * Returns true if the header type has an explicit subgroup ID (bits 1-2 = 0b10).
+   * @param t - The SubgroupHeaderType.
+   */
+  export function hasExplicitSubgroupId(t: SubgroupHeaderType): boolean {
+    return (t & 0x06) === 0x04
+  }
+
+  /**
+   * Returns true if the header type implies a subgroup ID of zero (bits 1-2 = 0b00).
+   * @param t - The SubgroupHeaderType.
+   */
+  export function isSubgroupIdZero(t: SubgroupHeaderType): boolean {
+    return (t & 0x06) === 0x00
+  }
+
+  /**
+   * Returns true if the header type implies subgroup ID is the first Object ID (bits 1-2 = 0b01).
+   * @param t - The SubgroupHeaderType.
+   */
+  export function isSubgroupIdFirstObjectId(t: SubgroupHeaderType): boolean {
+    return (t & 0x06) === 0x02
+  }
+
+  /**
+   * Returns true if the header type indicates End of Group (bit 3 set).
+   * @param t - The SubgroupHeaderType.
+   */
+  export function containsEndOfGroup(t: SubgroupHeaderType): boolean {
+    return (t & 0x08) !== 0
+  }
+
+  /**
+   * Returns true if the header type uses default publisher priority (bit 5 set).
+   * When true, the publisher_priority field is omitted from the header.
+   * @param t - The SubgroupHeaderType.
+   */
+  export function hasDefaultPriority(t: SubgroupHeaderType): boolean {
+    return (t & 0x20) !== 0
+  }
+
   /**
    * Converts a number or bigint to SubgroupHeaderType.
+   * Validates per MOQ draft-16: bit 4 must be set, SUBGROUP_ID_MODE must not be 0b11.
    * @param value - The value to convert.
    * @returns The corresponding SubgroupHeaderType.
    * @throws Error if the value is not valid.
    */
   export function tryFrom(value: number | bigint): SubgroupHeaderType {
     const v = typeof value === 'bigint' ? Number(value) : value
-    switch (v) {
-      case 0x10:
-        return SubgroupHeaderType.Type0x10
-      case 0x11:
-        return SubgroupHeaderType.Type0x11
-      case 0x12:
-        return SubgroupHeaderType.Type0x12
-      case 0x13:
-        return SubgroupHeaderType.Type0x13
-      case 0x14:
-        return SubgroupHeaderType.Type0x14
-      case 0x15:
-        return SubgroupHeaderType.Type0x15
-      case 0x18:
-        return SubgroupHeaderType.Type0x18
-      case 0x19:
-        return SubgroupHeaderType.Type0x19
-      case 0x1a:
-        return SubgroupHeaderType.Type0x1A
-      case 0x1b:
-        return SubgroupHeaderType.Type0x1B
-      case 0x1c:
-        return SubgroupHeaderType.Type0x1C
-      case 0x1d:
-        return SubgroupHeaderType.Type0x1D
-      default:
-        throw new Error(`Invalid SubgroupHeaderType: ${value}`)
+
+    // Bit 4 (0x10) must be set
+    if ((v & 0x10) === 0) {
+      throw new Error(`Invalid SubgroupHeaderType: 0x${v.toString(16)} (bit 4 not set)`)
     }
+
+    // SUBGROUP_ID_MODE (bits 1-2) must not be 0b11 (0x06)
+    if ((v & 0x06) === 0x06) {
+      throw new Error(`Invalid SubgroupHeaderType: 0x${v.toString(16)} (reserved SUBGROUP_ID_MODE)`)
+    }
+
+    // Must be in valid range
+    if (v < 0 || v > 0x3f) {
+      throw new Error(`Invalid SubgroupHeaderType: 0x${v.toString(16)} (out of range)`)
+    }
+
+    return v as SubgroupHeaderType
+  }
+
+  /**
+   * Determines the appropriate type for given properties.
+   * Bits 1-2 encode SUBGROUP_ID_MODE: 0b00=zero, 0b01=firstObjId, 0b10=explicit.
+   * @param hasExtensions - Whether extensions are present (bit 0).
+   * @param subgroupIdMode - SUBGROUP_ID_MODE (0, 1, or 2; represents 0b00, 0b01, 0b10).
+   * @param containsEndOfGroup - Whether this is end of group (bit 3).
+   * @param hasDefaultPriority - Whether to use default publisher priority (bit 5).
+   */
+  export function fromProperties(
+    hasExtensions: boolean,
+    subgroupIdMode: 0 | 1 | 2,
+    containsEndOfGroup: boolean,
+    hasDefaultPriority: boolean = false,
+  ): SubgroupHeaderType {
+    let type = 0x10 // bit 4 always set
+    if (hasExtensions) type |= 0x01
+    type |= (subgroupIdMode & 0x03) << 1 // bits 1-2
+    if (containsEndOfGroup) type |= 0x08
+    if (hasDefaultPriority) type |= 0x20
+    return type as SubgroupHeaderType
   }
 }
 

--- a/libs/moqtail-ts/src/model/data/object.ts
+++ b/libs/moqtail-ts/src/model/data/object.ts
@@ -50,28 +50,28 @@ export class MoqtObject {
     return this.location.object
   }
 
-  getSubgroupHeaderType(containsEnd: boolean): SubgroupHeaderType {
+  getSubgroupHeaderType(containsEnd: boolean, useDefaultPriority: boolean = false): SubgroupHeaderType {
     const hasExtensions = !!this.extensionHeaders && this.extensionHeaders.length > 0
-    const hasSubgroupId = this.subgroupId !== null
-    const isSubgroupIdZero = this.subgroupId === 0n
 
-    if (containsEnd) {
-      if (hasSubgroupId) {
-        return hasExtensions ? SubgroupHeaderType.Type0x1D : SubgroupHeaderType.Type0x1C
-      } else if (isSubgroupIdZero) {
-        return hasExtensions ? SubgroupHeaderType.Type0x19 : SubgroupHeaderType.Type0x18
-      } else {
-        return hasExtensions ? SubgroupHeaderType.Type0x1B : SubgroupHeaderType.Type0x1A
-      }
+    // Determine SUBGROUP_ID_MODE (bits 1-2, as defined in draft-16):
+    // 0b00 (0): Subgroup ID = 0 (absent from header)
+    // 0b01 (1): Subgroup ID = first Object ID (absent from header)
+    // 0b10 (2): Subgroup ID = explicit (present in header)
+    let subgroupIdMode: 0 | 1 | 2
+    if (this.subgroupId === null) {
+      subgroupIdMode = 1 // first-object-ID mode
+    } else if (this.subgroupId === 0n) {
+      subgroupIdMode = 0 // zero mode
     } else {
-      if (hasSubgroupId) {
-        return hasExtensions ? SubgroupHeaderType.Type0x15 : SubgroupHeaderType.Type0x14
-      } else if (isSubgroupIdZero) {
-        return hasExtensions ? SubgroupHeaderType.Type0x11 : SubgroupHeaderType.Type0x10
-      } else {
-        return hasExtensions ? SubgroupHeaderType.Type0x13 : SubgroupHeaderType.Type0x12
-      }
+      subgroupIdMode = 2 // explicit mode
     }
+
+    return SubgroupHeaderType.fromProperties(
+      hasExtensions,
+      subgroupIdMode,
+      containsEnd,
+      useDefaultPriority,
+    )
   }
 
   isDatagram(): boolean {
@@ -191,14 +191,14 @@ export class MoqtObject {
   static fromSubgroupObject(
     subgroupObject: SubgroupObject,
     groupId: bigint | number,
-    publisherPriority: number,
-    subgroupId: bigint | number,
+    publisherPriority: number | undefined,
+    subgroupId: bigint | number | null,
     fullTrackName: FullTrackName,
   ): MoqtObject {
     return new MoqtObject(
       fullTrackName,
       new Location(groupId, subgroupObject.objectId),
-      publisherPriority,
+      publisherPriority ?? 0,
       ObjectForwardingPreference.Subgroup,
       subgroupId,
       subgroupObject.objectStatus || ObjectStatus.Normal,

--- a/libs/moqtail-ts/src/model/data/object.ts
+++ b/libs/moqtail-ts/src/model/data/object.ts
@@ -53,7 +53,7 @@ export class MoqtObject {
   getSubgroupHeaderType(containsEnd: boolean, useDefaultPriority: boolean = false): SubgroupHeaderType {
     const hasExtensions = !!this.extensionHeaders && this.extensionHeaders.length > 0
 
-    // Determine SUBGROUP_ID_MODE (bits 1-2, as defined in draft-16):
+    // Determine SUBGROUP_ID_MODE (bits 1-2):
     // 0b00 (0): Subgroup ID = 0 (absent from header)
     // 0b01 (1): Subgroup ID = first Object ID (absent from header)
     // 0b10 (2): Subgroup ID = explicit (present in header)

--- a/libs/moqtail-ts/src/model/data/subgroup_header.ts
+++ b/libs/moqtail-ts/src/model/data/subgroup_header.ts
@@ -90,7 +90,8 @@ if (import.meta.vitest) {
   const { describe, test, expect } = import.meta.vitest
   describe('SubgroupHeader', () => {
     test('roundtrip serialization/deserialization', () => {
-      const headerType = SubgroupHeaderType.Type0x14
+      // explicit subgroup ID, no extensions, no end-of-group, priority present
+      const headerType = SubgroupHeaderType.fromProperties(false, 2, false)
       const trackAlias = 87n
       const groupId = 9n
       const subgroupId = 11n
@@ -106,10 +107,11 @@ if (import.meta.vitest) {
       expect(frozen.remaining).toBe(0)
     })
     test('roundtrip with default priority', () => {
-      const headerType = SubgroupHeaderType.Type0x30 // DEFAULT_PRIORITY bit set, subgroupId = 0
+      // subgroupId = 0, default priority (bit 5 set)
+      const headerType = SubgroupHeaderType.fromProperties(false, 0, false, true)
       const trackAlias = 87n
       const groupId = 9n
-      const subgroupId = 0n // Type0x30 has subgroupId = 0
+      const subgroupId = 0n
       const publisherPriority = undefined // Not included in wire format
       const header = new SubgroupHeader(headerType, trackAlias, groupId, subgroupId, publisherPriority)
       const frozen = header.serialize()
@@ -122,7 +124,8 @@ if (import.meta.vitest) {
       expect(frozen.remaining).toBe(0)
     })
     test('excess roundtrip', () => {
-      const headerType = SubgroupHeaderType.Type0x14
+      // explicit subgroup ID, no extensions, no end-of-group, priority present
+      const headerType = SubgroupHeaderType.fromProperties(false, 2, false)
       const trackAlias = 87n
       const groupId = 9n
       const subgroupId = 11n
@@ -144,7 +147,8 @@ if (import.meta.vitest) {
       expect(Array.from(frozen.getBytes(3))).toEqual([9, 1, 1])
     })
     test('partial message fails', () => {
-      const headerType = SubgroupHeaderType.Type0x14
+      // explicit subgroup ID, no extensions, no end-of-group, priority present
+      const headerType = SubgroupHeaderType.fromProperties(false, 2, false)
       const trackAlias = 87n
       const groupId = 9n
       const subgroupId = 11n

--- a/libs/moqtail-ts/src/model/data/subgroup_header.ts
+++ b/libs/moqtail-ts/src/model/data/subgroup_header.ts
@@ -29,7 +29,7 @@ export class SubgroupHeader {
     trackAlias: bigint | number,
     groupId: bigint | number,
     subgroupId: bigint | number | undefined,
-    readonly publisherPriority: number,
+    readonly publisherPriority: number | undefined,
   ) {
     this.trackAlias = BigInt(trackAlias)
     this.groupId = BigInt(groupId)
@@ -54,7 +54,16 @@ export class SubgroupHeader {
       }
       buf.putVI(this.subgroupId)
     }
-    buf.putU8(this.publisherPriority)
+    // Publisher priority is omitted when hasDefaultPriority bit is set
+    if (!SubgroupHeaderType.hasDefaultPriority(this.type)) {
+      if (this.publisherPriority === undefined) {
+        throw new ProtocolViolationError(
+          'SubgroupHeader.serialize',
+          'Publisher_priority field is required when DEFAULT_PRIORITY bit is not set',
+        )
+      }
+      buf.putU8(this.publisherPriority)
+    }
     return buf.freeze()
   }
 
@@ -68,7 +77,11 @@ export class SubgroupHeader {
     } else if (SubgroupHeaderType.isSubgroupIdZero(headerType)) {
       subgroupId = 0n
     }
-    const publisherPriority = buf.getU8()
+    // Publisher priority is omitted when hasDefaultPriority bit is set
+    let publisherPriority: number | undefined
+    if (!SubgroupHeaderType.hasDefaultPriority(headerType)) {
+      publisherPriority = buf.getU8()
+    }
     return new SubgroupHeader(headerType, trackAlias, groupId, subgroupId, publisherPriority)
   }
 }
@@ -90,6 +103,22 @@ if (import.meta.vitest) {
       expect(parsed.groupId).toBe(header.groupId)
       expect(parsed.subgroupId).toBe(header.subgroupId)
       expect(parsed.publisherPriority).toBe(header.publisherPriority)
+      expect(frozen.remaining).toBe(0)
+    })
+    test('roundtrip with default priority', () => {
+      const headerType = SubgroupHeaderType.Type0x30 // DEFAULT_PRIORITY bit set, subgroupId = 0
+      const trackAlias = 87n
+      const groupId = 9n
+      const subgroupId = 0n // Type0x30 has subgroupId = 0
+      const publisherPriority = undefined // Not included in wire format
+      const header = new SubgroupHeader(headerType, trackAlias, groupId, subgroupId, publisherPriority)
+      const frozen = header.serialize()
+      const parsed = SubgroupHeader.deserialize(frozen)
+      expect(parsed.type).toBe(header.type)
+      expect(parsed.trackAlias).toBe(header.trackAlias)
+      expect(parsed.groupId).toBe(header.groupId)
+      expect(parsed.subgroupId).toBe(header.subgroupId)
+      expect(parsed.publisherPriority).toBe(undefined)
       expect(frozen.remaining).toBe(0)
     })
     test('excess roundtrip', () => {

--- a/libs/moqtail-ts/src/model/data/subgroup_object.ts
+++ b/libs/moqtail-ts/src/model/data/subgroup_object.ts
@@ -46,7 +46,6 @@ export class SubgroupObject {
     return new SubgroupObject(objectId, extensionHeaders, null, payload)
   }
 
-  // TODO: object delta encoding is missing here...
   serialize(previousObjectId: bigint | undefined): FrozenByteBuffer {
     // the first object's object id is encoded as is
     // for the subsequent objects, the object id is encoded


### PR DESCRIPTION
## Summary

Implement subgroup header support for MOQ draft-16 section 10.4.2 in moqtail-ts and moqtail-rs libraries. This includes the serialization/deserialization logic for subgroup headers, updated object structures to support subgroup IDs, and integration with client and relay components.

## Changes

### Core Implementation
- **Rust Library** (`moqtail-rs`):
  - Add `SubgroupHeader` struct with support for three ID encoding modes (Section 10.4.2)
  - Implement `new_fixed_zero_id()`, `new_first_object_id()`, and `new_with_explicit_id()` constructors
  - Add serialization/deserialization logic with proper encoding/decoding of bits [5:4] and [3:0]
  - Update `Object` structure to include optional `SubgroupHeader` in data payloads
  - Add comprehensive type definitions in `constant.rs` for all 24 subgroup header types (0x10-0x1D, 0x30-0x3D)

- **TypeScript Library** (`moqtail-ts`):
  - Implement `SubgroupHeader` class with encoding mode support
  - Add helper functions: `hasPublisherPriority()`, `hasExplicitSubgroupId()`, `getPublisherPriority()`
  - Mirror Rust implementation for type definitions and serialization
  - Update `SubgroupObject` to properly handle subgroup header parsing and composition

### Integration
- Update `ObjectSerializationHeader` to properly encode object with subgroup headers
- Update client-side publisher to support subgroup-aware object publication
- Update transport layer data stream handlers for proper subgroup header handling
- Add support for Publisher Priority field integration from subgroup headers

## Testing
- Verify proper serialization/deserialization round-trips
- Validate bit layout encoding for all header type variations
- Confirm integration with existing client and relay message flows

## References
- MOQ draft-16, Section 10.4.2: [Subgroup Header Format](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16#section-10.4.2)
- Issue #114

