### PR TITLE
fix wrong termination of a subscription

### DIFF
--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -1070,7 +1070,6 @@ impl Subscription {
         connection_id, stream_id, track_alias
       );
 
-      tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
       let res = subscriber.close_stream(&stream_id).await;
       if let Err(e) = res {
         warn!(

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -610,30 +610,34 @@ impl Subscription {
       self.client_connection_id,
       self.track_alias()
     );
-    let mut event_rx_guard = self.event_rx.lock().await;
 
-    if let Some(ref mut event_rx) = *event_rx_guard {
-      match event_rx.recv().await {
-        Some(event) => {
-          if self.finished.load(Ordering::Relaxed) {
-            return;
-          }
-          self.handle_track_event(event).await;
-        }
-        None => {
-          // For unbounded receivers, recv() returns None when the channel is closed
-          // The channel is closed, we should finish the subscription
-          info!(
-            "Event receiver closed for subscriber: {} track: {}, finishing subscription",
-            self.client_connection_id,
-            self.track_alias()
-          );
-          self.finish().await;
-        }
+    // Dequeue while holding the lock, then release before processing.
+    let recv_result = {
+      let mut guard = self.event_rx.lock().await;
+      if let Some(ref mut rx) = *guard {
+        rx.recv().await
+      } else {
+        // Receiver was already taken by finish(); loop will break on is_finished().
+        return;
       }
-    } else {
-      // No receiver available, subscription has been finished
-      self.finish().await;
+    };
+
+    match recv_result {
+      Some(event) => {
+        if self.finished.load(Ordering::Relaxed) {
+          return;
+        }
+        self.handle_track_event(event).await;
+      }
+      None => {
+        // Channel closed (all senders dropped).
+        info!(
+          "Event receiver closed for subscriber: {} track: {}, finishing subscription",
+          self.client_connection_id,
+          self.track_alias()
+        );
+        self.finish().await;
+      }
     }
   }
 

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -305,7 +305,7 @@ impl Subscription {
             continue;
           }
           // 1 second timeout to check if the subscription is still valid
-          _ = tokio::time::sleep(tokio::time::Duration::from_secs(1)) => {
+          _ = tokio::time::sleep(tokio::time::Duration::from_secs(5)) => {
             // TODO: implement max timeout here
             continue;
           }

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -304,9 +304,9 @@ impl Subscription {
           _ = instance.receive() => {
             continue;
           }
-          // 1 second timeout to check if the subscription is still valid
+          // TODO: implement max timeout here
+          // 5 second timeout to check if the subscription is still valid
           _ = tokio::time::sleep(tokio::time::Duration::from_secs(5)) => {
-            // TODO: implement max timeout here
             continue;
           }
         }

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -1065,6 +1065,7 @@ impl Subscription {
         connection_id, stream_id, track_alias
       );
 
+      tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
       let res = subscriber.close_stream(&stream_id).await;
       if let Err(e) = res {
         warn!(

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -816,6 +816,7 @@ impl Subscription {
           if send_status {
             let mut send_stream_last_object_ids = self.send_stream_last_object_ids.write().await;
             send_stream_last_object_ids.insert(stream_id.clone(), Some(object.location.object));
+            drop(send_stream_last_object_ids); // Release the lock immediately
 
             // Update last sent max location
             self

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -264,18 +264,6 @@ impl Track {
         .await;
     }
 
-    // update the largest location
-    {
-      let mut largest_location = self.largest_location.write().await;
-      if object.location.group > largest_location.group
-        || (object.location.group == largest_location.group
-          && object.location.object > largest_location.object)
-      {
-        largest_location.group = object.location.group;
-        largest_location.object = object.location.object;
-      }
-    }
-
     // Send single Object event with optional header info
     let event = TrackEvent::SubgroupObject {
       stream_id: stream_id.clone(),
@@ -287,6 +275,18 @@ impl Track {
       .subscription_manager
       .send_event_to_subscribers(event)
       .await?;
+
+    // update the largest location
+    {
+      let mut largest_location = self.largest_location.write().await;
+      if object.location.group > largest_location.group
+        || (object.location.group == largest_location.group
+          && object.location.object > largest_location.object)
+      {
+        largest_location.group = object.location.group;
+        largest_location.object = object.location.object;
+      }
+    }
     Ok(())
   }
 

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -242,6 +242,18 @@ impl Track {
       );
     }
 
+    // Send single Object event with optional header info
+    let event = TrackEvent::SubgroupObject {
+      stream_id: stream_id.clone(),
+      object: object.clone(),
+      header_info: header_info.cloned(),
+    };
+
+    self
+      .subscription_manager
+      .send_event_to_subscribers(event)
+      .await?;
+
     if let Ok(fetch_object) = object.clone().try_into_fetch() {
       self.cache.add_object(fetch_object).await;
     } else {
@@ -263,18 +275,6 @@ impl Track {
         .log_track_object(self.track_alias, object, object_received_time)
         .await;
     }
-
-    // Send single Object event with optional header info
-    let event = TrackEvent::SubgroupObject {
-      stream_id: stream_id.clone(),
-      object: object.clone(),
-      header_info: header_info.cloned(),
-    };
-
-    self
-      .subscription_manager
-      .send_event_to_subscribers(event)
-      .await?;
 
     // update the largest location
     {

--- a/libs/moqtail-rs/src/model/data/subgroup_object.rs
+++ b/libs/moqtail-rs/src/model/data/subgroup_object.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use bytes::{Buf, Bytes, BytesMut};
-use tracing::debug;
+use tracing::trace;
 
 use crate::model::common::pair::KeyValuePair;
 use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
@@ -43,7 +43,7 @@ impl SubgroupObject {
       self.object_id
     };
 
-    debug!(
+    trace!(
       "SubgroupObject::serialize || object_id_delta: {} prev: {:?} object_id: {} ext_headers: {:?}",
       object_id_delta, previous_object_id, self.object_id, &self.extension_headers
     );
@@ -89,7 +89,7 @@ impl SubgroupObject {
       object_id_delta
     };
 
-    debug!(
+    trace!(
       "SubgroupObject::deserialize || object_id_delta: {} prev: {:?} object_id: {}",
       object_id_delta, previous_object_id, object_id
     );

--- a/libs/moqtail-rs/src/transport/data_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/data_stream_handler.rs
@@ -34,7 +34,7 @@ use crate::model::data::object::Object;
 use crate::model::data::subgroup_header::SubgroupHeader;
 use crate::model::data::subgroup_object::SubgroupObject;
 use crate::model::error::ParseError;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 // Timeout for header and subsequent objects
 const DATA_STREAM_TIMEOUT: Duration = Duration::from_secs(15);
@@ -331,7 +331,7 @@ impl RecvDataStream {
 
           consumed = c;
 
-          debug!(
+          trace!(
             "previous_object_id: {:?} object_id: {:?} consumed: {}",
             previous_object_id, &object_id, consumed
           );
@@ -527,7 +527,7 @@ impl RecvDataStream {
         }
         Err(ParseError::NotEnoughBytes { .. }) => {
           // Not enough bytes to parse the object, continue reading
-          debug!("Not enough bytes to parse the object, continuing to read...");
+          trace!("Not enough bytes to parse the object, continuing to read...");
           Ok((0, None)) // Indicate that we need more data
         }
         Err(e) => {


### PR DESCRIPTION
When the subscription does not receive events for 1 second, it gets terminated. However this can happen because of a congested link. The timeout was increased to 5 seconds. Also some minor optimizations were added.