### PR TITLE
feat: implementation of the scheduling algorithm in the relay

### DIFF
--- a/.changeset/curvy-emus-lick.md
+++ b/.changeset/curvy-emus-lick.md
@@ -1,0 +1,5 @@
+---
+'relay': minor
+---
+
+Implementation of the scheduling algorithm

--- a/apps/client/README.md
+++ b/apps/client/README.md
@@ -19,30 +19,34 @@ cargo run --bin client -- --command <COMMAND> [OPTIONS]
 
 ## Global Options
 
-| Option                    | Short | Default                  | Description                                             |
-| ------------------------- | ----- | ------------------------ | ------------------------------------------------------- |
-| `--command`               | `-c`  | _(required)_             | Command to run                                          |
-| `--server`                | `-s`  | `https://127.0.0.1:4433` | Server address                                          |
-| `--namespace`             | `-n`  | `moqtail`                | Track namespace                                         |
-| `--track-name`            | `-T`  | `demo`                   | Track name                                              |
-| `--no-cert-validation`    |       | `false`                  | Skip certificate validation                             |
-| `--forwarding-preference` |       | `subgroup`               | Object forwarding preference (`subgroup` or `datagram`) |
+| Option                    | Short | Default                  | Description                                                  |
+| ------------------------- | ----- | ------------------------ | ------------------------------------------------------------ |
+| `--command`               | `-c`  | _(required)_             | Command to run                                               |
+| `--server`                | `-s`  | `https://127.0.0.1:4433` | Server address                                               |
+| `--namespace`             | `-n`  | `moqtail`                | Track namespace                                              |
+| `--track-name`            | `-T`  | `demo`                   | Track name                                                   |
+| `--no-cert-validation`    |       | `false`                  | Skip certificate validation                                  |
+| `--forwarding-preference` |       | `subgroup`               | Object forwarding preference (`subgroup` or `datagram`)      |
+| `--group-order`           |       | `ascending`              | Group delivery order (`original`, `ascending`, `descending`) |
 
 ## Publish Options
 
-| Option                | Short | Default    | Description                              |
-| --------------------- | ----- | ---------- | ---------------------------------------- |
-| `--group-count`       |       | `100`      | Number of groups to send                 |
-| `--interval`          | `-i`  | `1000`     | Interval between objects in milliseconds |
-| `--objects-per-group` |       | `10`       | Number of objects per group              |
-| `--payload-size`      |       | `1200`     | Payload size in bytes                    |
-| `--track-alias`       |       | _(random)_ | Track alias (random if not specified)    |
+| Option                 | Short | Default    | Description                                   |
+| ---------------------- | ----- | ---------- | --------------------------------------------- |
+| `--group-count`        |       | `100`      | Number of groups to send                      |
+| `--interval`           | `-i`  | `1000`     | Interval between objects in milliseconds      |
+| `--objects-per-group`  |       | `10`       | Number of objects per group                   |
+| `--payload-size`       |       | `1200`     | Payload size in bytes                         |
+| `--track-alias`        |       | _(random)_ | Track alias (random if not specified)         |
+| `--publisher-priority` |       | `128`      | Publisher priority 0 (highest) – 255 (lowest) |
 
 ## Subscribe Options
 
-| Option       | Short | Default | Description                                    |
-| ------------ | ----- | ------- | ---------------------------------------------- |
-| `--duration` | `-d`  | `0`     | Duration to listen in seconds (0 = indefinite) |
+| Option                  | Short | Default  | Description                                                     |
+| ----------------------- | ----- | -------- | --------------------------------------------------------------- |
+| `--duration`            | `-d`  | `0`      | Duration to listen in seconds (0 = indefinite)                  |
+| `--subscriber-priority` |       | `128`    | Subscriber priority 0 (highest) – 255 (lowest)                  |
+| `--extra-track`         |       | _(none)_ | Second track subscription for priority testing: `name:priority` |
 
 ## Fetch Options
 
@@ -85,3 +89,80 @@ Connect to a remote server with certificate validation disabled:
 ```
 cargo run --bin client -- -c publish --server https://relay.example.com:4433 --no-cert-validation
 ```
+
+## Testing QUIC Stream Priority Scheduling
+
+The relay implements the MOQT four-tier scheduling algorithm: subscriber priority > publisher priority > group order > subgroup/object ID. QUIC stream priorities are assigned using a band mapping so tracks with different priorities never interfere on the same connection.
+
+To observe the scheduler in action you need bandwidth pressure on a single subscriber connection. The relay's `--write-kbps-limit` flag creates a per-connection token bucket that throttles writes, causing the QUIC send buffer to fill and forcing the scheduler to choose between streams.
+
+**Terminal 1 — relay with 200 kbps per-subscriber cap:**
+
+```
+cargo run --bin relay -- --write-kbps-limit 200
+```
+
+**Terminal 2 — high-priority publisher (track `demo`, publisher-priority=128):**
+
+```
+cargo run --bin client -- -c publish-namespace -T demo \
+  --publisher-priority 128 --no-cert-validation \
+  --interval 0 --group-count 80 --objects-per-group 2 --payload-size 30000
+```
+
+**Terminal 3 — low-priority publisher (track `demo2`, publisher-priority=128):**
+
+```
+cargo run --bin client -- -c publish-namespace -T demo2 \
+  --publisher-priority 128 --no-cert-validation \
+  --interval 0 --group-count 80 --objects-per-group 2 --payload-size 30000
+```
+
+**Terminal 4 — one subscriber to both tracks with different subscriber priorities:**
+
+```
+cargo run --bin client -- -c subscribe \
+  -T demo --subscriber-priority 10 \
+  --extra-track "demo2:200" \
+  --no-cert-validation --duration 90
+```
+
+Start the publishers before the subscriber. The subscriber log will show objects from both tracks interleaved. At every group where both tracks deliver simultaneously, `demo` (priority 10) consistently arrives before `demo2` (priority 200):
+
+```
+Received object 10: track=alias=1(primary) group=2, object=1  ← arrives first
+Received object 11: track=alias=2(demo2)   group=2, object=0  ← arrives 0.3 ms later
+...
+Received object 30: track=alias=1(primary) group=7, object=1  ← arrives first
+Received object 31: track=alias=2(demo2)   group=7, object=0  ← arrives 0.7 ms later
+```
+
+The `seq=GAP` messages in the subscriber output are expected — the stats counter tracks objects from both tracks as a single sequence, so cross-track interleaving appears as gaps. They do not indicate missing objects.
+
+### Priority parameters
+
+| Parameter               | Where set                | Effect                                                                      |
+| ----------------------- | ------------------------ | --------------------------------------------------------------------------- |
+| `--subscriber-priority` | subscriber CLI           | Most significant priority tier (0 = highest)                                |
+| `--publisher-priority`  | publisher CLI            | Second tier, tie-breaks within same subscriber priority                     |
+| `--group-order`         | publisher/subscriber CLI | `ascending`: earlier groups preferred; `descending`: later groups preferred |
+| `--extra-track name:N`  | subscriber CLI           | Subscribes to a second track at priority N on the same connection           |
+
+### Using OS-level bandwidth throttling
+
+For a real UDP-layer bottleneck, throttle the loopback interface at the OS level and run the relay **without** `--write-kbps-limit`. Any tool that limits UDP throughput to roughly 1 Mbit/s is sufficient.
+
+**Linux — `tc` (traffic control):**
+
+```bash
+# Add a 1 Mbit/s rate limit with 10 ms delay on loopback
+sudo tc qdisc add dev lo root netem rate 1mbit delay 10ms
+
+# Run tests…
+
+# Teardown
+sudo tc qdisc del dev lo root
+```
+
+**macOS — Network Link Conditioner:**
+Install the **Network Link Conditioner** preference pane from _Additional Tools for Xcode_ (available at developer.apple.com/download/all). Create a custom profile with ~1000 Kbps downlink/uplink and enable it. Disable when done.

--- a/apps/client/src/cli.rs
+++ b/apps/client/src/cli.rs
@@ -13,6 +13,24 @@
 // limitations under the License.
 
 use clap::{Parser, ValueEnum};
+use moqtail::model::control::constant::GroupOrder;
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum CliGroupOrder {
+  Original,
+  Ascending,
+  Descending,
+}
+
+impl From<CliGroupOrder> for GroupOrder {
+  fn from(o: CliGroupOrder) -> Self {
+    match o {
+      CliGroupOrder::Original => GroupOrder::Original,
+      CliGroupOrder::Ascending => GroupOrder::Ascending,
+      CliGroupOrder::Descending => GroupOrder::Descending,
+    }
+  }
+}
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ForwardingPreference {
@@ -109,4 +127,21 @@ pub struct Cli {
   /// Cancel the fetch after receiving N objects (fetch only, 0 = no cancel)
   #[arg(long, default_value_t = 0)]
   pub cancel_after: u64,
+
+  /// Subscriber priority 0 (highest) – 255 (lowest) (subscribe only)
+  #[arg(long, default_value_t = 128)]
+  pub subscriber_priority: u8,
+
+  /// Publisher priority 0 (highest) – 255 (lowest) (publish only)
+  #[arg(long, default_value_t = 128)]
+  pub publisher_priority: u8,
+
+  /// Group order for the track
+  #[arg(long, value_enum, default_value = "ascending")]
+  pub group_order: CliGroupOrder,
+
+  /// Additional track to subscribe to for priority testing: "track-name:priority"
+  /// e.g. --extra-track demo2:200
+  #[arg(long)]
+  pub extra_track: Option<String>,
 }

--- a/apps/client/src/main.rs
+++ b/apps/client/src/main.rs
@@ -53,6 +53,8 @@ async fn main() -> Result<(), anyhow::Error> {
         track_alias: cli
           .track_alias
           .unwrap_or_else(|| rand::random::<u64>() & ((1u64 << 62) - 1)),
+        publisher_priority: cli.publisher_priority,
+        group_order: cli.group_order.into(),
       };
       publisher::run(moq_conn, config).await
     }
@@ -64,16 +66,26 @@ async fn main() -> Result<(), anyhow::Error> {
         interval: cli.interval,
         objects_per_group: cli.objects_per_group,
         payload_size: cli.payload_size,
+        publisher_priority: cli.publisher_priority,
+        group_order: cli.group_order.into(),
       };
       publisher::run_namespace(moq_conn, config).await
     }
     Command::Subscribe => {
+      let extra = cli.extra_track.as_deref().and_then(|s| {
+        let (name, prio) = s.rsplit_once(':')?;
+        let priority: u8 = prio.parse().ok()?;
+        Some((name.to_string(), priority))
+      });
       subscriber::run(
         moq_conn,
         &cli.namespace,
         &cli.track_name,
         cli.forwarding_preference,
         cli.duration,
+        cli.subscriber_priority,
+        cli.group_order.into(),
+        extra,
       )
       .await
     }

--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -45,6 +45,8 @@ pub struct PublishConfig {
   pub objects_per_group: u64,
   pub payload_size: usize,
   pub track_alias: u64,
+  pub publisher_priority: u8,
+  pub group_order: GroupOrder,
 }
 
 pub struct PublishNamespaceConfig {
@@ -54,6 +56,8 @@ pub struct PublishNamespaceConfig {
   pub interval: u64,
   pub objects_per_group: u64,
   pub payload_size: usize,
+  pub publisher_priority: u8,
+  pub group_order: GroupOrder,
 }
 
 pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -> Result<()> {
@@ -73,6 +77,7 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
     interval: config.interval,
     objects_per_group: config.objects_per_group,
     payload_size: config.payload_size,
+    publisher_priority: config.publisher_priority,
   };
 
   // Step 2: Listen for Subscribe messages and serve data
@@ -96,6 +101,7 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
         );
 
         let msg = SubscribeOk::new(m.request_id, track_alias, vec![], vec![]);
+
         control_stream.send_impl(&msg).await?;
         info!(
           "SubscribeOk sent for request_id={}, track_alias={}",
@@ -152,6 +158,7 @@ pub async fn run(moq: MoqConnection, config: PublishConfig) -> Result<()> {
     interval: config.interval,
     objects_per_group: config.objects_per_group,
     payload_size: config.payload_size,
+    publisher_priority: config.publisher_priority,
   };
 
   publish_track(
@@ -160,6 +167,7 @@ pub async fn run(moq: MoqConnection, config: PublishConfig) -> Result<()> {
     &ns,
     &config.track_name,
     config.track_alias,
+    config.group_order,
     &data_config,
   )
   .await?;
@@ -212,6 +220,7 @@ struct DataConfig {
   interval: u64,
   objects_per_group: u64,
   payload_size: usize,
+  publisher_priority: u8,
 }
 
 async fn publish_track(
@@ -220,6 +229,7 @@ async fn publish_track(
   namespace: &Tuple,
   track_name: &str,
   track_alias: u64,
+  group_order: GroupOrder,
   data_config: &DataConfig,
 ) -> Result<()> {
   info!("Publishing track: track_alias={}", track_alias);
@@ -229,7 +239,7 @@ async fn publish_track(
     TupleField::from_utf8(track_name),
     track_alias,
     vec![
-      MessageParameter::new_group_order(GroupOrder::Ascending),
+      MessageParameter::new_group_order(group_order),
       MessageParameter::new_largest_object(Location::new(0, 0)),
       MessageParameter::Forward { forward: true },
     ],
@@ -264,6 +274,7 @@ async fn send_data(
         config.interval,
         config.objects_per_group,
         config.payload_size,
+        config.publisher_priority,
       )
       .await
     }
@@ -275,6 +286,7 @@ async fn send_data(
         config.interval,
         config.objects_per_group,
         config.payload_size,
+        config.publisher_priority,
       )
       .await
     }
@@ -288,6 +300,7 @@ async fn send_datagrams(
   interval_ms: u64,
   objects_per_group: u64,
   payload_size: usize,
+  publisher_priority: u8,
 ) -> Result<()> {
   let interval = Duration::from_millis(interval_ms);
   info!(
@@ -303,8 +316,8 @@ async fn send_datagrams(
         track_alias,
         group_id,
         object_id,
-        Some(0), // publisher_priority
-        None,    // extension_headers
+        Some(publisher_priority), // publisher_priority
+        None,                     // extension_headers
         Bytes::from(payload),
         false, // end_of_group
       );
@@ -346,6 +359,7 @@ async fn send_via_streams(
   interval_ms: u64,
   objects_per_group: u64,
   payload_size: usize,
+  publisher_priority: u8,
 ) -> Result<()> {
   let interval = Duration::from_millis(interval_ms);
   info!(
@@ -357,8 +371,14 @@ async fn send_via_streams(
     info!("Opening stream for group {}", group_id);
     let stream = connection.open_uni().await?.await?;
 
-    let sub_header =
-      SubgroupHeader::new_with_explicit_id(track_alias, group_id, 1u64, Some(1u8), true, true);
+    let sub_header = SubgroupHeader::new_with_explicit_id(
+      track_alias,
+      group_id,
+      1u64,
+      Some(publisher_priority),
+      true,
+      true,
+    );
     let header_info = HeaderInfo::Subgroup { header: sub_header };
     let stream = Arc::new(Mutex::new(stream));
     let mut handler = SendDataStream::new(stream, header_info).await?;

--- a/apps/client/src/subscriber.rs
+++ b/apps/client/src/subscriber.rs
@@ -29,28 +29,27 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info};
 
-pub async fn run(
-  moq: MoqConnection,
+/// Subscribe to one track and return its assigned track alias.
+async fn subscribe_track(
+  control_stream: &mut moqtail::transport::control_stream_handler::ControlStreamHandler,
   namespace: &str,
   track_name: &str,
-  forwarding_preference: ForwardingPreference,
-  duration: u64,
-) -> Result<()> {
-  let MoqConnection {
-    connection,
-    mut control_stream,
-  } = moq;
-
-  // Subscribe to track
+  request_id: u64,
+  subscriber_priority: u8,
+  group_order: GroupOrder,
+) -> Result<u64> {
   let ns = Tuple::from_utf8_path(namespace);
-  info!("Subscribing to track: {}/{}", namespace, track_name);
+  info!(
+    "Subscribing to track: {}/{} (request_id={}, priority={})",
+    namespace, track_name, request_id, subscriber_priority
+  );
   let subscribe = Subscribe::new_latest_object(
-    0, // request_id
+    request_id,
     ns,
     TupleField::from_utf8(track_name),
     vec![
-      MessageParameter::new_subscriber_priority(0),
-      MessageParameter::new_group_order(GroupOrder::Ascending),
+      MessageParameter::new_subscriber_priority(subscriber_priority),
+      MessageParameter::new_group_order(group_order),
       MessageParameter::new_forward(true),
     ],
   );
@@ -58,20 +57,65 @@ pub async fn run(
     .send(&ControlMessage::Subscribe(Box::new(subscribe)))
     .await?;
 
-  // Wait for SubscribeOk
-  info!("Waiting for SubscribeOk...");
-  let track_alias = match control_stream.next_message().await {
+  match control_stream.next_message().await {
     Ok(ControlMessage::SubscribeOk(m)) => {
-      info!("Subscribed: track_alias={}", m.track_alias);
-      m.track_alias
+      info!(
+        "Subscribed: track={} track_alias={}",
+        track_name, m.track_alias
+      );
+      Ok(m.track_alias)
     }
-    Ok(m) => anyhow::bail!("Expected SubscribeOk, got {:?}", m),
-    Err(e) => anyhow::bail!("Failed waiting for SubscribeOk: {:?}", e),
+    Ok(m) => anyhow::bail!("Expected SubscribeOk for {}, got {:?}", track_name, m),
+    Err(e) => anyhow::bail!("Failed waiting for SubscribeOk for {}: {:?}", track_name, e),
+  }
+}
+
+pub async fn run(
+  moq: MoqConnection,
+  namespace: &str,
+  track_name: &str,
+  forwarding_preference: ForwardingPreference,
+  duration: u64,
+  subscriber_priority: u8,
+  group_order: GroupOrder,
+  // Optional second track for priority testing: (track_name, subscriber_priority)
+  extra_track: Option<(String, u8)>,
+) -> Result<()> {
+  let MoqConnection {
+    connection,
+    mut control_stream,
+  } = moq;
+
+  let track_alias = subscribe_track(
+    &mut control_stream,
+    namespace,
+    track_name,
+    0,
+    subscriber_priority,
+    group_order,
+  )
+  .await?;
+
+  let extra_alias = if let Some((ref extra_name, extra_priority)) = extra_track {
+    let alias = subscribe_track(
+      &mut control_stream,
+      namespace,
+      extra_name,
+      1,
+      extra_priority,
+      group_order,
+    )
+    .await?;
+    Some((extra_name.clone(), alias))
+  } else {
+    None
   };
 
   match forwarding_preference {
     ForwardingPreference::Datagram => receive_datagrams(&connection, track_alias, duration).await,
-    ForwardingPreference::Subgroup => receive_streams(&connection, track_alias, duration).await,
+    ForwardingPreference::Subgroup => {
+      receive_streams(&connection, track_alias, extra_alias, duration).await
+    }
   }
 }
 
@@ -165,10 +209,19 @@ async fn receive_datagrams(
 
 async fn receive_streams(
   connection: &Arc<wtransport::Connection>,
-  _track_alias: u64,
+  primary_alias: u64,
+  extra_alias: Option<(String, u64)>,
   duration: u64,
 ) -> Result<()> {
   info!("Listening for incoming streams...");
+
+  // Build a map from track_alias → label for log output
+  let mut alias_to_label = std::collections::HashMap::new();
+  alias_to_label.insert(primary_alias, format!("alias={primary_alias}(primary)"));
+  if let Some((ref name, alias)) = extra_alias {
+    alias_to_label.insert(alias, format!("alias={alias}({name})"));
+  }
+  let alias_to_label = Arc::new(alias_to_label);
 
   let pending_fetches = Arc::new(RwLock::new(BTreeMap::new()));
   let conn = connection.clone();
@@ -180,7 +233,6 @@ async fn receive_streams(
     loop {
       match conn.accept_uni().await {
         Ok(stream) => {
-          info!("Accepted unidirectional stream");
           let stream_handler = RecvDataStream::new(stream, pending_fetches_clone.clone());
           let mut handler = &stream_handler;
 
@@ -189,25 +241,30 @@ async fn receive_streams(
             match object {
               Some(obj) => {
                 let sequence_ok = stats.record_object(obj.location.group, obj.location.object);
+                let label = alias_to_label
+                  .get(&obj.track_alias)
+                  .map(|s| s.as_str())
+                  .unwrap_or("unknown");
 
                 if should_log(stats.total_received) || !sequence_ok {
                   info!(
-                    "Received object {}: group={}, object={}, seq={}",
+                    "Received object {}: track={} group={}, object={}, seq={}",
                     stats.total_received,
+                    label,
                     obj.location.group,
                     obj.location.object,
                     if sequence_ok { "OK" } else { "GAP" }
                   );
                 } else {
                   debug!(
-                    "Received object {}: group={}, object={}",
-                    stats.total_received, obj.location.group, obj.location.object
+                    "Received object {}: track={} group={}, object={}",
+                    stats.total_received, label, obj.location.group, obj.location.object
                   );
                 }
                 handler = next_handler;
               }
               None => {
-                info!("Stream closed");
+                debug!("Stream closed");
                 break;
               }
             }

--- a/apps/relay/src/server/client.rs
+++ b/apps/relay/src/server/client.rs
@@ -37,11 +37,51 @@ use switch_context::SwitchContext;
 use std::{
   collections::{BTreeMap, HashMap, VecDeque},
   sync::Arc,
+  time::Duration,
 };
 use tokio::sync::Notify;
 use tokio::sync::{Mutex, RwLock, watch};
+use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
 use wtransport::{Connection, SendStream, error::StreamWriteError};
+
+/// Token-bucket rate limiter. All streams of one subscriber share a single
+/// bucket so they compete for bandwidth — the QUIC scheduler then drains
+/// higher-priority streams first when writes are pending.
+#[derive(Debug)]
+struct TokenBucket {
+  rate_bytes_per_sec: f64,
+  tokens: f64,
+  last_refill: Instant,
+}
+
+impl TokenBucket {
+  fn new(rate_kbps: u64) -> Self {
+    let rate = rate_kbps as f64 * 1000.0 / 8.0; // kbps → bytes/sec
+    Self {
+      rate_bytes_per_sec: rate,
+      tokens: rate, // start with one second worth of tokens
+      last_refill: Instant::now(),
+    }
+  }
+
+  async fn consume(&mut self, bytes: usize) {
+    let now = Instant::now();
+    let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+    self.tokens = (self.tokens + elapsed * self.rate_bytes_per_sec).min(self.rate_bytes_per_sec); // cap at 1 second of burst
+    self.last_refill = now;
+
+    let needed = bytes as f64;
+    if self.tokens < needed {
+      let deficit = needed - self.tokens;
+      let wait = Duration::from_secs_f64(deficit / self.rate_bytes_per_sec);
+      tokio::time::sleep(wait).await;
+      self.tokens = 0.0;
+    } else {
+      self.tokens -= needed;
+    }
+  }
+}
 
 /// Number of partitions for send stream management to reduce lock contention.
 /// Each partition contains a separate HashMap protected by its own RwLock.
@@ -84,6 +124,10 @@ pub(crate) struct MOQTClient {
   pub subscriptions: TrackSubscriptionMap,
 
   pub switch_context: SwitchContext,
+
+  // Optional per-connection write rate limiter. All streams of this client share
+  // the same bucket so they compete for bandwidth, exercising QUIC stream priority.
+  rate_limiter: Option<Arc<Mutex<TokenBucket>>>,
 }
 
 impl MOQTClient {
@@ -96,6 +140,13 @@ impl MOQTClient {
     for _ in 0..SEND_STREAM_PARTITION_COUNT {
       send_streams.push(Arc::new(RwLock::new(HashMap::new())));
     }
+
+    let kbps = crate::server::config::AppConfig::load().write_kbps_limit;
+    let rate_limiter = if kbps > 0 {
+      Some(Arc::new(Mutex::new(TokenBucket::new(kbps))))
+    } else {
+      None
+    };
 
     MOQTClient {
       connection_id,
@@ -114,6 +165,7 @@ impl MOQTClient {
       fetch_cancel_senders: Arc::new(RwLock::new(HashMap::new())),
       subscriptions: TrackSubscriptionMap::new(),
       switch_context: SwitchContext::new(),
+      rate_limiter,
     }
   }
 
@@ -354,7 +406,12 @@ impl MOQTClient {
       }
     };
 
-    // flow control
+    // Rate-limit before writing so all streams of this connection compete for
+    // the shared bandwidth budget, causing QUIC buffers to fill and the QUIC
+    // stream priority scheduler to choose between them.
+    if let Some(rl) = &self.rate_limiter {
+      rl.lock().await.consume(object.len()).await;
+    }
 
     if let Some(s) = send_stream {
       let mut stream = s.lock().await;

--- a/apps/relay/src/server/config.rs
+++ b/apps/relay/src/server/config.rs
@@ -73,6 +73,11 @@ pub struct Cli {
   /// Initial maximum request ID
   #[arg(long, default_value_t = u64::MAX / 8)]
   pub initial_max_request_id: u64,
+
+  /// Simulate a bandwidth cap per subscriber connection (kbps). 0 = unlimited.
+  /// Useful for testing QUIC stream priority scheduling without OS-level throttling.
+  #[arg(long, default_value_t = 0)]
+  pub write_kbps_limit: u64,
 }
 #[derive(Debug, Clone)]
 pub struct AppConfig {
@@ -90,6 +95,8 @@ pub struct AppConfig {
   pub enable_token_logging: bool,
   pub token_log_path: String,
   pub initial_max_request_id: u64,
+  /// 0 = unlimited. Non-zero caps relay writes to this many kbps per subscriber connection.
+  pub write_kbps_limit: u64,
 }
 
 impl AppConfig {
@@ -112,6 +119,7 @@ impl AppConfig {
         enable_token_logging: cli.enable_token_logging,
         token_log_path: cli.token_log_path,
         initial_max_request_id: cli.initial_max_request_id,
+        write_kbps_limit: cli.write_kbps_limit,
       }
     })
   }
@@ -194,6 +202,7 @@ mod tests {
       enable_token_logging: false,
       token_log_path: "/tmp/moqtail_relay_tokens.csv".to_string(),
       initial_max_request_id: u64::MAX / 8,
+      write_kbps_limit: 0,
     };
 
     let config = AppConfig {
@@ -211,6 +220,7 @@ mod tests {
       enable_token_logging: cli.enable_token_logging,
       token_log_path: cli.token_log_path,
       initial_max_request_id: cli.initial_max_request_id,
+      write_kbps_limit: cli.write_kbps_limit,
     };
 
     assert_eq!(config.initial_max_request_id, u64::MAX / 8);

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -240,9 +240,8 @@ pub async fn handle(
         let mut object_count = 0;
         let mut send_stream = None;
         let mut cancelled = false;
-        let mut fetch_prev_ctx: Option<
-          moqtail::model::data::fetch_object::FetchObjectContext,
-        > = None;
+        let mut fetch_prev_ctx: Option<moqtail::model::data::fetch_object::FetchObjectContext> =
+          None;
         loop {
           tokio::select! {
             event = object_rx.recv() => {

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -79,7 +79,7 @@ impl From<Publish> for SubscriptionOrigin {
 #[derive(Debug, Clone)]
 pub struct SubscriptionState {
   pub subscriber_priority: u8,
-  pub _group_order: GroupOrder,
+  pub group_order: GroupOrder,
   pub forward: bool,
   pub filter_type: FilterType,
   pub start_location: Option<Location>,
@@ -177,7 +177,7 @@ impl From<SubscriptionOrigin> for SubscriptionState {
 
         Self {
           subscriber_priority,
-          _group_order: group_order,
+          group_order,
           forward,
           filter_type,
           start_location,
@@ -244,7 +244,7 @@ impl From<SubscriptionOrigin> for SubscriptionState {
 
         Self {
           subscriber_priority,
-          _group_order: group_order,
+          group_order,
           forward,
           filter_type,
           start_location,
@@ -256,6 +256,28 @@ impl From<SubscriptionOrigin> for SubscriptionState {
         }
       }
     }
+  }
+}
+
+/// Compute QUIC stream priority from MOQT scheduling parameters.
+///
+/// The i32 space is divided into 65536 bands (one per sub_prio × pub_prio pair).
+/// Within each band, group_id determines relative position according to group_order:
+///   Ascending / Original – lower group_id = higher priority (counts down from band_max)
+///   Descending            – higher group_id = higher priority (counts up from band_min)
+fn compute_stream_priority(
+  sub_prio: u8,
+  pub_prio: u8,
+  group_order: GroupOrder,
+  group_id: u64,
+) -> i32 {
+  const BAND_SIZE: i64 = 65536;
+  let priority_index = (255 - sub_prio as i64) * 256 + (255 - pub_prio as i64);
+  let band_min = i32::MIN as i64 + priority_index * BAND_SIZE;
+  let group_slot = (group_id % BAND_SIZE as u64) as i64;
+  match group_order {
+    GroupOrder::Ascending | GroupOrder::Original => (band_min + BAND_SIZE - 1 - group_slot) as i32,
+    GroupOrder::Descending => (band_min + group_slot) as i32,
   }
 }
 
@@ -1053,9 +1075,17 @@ impl Subscription {
         utils::bytes_to_hex(&header_payload)
       );
 
-      // set priority based on the current time
-      // TODO: revisit this logic to set priority based on the subscription
-      let priority = i32::MAX - (utils::passed_time_since_start() % i32::MAX as u128) as i32;
+      let (pub_prio, group_id) = match &header_info {
+        HeaderInfo::Subgroup { header } => {
+          (header.publisher_priority.unwrap_or(128u8), header.group_id)
+        }
+        HeaderInfo::Fetch { .. } => (128u8, 0u64),
+      };
+      let (sub_prio, group_order) = {
+        let state = self.subscription_state.read().await;
+        (state.subscriber_priority, state.group_order)
+      };
+      let priority = compute_stream_priority(sub_prio, pub_prio, group_order, group_id);
 
       let send_stream = match self
         .subscriber
@@ -1261,5 +1291,92 @@ impl Subscription {
     );
 
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use moqtail::model::control::constant::GroupOrder;
+
+  #[test]
+  fn test_highest_priority_near_i32_max() {
+    let p = compute_stream_priority(0, 0, GroupOrder::Ascending, 0);
+    assert!(
+      p > 2_100_000_000,
+      "highest priority should be near i32::MAX, got {p}"
+    );
+  }
+
+  #[test]
+  fn test_lowest_priority_near_i32_min() {
+    let p = compute_stream_priority(255, 255, GroupOrder::Ascending, 0);
+    assert!(
+      p < -2_100_000_000,
+      "lowest priority should be near i32::MIN, got {p}"
+    );
+  }
+
+  #[test]
+  fn test_ascending_lower_group_higher_priority() {
+    let p0 = compute_stream_priority(0, 0, GroupOrder::Ascending, 0);
+    let p1 = compute_stream_priority(0, 0, GroupOrder::Ascending, 1);
+    assert!(p0 > p1, "group 0 should outrank group 1 in Ascending order");
+  }
+
+  #[test]
+  fn test_descending_higher_group_higher_priority() {
+    let p0 = compute_stream_priority(0, 0, GroupOrder::Descending, 0);
+    let p1 = compute_stream_priority(0, 0, GroupOrder::Descending, 1);
+    assert!(
+      p1 > p0,
+      "group 1 should outrank group 0 in Descending order"
+    );
+  }
+
+  #[test]
+  fn test_original_same_as_ascending() {
+    for g in [0u64, 1, 100, 65535] {
+      assert_eq!(
+        compute_stream_priority(10, 20, GroupOrder::Original, g),
+        compute_stream_priority(10, 20, GroupOrder::Ascending, g),
+        "Original should behave like Ascending for group {g}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_subscriber_priority_dominates() {
+    // sub=0,pub=255 must outrank sub=1,pub=0 regardless of group
+    let high = compute_stream_priority(0, 255, GroupOrder::Ascending, 0);
+    let low = compute_stream_priority(1, 0, GroupOrder::Ascending, 0);
+    assert!(
+      high > low,
+      "subscriber priority must dominate publisher priority"
+    );
+  }
+
+  #[test]
+  fn test_publisher_priority_tie_break() {
+    let high = compute_stream_priority(10, 0, GroupOrder::Ascending, 0);
+    let low = compute_stream_priority(10, 1, GroupOrder::Ascending, 0);
+    assert!(high > low, "lower pub_prio number = higher priority");
+  }
+
+  #[test]
+  fn test_all_values_within_i32_range() {
+    for sub in [0u8, 128, 255] {
+      for pub_ in [0u8, 128, 255] {
+        for &order in &[
+          GroupOrder::Ascending,
+          GroupOrder::Descending,
+          GroupOrder::Original,
+        ] {
+          for group in [0u64, 1, 65534, 65535, 65536, u64::MAX] {
+            let _ = compute_stream_priority(sub, pub_, order, group); // must not panic/overflow
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR implements the scheduling algorithm in the relay defined in the draft. 

Look at the comments for a detailed explanation of how priorities are computed based on the subscriber abd publisher priorities.