### PR TITLE
[upstream fetches] Plumbing to forward FETCH data received from upstream [2/n]

### DIFF
--- a/apps/relay/src/server.rs
+++ b/apps/relay/src/server.rs
@@ -29,7 +29,7 @@ mod track_cache;
 mod track_manager;
 mod utils;
 
-use crate::server::session_context::PendingRequest;
+use crate::server::session_context::{PendingRequest, UpstreamFetchEvent};
 use crate::server::{config::AppConfig, session::Session};
 use anyhow::Result;
 use client_manager::ClientManager;
@@ -37,8 +37,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use tokio::signal;
-use tokio::sync::Notify;
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock, mpsc};
 use tracing::{debug, error, info};
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
@@ -52,6 +51,7 @@ pub(crate) struct Server {
   pub relay_pending_requests: Arc<RwLock<BTreeMap<u64, PendingRequest>>>,
   pub app_config: &'static AppConfig,
   pub relay_next_request_id: Arc<AtomicU64>,
+  pub upstream_fetch_senders: Arc<RwLock<BTreeMap<u64, mpsc::Sender<UpstreamFetchEvent>>>>,
 }
 
 impl Server {
@@ -68,6 +68,7 @@ impl Server {
       relay_pending_requests: Arc::new(RwLock::new(BTreeMap::new())),
       app_config: config,
       relay_next_request_id: Arc::new(AtomicU64::new(1u64)), // relay's request id starts at 1 and are odd
+      upstream_fetch_senders: Arc::new(RwLock::new(BTreeMap::new())),
     }
   }
 

--- a/apps/relay/src/server/config.rs
+++ b/apps/relay/src/server/config.rs
@@ -78,6 +78,13 @@ pub struct Cli {
   /// Useful for testing QUIC stream priority scheduling without OS-level throttling.
   #[arg(long, default_value_t = 0)]
   pub write_kbps_limit: u64,
+
+  /// Maximum number of upstream fetch gaps before skipping
+  #[arg(long, default_value_t = 10)]
+  pub max_upstream_fetch_gaps: u64,
+  /// Timeout in seconds for upstream fetch responses
+  #[arg(long, default_value_t = 10)]
+  pub upstream_fetch_timeout_secs: u64,
 }
 #[derive(Debug, Clone)]
 pub struct AppConfig {
@@ -97,6 +104,8 @@ pub struct AppConfig {
   pub initial_max_request_id: u64,
   /// 0 = unlimited. Non-zero caps relay writes to this many kbps per subscriber connection.
   pub write_kbps_limit: u64,
+  pub _max_upstream_fetch_gaps: u64,
+  pub _upstream_fetch_timeout: Duration,
 }
 
 impl AppConfig {
@@ -120,6 +129,8 @@ impl AppConfig {
         token_log_path: cli.token_log_path,
         initial_max_request_id: cli.initial_max_request_id,
         write_kbps_limit: cli.write_kbps_limit,
+        _max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
+        _upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
       }
     })
   }
@@ -203,6 +214,8 @@ mod tests {
       token_log_path: "/tmp/moqtail_relay_tokens.csv".to_string(),
       initial_max_request_id: u64::MAX / 8,
       write_kbps_limit: 0,
+      max_upstream_fetch_gaps: 10,
+      upstream_fetch_timeout_secs: 10,
     };
 
     let config = AppConfig {
@@ -221,6 +234,8 @@ mod tests {
       token_log_path: cli.token_log_path,
       initial_max_request_id: cli.initial_max_request_id,
       write_kbps_limit: cli.write_kbps_limit,
+      _max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
+      _upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
     };
 
     assert_eq!(config.initial_max_request_id, u64::MAX / 8);

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -60,9 +60,9 @@ impl Session {
       "New session:
       Remote Address: '{:?}'
       Origin: '{:?}'
-      Authority: '{}', 
+      Authority: '{}',
       Path: '{}'
-      User-Agent: '{:?}' 
+      User-Agent: '{:?}'
       Headers: '{:?}'
       ",
       remote_addr, origin, authority, path, user_agent, headers
@@ -96,11 +96,13 @@ impl Session {
     let track_manager = server.track_manager.clone();
     let server_config = server.app_config;
     let relay_pending_requests = server.relay_pending_requests.clone();
+    let upstream_fetch_senders = server.upstream_fetch_senders.clone();
     let relay_next_request_id = server.relay_next_request_id.clone();
     let connection = session_request.accept().await?;
 
     let request_maps = RequestMaps {
       relay_pending_requests,
+      upstream_fetch_senders,
     };
 
     let context = Arc::new(SessionContext::new(
@@ -583,6 +585,10 @@ impl Session {
     let mut track_alias = 0u64;
     let mut stream_id: Option<StreamId> = None;
     let mut current_track: Option<Arc<RwLock<Track>>> = None;
+    // Used if this stream is a response to an upstream fetch the relay issued.
+    let mut upstream_sender: Option<
+      tokio::sync::mpsc::Sender<super::session_context::UpstreamFetchEvent>,
+    > = None;
 
     let mut object_count = 0;
 
@@ -622,6 +628,18 @@ impl Session {
                   .await
                   .get(&fetch_request_id)
                   .map_or(0, |r| r.track_alias);
+
+                // Check if this stream is a response to a relay-initiated
+                // upstream fetch. If so, grab the sender to forward objects.
+                if let Some(sender) = context
+                  .upstream_fetch_senders
+                  .read()
+                  .await
+                  .get(&fetch_request_id)
+                  .cloned()
+                {
+                  upstream_sender = Some(sender);
+                }
               }
             }
 
@@ -692,6 +710,17 @@ impl Session {
               "Failed to process object track: alias: {:?} track name: {:?} error: {:?}",
               track_alias, &track.full_track_name, e
             );
+          }
+
+          // Forward object to upstream fetch channel if this is a relay-initiated fetch
+          if let Some(ref sender) = upstream_sender
+            && let Ok(fetch_object) = object.clone().try_into_fetch()
+          {
+            let _ = sender
+              .send(super::session_context::UpstreamFetchEvent::Object(
+                fetch_object,
+              ))
+              .await;
           }
 
           object_count += 1;

--- a/apps/relay/src/server/session_context.rs
+++ b/apps/relay/src/server/session_context.rs
@@ -19,7 +19,9 @@ use std::{
     atomic::{AtomicBool, AtomicU64},
   },
 };
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, mpsc};
+
+use moqtail::model::data::fetch_object::FetchObjectPayload;
 use wtransport::Connection;
 
 use moqtail::transport::data_stream_handler::{FetchRequest, SubscribeRequest};
@@ -58,8 +60,24 @@ pub enum PendingRequest {
   },
 }
 
+/// This is used when the relay sends a FETCH request to the upstream.
+/// It gets an event of this type from the upstream, and calls send() on
+/// the relevant upstream_fetch_senders entry.
+/// The receiver awaits entries in a loop and sends them downstream.
+#[allow(dead_code)]
+pub(crate) enum UpstreamFetchEvent {
+  Object(FetchObjectPayload),
+  StreamClosed,
+  Error(String),
+}
+
 pub struct RequestMaps {
   pub relay_pending_requests: Arc<RwLock<BTreeMap<u64, PendingRequest>>>,
+  /// This is used when the relay sends a FETCH request to the upstream.
+  /// When objects are received from the upstream, send() is called on the relevant entry
+  /// in the upstream_fetch_senders.
+  /// The receiver loop awaits the entries and sends them downstream.
+  pub upstream_fetch_senders: Arc<RwLock<BTreeMap<u64, mpsc::Sender<UpstreamFetchEvent>>>>,
 }
 
 pub struct SessionContext {
@@ -73,6 +91,7 @@ pub struct SessionContext {
   pub(crate) is_connection_closed: Arc<AtomicBool>,
   pub(crate) relay_next_request_id: Arc<AtomicU64>,
   pub(crate) max_request_id: Arc<AtomicU64>,
+  pub(crate) upstream_fetch_senders: Arc<RwLock<BTreeMap<u64, mpsc::Sender<UpstreamFetchEvent>>>>,
 }
 
 impl SessionContext {
@@ -95,6 +114,7 @@ impl SessionContext {
       is_connection_closed: Arc::new(AtomicBool::new(false)),
       relay_next_request_id,
       max_request_id: Arc::new(AtomicU64::new(server_config.initial_max_request_id)),
+      upstream_fetch_senders: request_maps.upstream_fetch_senders,
     }
   }
 


### PR DESCRIPTION
In this PR, I'm making some plumbing changes so that in handle_uni_stream, when we receive objects in a stream from the upstream, we can forward it to the downstream.