### PR TITLE
fix(moqtail-ts): adds isValidTrackAlias validator

### DIFF
--- a/.changeset/legal-cities-thank.md
+++ b/.changeset/legal-cities-thank.md
@@ -1,0 +1,5 @@
+---
+'moqtail': minor
+---
+
+Add `isValidTrackAlias` type guard in `src/client/util/validators.ts`,

--- a/.changeset/legal-cities-thank.md
+++ b/.changeset/legal-cities-thank.md
@@ -2,4 +2,4 @@
 'moqtail': minor
 ---
 
-Add `isValidTrackAlias` type guard in `src/client/util/validators.ts`,
+Add `isValidTrackAlias` type guard in `src/client/util/validators.ts`. Thanks to [thexeos](https://github.com/thexeos) for pointing out the bug and proposing the fix.

--- a/libs/moqtail-ts/src/client/client.ts
+++ b/libs/moqtail-ts/src/client/client.ts
@@ -82,6 +82,7 @@ import { SubscribePublication } from './publication/subscribe'
 import { FetchPublication } from './publication/fetch'
 import { PublishPublication } from './publication/publish'
 import { random60bitId } from './util/random_id'
+import { isValidTrackAlias } from './util/validators'
 import {
   MOQtailRequest,
   SubscribeOptions,
@@ -855,7 +856,7 @@ export class MOQtailClient {
    */
   addOrUpdateTrack(track: Track) {
     this.#ensureActive()
-    if (!track.trackAlias) {
+    if (!isValidTrackAlias(track.trackAlias)) {
       track.trackAlias = random60bitId()
     }
     this.trackSources.set(track.fullTrackName.toString(), track)
@@ -1151,7 +1152,7 @@ export class MOQtailClient {
         const request = this.requests.get(subscriptionRequestId)!
         if (request instanceof SubscribeRequest) {
           const trackAlias = this.subscriptionAliasMap.get(subscriptionRequestId)
-          if (!trackAlias)
+          if (!isValidTrackAlias(trackAlias))
             throw new InternalError('MOQtailClient.subscribeUpdate', 'Request exists but track alias mapping does not')
           const subscription = this.subscriptions.get(trackAlias)
           if (!subscription)
@@ -1210,7 +1211,7 @@ export class MOQtailClient {
         throw new ProtocolViolationError('MOQtailClient.switch', 'Request id is not a subscription')
 
       const trackAlias = this.subscriptionAliasMap.get(subscriptionRequestId)
-      if (!trackAlias)
+      if (!isValidTrackAlias(trackAlias))
         throw new InternalError('MOQtailClient.switch', 'Request exists but track alias mapping does not')
       const subscription = this.subscriptions.get(trackAlias)
       if (!subscription) throw new InternalError('MOQtailClient.switch', 'Request exists but subscription does not')

--- a/libs/moqtail-ts/src/client/handler/subscribe.ts
+++ b/libs/moqtail-ts/src/client/handler/subscribe.ts
@@ -20,6 +20,7 @@ import { ControlMessageHandler } from './handler'
 import { SubscribePublication } from '../publication/subscribe'
 import { logger } from '../../util/logger'
 import { LargestObject } from '../../model/parameter/message/largest_object'
+import { isValidTrackAlias } from '../util/validators'
 
 export const handlerSubscribe: ControlMessageHandler<Subscribe> = async (client, msg) => {
   logger.debug('handler/subscribe', `received requestId=${msg.requestId} ftn="${msg.fullTrackName}"`)
@@ -53,7 +54,8 @@ export const handlerSubscribe: ControlMessageHandler<Subscribe> = async (client,
     await client.controlStream.send(response)
     return
   }
-  if (!track.trackAlias) throw new Error('Expected track alias to be set')
+
+  if (!isValidTrackAlias(track.trackAlias)) throw new Error('Expected track alias to be set')
 
   const largestLocation = track.trackSource.live.largestLocation
   const parameters = [...msg.parameters]

--- a/libs/moqtail-ts/src/client/util/validators.ts
+++ b/libs/moqtail-ts/src/client/util/validators.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2026 The MOQtail Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns true when `trackAlias` is a valid (non-negative) track alias. Zero is a legal value. */
+export function isValidTrackAlias(trackAlias: bigint | undefined): trackAlias is bigint {
+  return trackAlias !== undefined && trackAlias >= 0n
+}
+
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest
+  describe('isValidTrackAlias', () => {
+    it('accepts zero', () => {
+      expect(isValidTrackAlias(0n)).toBe(true)
+    })
+    it('accepts positive alias', () => {
+      expect(isValidTrackAlias(1n)).toBe(true)
+      expect(isValidTrackAlias(9999999999n)).toBe(true)
+    })
+    it('rejects undefined', () => {
+      expect(isValidTrackAlias(undefined)).toBe(false)
+    })
+    it('rejects negative alias', () => {
+      expect(isValidTrackAlias(-1n)).toBe(false)
+    })
+  })
+}


### PR DESCRIPTION
Add `isValidTrackAlias` type guard in `src/client/util/validators.ts`,
    consolidating three inconsistent checks (`!trackAlias`, `=== undefined`, and a
    compound condition) into one canonical test that correctly accepts 0 as a valid
    alias.

Co-authored-by: @thexeos

Closes #156 