### PR TITLE
[upstream fetches] Finish implementation of sending FETCH requests upstream for cache misses [4/n]

### DIFF
--- a/.changeset/blue-carrots-wear.md
+++ b/.changeset/blue-carrots-wear.md
@@ -1,0 +1,5 @@
+---
+'relay': patch
+---
+
+Send fetches upstream for cache misses.

--- a/.changeset/blue-carrots-wear.md
+++ b/.changeset/blue-carrots-wear.md
@@ -1,5 +1,0 @@
----
-'relay': patch
----
-
-Send fetches upstream for cache misses.

--- a/.changeset/empty-berries-begin.md
+++ b/.changeset/empty-berries-begin.md
@@ -1,0 +1,5 @@
+---
+'relay': patch
+---
+
+Send fetches upstream for cache misses

--- a/apps/relay/src/server/client.rs
+++ b/apps/relay/src/server/client.rs
@@ -108,8 +108,10 @@ pub(crate) struct MOQTClient {
   pub message_notify: Arc<Notify>, // notify when a new message is available
   pub send_streams: Arc<SendStreamList>,
 
-  // this contains the requests made by the client and the corresponding request
-  pub fetch_requests: Arc<RwLock<BTreeMap<u64, FetchRequest>>>,
+  // fetch requests that this client sent to the relay
+  pub incoming_fetch_requests: Arc<RwLock<BTreeMap<u64, FetchRequest>>>,
+  // fetch requests that the relay sent to this client
+  pub outgoing_fetch_requests: Arc<RwLock<BTreeMap<u64, FetchRequest>>>,
 
   // this contains the requests made by the client and the corresponding request.
   // The key value is the original request id.
@@ -159,7 +161,8 @@ impl MOQTClient {
       message_queue: Arc::new(RwLock::new(VecDeque::new())),
       message_notify: Arc::new(Notify::default()),
       send_streams: Arc::new(send_streams),
-      fetch_requests: Arc::new(RwLock::new(BTreeMap::new())),
+      incoming_fetch_requests: Arc::new(RwLock::new(BTreeMap::new())),
+      outgoing_fetch_requests: Arc::new(RwLock::new(BTreeMap::new())),
       subscribe_requests: Arc::new(RwLock::new(BTreeMap::new())),
       inbound_requests: Arc::new(RwLock::new(BTreeMap::new())),
       fetch_cancel_senders: Arc::new(RwLock::new(HashMap::new())),

--- a/apps/relay/src/server/config.rs
+++ b/apps/relay/src/server/config.rs
@@ -104,8 +104,8 @@ pub struct AppConfig {
   pub initial_max_request_id: u64,
   /// 0 = unlimited. Non-zero caps relay writes to this many kbps per subscriber connection.
   pub write_kbps_limit: u64,
-  pub _max_upstream_fetch_gaps: u64,
-  pub _upstream_fetch_timeout: Duration,
+  pub max_upstream_fetch_gaps: u64,
+  pub upstream_fetch_timeout: Duration,
 }
 
 impl AppConfig {
@@ -129,8 +129,8 @@ impl AppConfig {
         token_log_path: cli.token_log_path,
         initial_max_request_id: cli.initial_max_request_id,
         write_kbps_limit: cli.write_kbps_limit,
-        _max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
-        _upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
+        max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
+        upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
       }
     })
   }
@@ -234,8 +234,8 @@ mod tests {
       token_log_path: cli.token_log_path,
       initial_max_request_id: cli.initial_max_request_id,
       write_kbps_limit: cli.write_kbps_limit,
-      _max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
-      _upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
+      max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
+      upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
     };
 
     assert_eq!(config.initial_max_request_id, u64::MAX / 8);

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -15,7 +15,6 @@
 use crate::server::client::MOQTClient;
 use crate::server::session_context::{PendingRequest, SessionContext, UpstreamFetchEvent};
 use crate::server::stream_id::StreamId;
-use crate::server::track_cache::CacheConsumeEvent;
 use crate::server::utils::build_stream_id;
 use core::result::Result::{Err, Ok};
 use moqtail::model::common::location::Location;
@@ -33,6 +32,8 @@ use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info, warn};
+
+const UPSTREAM_FETCH_CHANNEL_CAPACITY: usize = 64;
 
 pub async fn handle(
   client: Arc<MOQTClient>,
@@ -69,7 +70,7 @@ pub async fn handle(
         };
 
         client
-          .fetch_requests
+          .incoming_fetch_requests
           .write()
           .await
           .insert(request_id, req.clone());
@@ -191,35 +192,28 @@ pub async fn handle(
         if let Some(PendingRequest::Fetch(req)) = inbound.get_mut(&request_id) {
           req.track_alias = track_read.relay_track_id;
         }
-        let mut fetches = client.fetch_requests.write().await;
+        let mut fetches = client.incoming_fetch_requests.write().await;
         if let Some(req) = fetches.get_mut(&request_id) {
           req.track_alias = track_read.relay_track_id;
         }
       }
 
       // Register a cancel channel for this fetch request
-      let (cancel_tx, mut cancel_rx) = watch::channel(false);
+      let (cancel_tx, cancel_rx) = watch::channel(false);
       {
         let mut senders = client.fetch_cancel_senders.write().await;
         senders.insert(request_id, cancel_tx);
       }
 
       tokio::spawn(async move {
-        // TODO: verify the range exist. Currently we just return what we have...
         let track_read = track.read().await;
-        let mut object_rx = track_read
-          .cache
-          .read_objects(
-            start_location.clone().unwrap(),
-            end_location.clone().unwrap(),
-            true, /* report_end_location */
-          )
-          .await;
+        let start_location = start_location.unwrap();
+        let end_location = end_location.unwrap();
 
         let fetch_header = FetchHeader::new(request_id);
         let header_info = HeaderInfo::Fetch {
           header: fetch_header,
-          fetch_request: fetch,
+          fetch_request: fetch.clone(),
         };
 
         let stream_id = build_stream_id(track_read.relay_track_id, &header_info);
@@ -239,143 +233,227 @@ pub async fn handle(
         };
 
         let mut object_count = 0;
+        let mut upstream_gap_count: u64 = 0;
         let mut send_stream = None;
         let mut cancelled = false;
         let mut fetch_prev_ctx: Option<moqtail::model::data::fetch_object::FetchObjectContext> =
           None;
-        loop {
-          tokio::select! {
-            event = object_rx.recv() => {
-              match event {
-                Some(event) => match event {
-                  CacheConsumeEvent::NoObject => {
-                    // there is no object found
-                    break;
-                  }
-                  CacheConsumeEvent::EndLocation(end_location) => {
-                    info!(
-                      "handle_fetch_messages | sending fetch_ok | actual end_location: {:?}",
-                      &end_location
-                    );
-                    // TODO: implement descending fetch
-                    // TODO: end of track is correct?
-                    let largest_location = track_read.largest_location.read().await;
-                    let end_of_track = largest_location.group == end_location.group;
-                    drop(largest_location);
-                    let cached_extensions = { track_read.track_extensions.read().await.clone() };
-                    let fetch_ok = FetchOk::new(
-                      request_id,
-                      end_of_track,
-                      end_location,
-                      vec![],
-                      cached_extensions,
-                    );
+        let mut group_id = start_location.group;
 
+        while group_id <= end_location.group {
+          if *cancel_rx.borrow() {
+            info!(
+              "handle_fetch_messages | Fetch cancelled for request_id: {}",
+              request_id
+            );
+            cancelled = true;
+            break;
+          }
+
+          if let Some(group_objects) = track_read.cache.get_group(group_id).await {
+            // === CACHE HIT ===
+            let objects = group_objects.read().await;
+            for object in objects.iter() {
+              if group_id == start_location.group && object.object_id < start_location.object {
+                continue;
+              }
+              if group_id == end_location.group && object.object_id >= end_location.object {
+                break;
+              }
+
+              if object_count == 0 {
+                send_stream = match stream_fn(client.clone(), &stream_id).await {
+                  Some(ss) => Some(ss),
+                  None => {
                     client
-                      .queue_message(ControlMessage::FetchOk(Box::new(fetch_ok)))
-                      .await;
+                      .fetch_cancel_senders
+                      .write()
+                      .await
+                      .remove(&request_id);
+                    return Err(TerminationCode::InternalError);
                   }
-                  CacheConsumeEvent::Object(object) => {
+                };
+              }
+
+              let fetch_obj =
+                moqtail::model::data::fetch_object::FetchObject::Object(object.clone());
+              let serialized = fetch_obj.serialize(fetch_prev_ctx.as_ref()).unwrap();
+              fetch_prev_ctx = fetch_obj.context();
+
+              if let Err(e) = client
+                .write_stream_object(
+                  &stream_id,
+                  object.object_id,
+                  serialized,
+                  send_stream.as_ref().cloned(),
+                )
+                .await
+              {
+                error!(
+                  "handle_fetch_messages | Error writing object to stream: {:?}",
+                  e
+                );
+                client
+                  .fetch_cancel_senders
+                  .write()
+                  .await
+                  .remove(&request_id);
+                return Err(TerminationCode::InternalError);
+              }
+
+              if context.server_config.enable_object_logging {
+                let sending_time = crate::server::utils::passed_time_since_start();
+                if let Ok(fetch_object) = moqtail::model::data::object::Object::try_from_fetch(
+                  object.clone(),
+                  track_read.relay_track_id,
+                ) {
+                  track_read
+                    .object_logger
+                    .log_fetch_object(
+                      track_read.relay_track_id,
+                      context.connection_id,
+                      request_id,
+                      &fetch_object,
+                      true,
+                      sending_time,
+                    )
+                    .await;
+                }
+              }
+
+              object_count += 1;
+            }
+            group_id += 1;
+          } else {
+            // === CACHE MISS ===
+            // Scan ahead to find contiguous gap [gap_start .. gap_end]
+            let gap_start: u64 = group_id;
+            let mut gap_end = group_id;
+            while gap_end < end_location.group
+              && track_read.cache.get_group(gap_end + 1).await.is_none()
+            {
+              gap_end += 1;
+            }
+
+            let max_upstream_fetch_gaps = context.server_config.max_upstream_fetch_gaps;
+            if upstream_gap_count >= max_upstream_fetch_gaps {
+              warn!(
+                "handle_fetch_delivery | Reached max upstream fetch gap limit ({}), skipping gap at group {}",
+                max_upstream_fetch_gaps, gap_start
+              );
+              group_id = gap_end + 1;
+              continue;
+            }
+            upstream_gap_count += 1;
+
+            // Issue upstream fetch for the gap
+            let upstream_rx = send_upstream_fetch_for_range(
+              &client,
+              &context,
+              &track_read,
+              &fetch,
+              gap_start,
+              gap_end,
+            )
+            .await;
+
+            if let Some(mut rx) = upstream_rx {
+              let timeout = context.server_config.upstream_fetch_timeout;
+              loop {
+                match tokio::time::timeout(timeout, rx.recv()).await {
+                  Ok(Some(UpstreamFetchEvent::Object(object))) => {
                     if object_count == 0 {
-                      info!("handle_fetch_messages | starting stream {:?}", &stream_id);
                       send_stream = match stream_fn(client.clone(), &stream_id).await {
                         Some(ss) => Some(ss),
                         None => {
-                          // Clean up cancel sender before returning
-                          client.fetch_cancel_senders.write().await.remove(&request_id);
+                          client
+                            .fetch_cancel_senders
+                            .write()
+                            .await
+                            .remove(&request_id);
                           return Err(TerminationCode::InternalError);
                         }
                       };
                     }
-                    let object_id = object.object_id;
+
                     let fetch_obj =
                       moqtail::model::data::fetch_object::FetchObject::Object(object.clone());
-                    let serialized = fetch_obj
-                      .serialize(fetch_prev_ctx.as_ref())
-                      .unwrap();
+                    let serialized = fetch_obj.serialize(fetch_prev_ctx.as_ref()).unwrap();
                     fetch_prev_ctx = fetch_obj.context();
-                    let is_sent = if let Err(e) = client
+
+                    if let Err(e) = client
                       .write_stream_object(
                         &stream_id,
-                        object_id,
+                        object.object_id,
                         serialized,
                         send_stream.as_ref().cloned(),
                       )
                       .await
                     {
                       error!(
-                        "handle_fetch_messages | Error writing object to stream: {:?}",
+                        "handle_fetch_messages | Error writing upstream object to stream: {:?}",
                         e
                       );
-                      false
-                    } else {
-                      true
-                    };
-
-                    if !is_sent {
-                      // Clean up cancel sender before returning
-                      client.fetch_cancel_senders.write().await.remove(&request_id);
+                      client
+                        .fetch_cancel_senders
+                        .write()
+                        .await
+                        .remove(&request_id);
                       return Err(TerminationCode::InternalError);
                     }
 
-                    // Log fetch stream object if enabled
                     if context.server_config.enable_object_logging {
                       let sending_time = crate::server::utils::passed_time_since_start();
-                      let subgroup_id = match object.forwarding_preference {
-                        moqtail::model::data::constant::ObjectForwardingPreference::Subgroup => {
-                          Some(object.subgroup_id)
-                        }
-                        moqtail::model::data::constant::ObjectForwardingPreference::Datagram => {
-                          None
-                        }
-                      };
-                      let fetch_object = moqtail::model::data::object::Object {
-                        track_alias: track_read.relay_track_id,
-                        location: moqtail::model::common::location::Location::new(
-                          object.group_id,
-                          object.object_id,
-                        ),
-                        publisher_priority: object.publisher_priority,
-                        forwarding_preference: object.forwarding_preference.clone(),
-                        subgroup_id,
-                        status: moqtail::model::data::constant::ObjectStatus::Normal,
-                        extensions: object.extension_headers.clone(),
-                        payload: if object.payload.is_empty() {
-                          None
-                        } else {
-                          Some(object.payload.clone())
-                        },
-                      };
-                      track_read
-                        .object_logger
-                        .log_fetch_object(
-                          track_read.relay_track_id,
-                          context.connection_id,
-                          request_id,
-                          &fetch_object,
-                          is_sent,
-                          sending_time,
-                        )
-                        .await;
+                      if let Ok(fetch_object) = moqtail::model::data::object::Object::try_from_fetch(
+                        object.clone(),
+                        track_read.relay_track_id,
+                      ) {
+                        track_read
+                          .object_logger
+                          .log_fetch_object(
+                            track_read.relay_track_id,
+                            context.connection_id,
+                            request_id,
+                            &fetch_object,
+                            true,
+                            sending_time,
+                          )
+                          .await;
+                      }
                     }
-                    info!(
-                      "handle_fetch_messages | Wrote object to stream: {} object_id: {}",
-                      &stream_id, object_id
-                    );
+
                     object_count += 1;
                   }
-                },
-                None => {
-                  warn!("handle_fetch_messages | No object.");
-                  break;
+                  Ok(Some(UpstreamFetchEvent::StreamClosed)) => {
+                    break;
+                  }
+                  Ok(Some(UpstreamFetchEvent::Error(e))) => {
+                    warn!(
+                      "handle_fetch_messages | Upstream fetch error for gap [{}, {}]: {}",
+                      gap_start, gap_end, e
+                    );
+                    break;
+                  }
+                  Ok(None) => {
+                    break;
+                  }
+                  Err(_) => {
+                    warn!(
+                      "handle_fetch_messages | Upstream fetch timed out for gap [{}, {}]",
+                      gap_start, gap_end
+                    );
+                    context
+                      .upstream_fetch_senders
+                      .write()
+                      .await
+                      .remove(&gap_start);
+                    break;
+                  }
                 }
               }
             }
-            _ = cancel_rx.changed() => {
-              info!("handle_fetch_messages | Fetch cancelled for request_id: {}", request_id);
-              cancelled = true;
-              break;
-            }
+
+            group_id = gap_end + 1;
           }
         }
 
@@ -403,7 +481,7 @@ pub async fn handle(
           );
 
           // 1. Send FETCH_OK
-          let end_loc = start_location.clone().unwrap_or(Location::new(0, 0));
+          let end_loc = start_location.clone();
           let fetch_ok = FetchOk::new(request_id, false, end_loc, vec![], vec![]);
 
           client
@@ -438,7 +516,11 @@ pub async fn handle(
 
         // Clean up the unified map since the fetch is done
         client.inbound_requests.write().await.remove(&request_id);
-        client.fetch_requests.write().await.remove(&request_id);
+        client
+          .incoming_fetch_requests
+          .write()
+          .await
+          .remove(&request_id);
 
         // Clean up cancel sender
         client
@@ -464,7 +546,11 @@ pub async fn handle(
       // Remove the fetch request from the client maps
       {
         client.inbound_requests.write().await.remove(&request_id);
-        client.fetch_requests.write().await.remove(&request_id);
+        client
+          .incoming_fetch_requests
+          .write()
+          .await
+          .remove(&request_id);
         debug!(
           "Removed FETCH request {} from client maps after Cancel",
           request_id
@@ -564,20 +650,33 @@ async fn send_upstream_fetch_for_range(
     original_fetch.parameters.clone(),
   );
 
-  let (upstream_tx, upstream_rx) = mpsc::channel(64);
+  let (upstream_tx, upstream_rx) = mpsc::channel(UPSTREAM_FETCH_CHANNEL_CAPACITY);
 
   {
-    let pending = PendingRequest::Fetch(FetchRequest {
+    // Use the publisher's track alias so handle_uni_stream can resolve the track on the response.
+    let publisher_alias = track_read
+      .publisher_aliases
+      .read()
+      .await
+      .get(&publisher.connection_id)
+      .copied()
+      .unwrap_or(0);
+    let req = FetchRequest {
       original_request_id: relay_request_id,
       requested_by: client.connection_id,
       fetch_request: upstream_fetch.clone(),
-      track_alias: track_read.relay_track_id,
-    });
+      track_alias: publisher_alias,
+    };
+    publisher
+      .outgoing_fetch_requests
+      .write()
+      .await
+      .insert(relay_request_id, req.clone());
     context
       .relay_pending_requests
       .write()
       .await
-      .insert(relay_request_id, pending);
+      .insert(relay_request_id, PendingRequest::Fetch(req));
     context
       .upstream_fetch_senders
       .write()
@@ -608,5 +707,9 @@ async fn send_request_error(
     .await;
   // Remove the request from the client maps on error
   client.inbound_requests.write().await.remove(&request_id);
-  client.fetch_requests.write().await.remove(&request_id);
+  client
+    .incoming_fetch_requests
+    .write()
+    .await
+    .remove(&request_id);
 }

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -666,13 +666,22 @@ async fn send_upstream_fetch_for_range(
 
   {
     // Use the publisher's track alias so handle_uni_stream can resolve the track on the response.
-    let publisher_alias = track_read
+    let publisher_alias = match track_read
       .publisher_aliases
       .read()
       .await
       .get(&publisher.connection_id)
       .copied()
-      .unwrap_or(0);
+    {
+      Some(alias) => alias,
+      None => {
+        warn!(
+          "send_upstream_fetch_for_range | No publisher alias found for connection {}",
+          publisher.connection_id
+        );
+        return None;
+      }
+    };
     let req = FetchRequest {
       original_request_id: relay_request_id,
       requested_by: client.connection_id,

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -199,7 +199,7 @@ pub async fn handle(
       }
 
       // Register a cancel channel for this fetch request
-      let (cancel_tx, cancel_rx) = watch::channel(false);
+      let (cancel_tx, mut cancel_rx) = watch::channel(false);
       {
         let mut senders = client.fetch_cancel_senders.write().await;
         senders.insert(request_id, cancel_tx);
@@ -360,12 +360,42 @@ pub async fn handle(
             if let Some((relay_request_id, mut rx)) = upstream_rx {
               let timeout = context.server_config.upstream_fetch_timeout;
               loop {
-                match tokio::time::timeout(timeout, rx.recv()).await {
-                  Ok(Some(UpstreamFetchEvent::Object(object))) => {
-                    if object_count == 0 {
-                      send_stream = match stream_fn(client.clone(), &stream_id).await {
-                        Some(ss) => Some(ss),
-                        None => {
+                tokio::select! {
+                  result = tokio::time::timeout(timeout, rx.recv()) => {
+                    match result {
+                      Ok(Some(UpstreamFetchEvent::Object(object))) => {
+                        if object_count == 0 {
+                          send_stream = match stream_fn(client.clone(), &stream_id).await {
+                            Some(ss) => Some(ss),
+                            None => {
+                              client
+                                .fetch_cancel_senders
+                                .write()
+                                .await
+                                .remove(&request_id);
+                              return Err(TerminationCode::InternalError);
+                            }
+                          };
+                        }
+
+                        let fetch_obj =
+                          moqtail::model::data::fetch_object::FetchObject::Object(object.clone());
+                        let serialized = fetch_obj.serialize(fetch_prev_ctx.as_ref()).unwrap();
+                        fetch_prev_ctx = fetch_obj.context();
+
+                        if let Err(e) = client
+                          .write_stream_object(
+                            &stream_id,
+                            object.object_id,
+                            serialized,
+                            send_stream.as_ref().cloned(),
+                          )
+                          .await
+                        {
+                          error!(
+                            "handle_fetch_messages | Error writing upstream object to stream: {:?}",
+                            e
+                          );
                           client
                             .fetch_cancel_senders
                             .write()
@@ -373,80 +403,62 @@ pub async fn handle(
                             .remove(&request_id);
                           return Err(TerminationCode::InternalError);
                         }
-                      };
-                    }
 
-                    let fetch_obj =
-                      moqtail::model::data::fetch_object::FetchObject::Object(object.clone());
-                    let serialized = fetch_obj.serialize(fetch_prev_ctx.as_ref()).unwrap();
-                    fetch_prev_ctx = fetch_obj.context();
-
-                    if let Err(e) = client
-                      .write_stream_object(
-                        &stream_id,
-                        object.object_id,
-                        serialized,
-                        send_stream.as_ref().cloned(),
-                      )
-                      .await
-                    {
-                      error!(
-                        "handle_fetch_messages | Error writing upstream object to stream: {:?}",
-                        e
-                      );
-                      client
-                        .fetch_cancel_senders
-                        .write()
-                        .await
-                        .remove(&request_id);
-                      return Err(TerminationCode::InternalError);
-                    }
-
-                    if context.server_config.enable_object_logging {
-                      let sending_time = crate::server::utils::passed_time_since_start();
-                      if let Ok(fetch_object) = moqtail::model::data::object::Object::try_from_fetch(
-                        object.clone(),
-                        track_read.relay_track_id,
-                      ) {
-                        track_read
-                          .object_logger
-                          .log_fetch_object(
+                        if context.server_config.enable_object_logging {
+                          let sending_time = crate::server::utils::passed_time_since_start();
+                          if let Ok(fetch_object) = moqtail::model::data::object::Object::try_from_fetch(
+                            object.clone(),
                             track_read.relay_track_id,
-                            context.connection_id,
-                            request_id,
-                            &fetch_object,
-                            true,
-                            sending_time,
-                          )
-                          .await;
+                          ) {
+                            track_read
+                              .object_logger
+                              .log_fetch_object(
+                                track_read.relay_track_id,
+                                context.connection_id,
+                                request_id,
+                                &fetch_object,
+                                true,
+                                sending_time,
+                              )
+                              .await;
+                          }
+                        }
+
+                        object_count += 1;
+                      }
+                      Ok(Some(UpstreamFetchEvent::StreamClosed)) => {
+                        break;
+                      }
+                      Ok(Some(UpstreamFetchEvent::Error(e))) => {
+                        warn!(
+                          "handle_fetch_messages | Upstream fetch error for gap [{}, {}]: {}",
+                          gap_start, gap_end, e
+                        );
+                        break;
+                      }
+                      Ok(None) => {
+                        break;
+                      }
+                      Err(_) => {
+                        warn!(
+                          "handle_fetch_messages | Upstream fetch timed out for gap [{}, {}]",
+                          gap_start, gap_end
+                        );
+                        context
+                          .upstream_fetch_senders
+                          .write()
+                          .await
+                          .remove(&relay_request_id);
+                        break;
                       }
                     }
-
-                    object_count += 1;
                   }
-                  Ok(Some(UpstreamFetchEvent::StreamClosed)) => {
-                    break;
-                  }
-                  Ok(Some(UpstreamFetchEvent::Error(e))) => {
-                    warn!(
-                      "handle_fetch_messages | Upstream fetch error for gap [{}, {}]: {}",
-                      gap_start, gap_end, e
+                  _ = cancel_rx.changed() => {
+                    info!(
+                      "handle_fetch_messages | Fetch cancelled during upstream fetch for request_id: {}",
+                      request_id
                     );
-                    break;
-                  }
-                  Ok(None) => {
-                    break;
-                  }
-                  Err(_) => {
-                    warn!(
-                      "handle_fetch_messages | Upstream fetch timed out for gap [{}, {}]",
-                      gap_start, gap_end
-                    );
-                    context
-                      .upstream_fetch_senders
-                      .write()
-                      .await
-                      .remove(&relay_request_id);
+                    cancelled = true;
                     break;
                   }
                 }

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -357,7 +357,7 @@ pub async fn handle(
             )
             .await;
 
-            if let Some((relay_request_id, mut rx)) = upstream_rx {
+            if let Some((relay_request_id, upstream_publisher, mut rx)) = upstream_rx {
               let timeout = context.server_config.upstream_fetch_timeout;
               loop {
                 tokio::select! {
@@ -444,11 +444,6 @@ pub async fn handle(
                           "handle_fetch_messages | Upstream fetch timed out for gap [{}, {}]",
                           gap_start, gap_end
                         );
-                        context
-                          .upstream_fetch_senders
-                          .write()
-                          .await
-                          .remove(&relay_request_id);
                         break;
                       }
                     }
@@ -463,6 +458,23 @@ pub async fn handle(
                   }
                 }
               }
+
+              // Clean up upstream fetch state
+              context
+                .upstream_fetch_senders
+                .write()
+                .await
+                .remove(&relay_request_id);
+              context
+                .relay_pending_requests
+                .write()
+                .await
+                .remove(&relay_request_id);
+              upstream_publisher
+                .outgoing_fetch_requests
+                .write()
+                .await
+                .remove(&relay_request_id);
             }
 
             group_id = gap_end + 1;
@@ -611,7 +623,8 @@ pub async fn handle(
 }
 
 /// Send an upstream Fetch to the publisher for a cache gap [gap_start, gap_end].
-/// Returns the relay request ID and an mpsc::Receiver through which upstream objects will be forwarded.
+/// Returns the relay request ID, the publisher client, and an mpsc::Receiver through which
+/// upstream objects will be forwarded.
 #[allow(dead_code)]
 async fn send_upstream_fetch_for_range(
   client: &Arc<MOQTClient>,
@@ -620,7 +633,7 @@ async fn send_upstream_fetch_for_range(
   original_fetch: &Fetch,
   gap_start: u64,
   gap_end: u64,
-) -> Option<(u64, mpsc::Receiver<UpstreamFetchEvent>)> {
+) -> Option<(u64, Arc<MOQTClient>, mpsc::Receiver<UpstreamFetchEvent>)> {
   let publisher = {
     let m = context.client_manager.read().await;
     match m
@@ -709,7 +722,7 @@ async fn send_upstream_fetch_for_range(
     .queue_message(ControlMessage::Fetch(Box::new(upstream_fetch)))
     .await;
 
-  Some((relay_request_id, upstream_rx))
+  Some((relay_request_id, publisher, upstream_rx))
 }
 
 async fn send_request_error(

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -357,7 +357,7 @@ pub async fn handle(
             )
             .await;
 
-            if let Some(mut rx) = upstream_rx {
+            if let Some((relay_request_id, mut rx)) = upstream_rx {
               let timeout = context.server_config.upstream_fetch_timeout;
               loop {
                 match tokio::time::timeout(timeout, rx.recv()).await {
@@ -446,7 +446,7 @@ pub async fn handle(
                       .upstream_fetch_senders
                       .write()
                       .await
-                      .remove(&gap_start);
+                      .remove(&relay_request_id);
                     break;
                   }
                 }
@@ -599,7 +599,7 @@ pub async fn handle(
 }
 
 /// Send an upstream Fetch to the publisher for a cache gap [gap_start, gap_end].
-/// Returns an mpsc::Receiver through which upstream objects will be forwarded.
+/// Returns the relay request ID and an mpsc::Receiver through which upstream objects will be forwarded.
 #[allow(dead_code)]
 async fn send_upstream_fetch_for_range(
   client: &Arc<MOQTClient>,
@@ -608,7 +608,7 @@ async fn send_upstream_fetch_for_range(
   original_fetch: &Fetch,
   gap_start: u64,
   gap_end: u64,
-) -> Option<mpsc::Receiver<UpstreamFetchEvent>> {
+) -> Option<(u64, mpsc::Receiver<UpstreamFetchEvent>)> {
   let publisher = {
     let m = context.client_manager.read().await;
     match m
@@ -688,7 +688,7 @@ async fn send_upstream_fetch_for_range(
     .queue_message(ControlMessage::Fetch(Box::new(upstream_fetch)))
     .await;
 
-  Some(upstream_rx)
+  Some((relay_request_id, upstream_rx))
 }
 
 async fn send_request_error(

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -579,7 +579,7 @@ impl Session {
 
     debug!("client is {}", client.connection_id);
 
-    let mut stream_handler = &RecvDataStream::new(stream, client.fetch_requests.clone());
+    let mut stream_handler = &RecvDataStream::new(stream, client.outgoing_fetch_requests.clone());
 
     let mut first_object = true;
     let mut track_alias = 0u64;
@@ -623,7 +623,7 @@ impl Session {
                 debug!("received Fetch header: {:?}", header);
                 let fetch_request_id = header.request_id;
                 track_alias = client
-                  .fetch_requests
+                  .outgoing_fetch_requests
                   .read()
                   .await
                   .get(&fetch_request_id)

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -450,7 +450,7 @@ impl Subscription {
                         );
                         instance.handle_track_event(track_event).await;
                       }
-                      CacheConsumeEvent::EndLocation(_) => {}
+                      CacheConsumeEvent::EndLocation => {}
                     },
                     None => {
                       warn!("handle_fetch_messages | No object.");

--- a/apps/relay/src/server/track_cache.rs
+++ b/apps/relay/src/server/track_cache.rs
@@ -65,7 +65,7 @@ pub struct TrackCache {
 #[derive(Debug, Clone)]
 pub enum CacheConsumeEvent {
   Object(FetchObjectPayload),
-  EndLocation(Location),
+  EndLocation,
   NoObject,
 }
 
@@ -262,7 +262,7 @@ impl TrackCache {
           groups_in_range.len(),
           &end_location
         );
-        if let Err(err) = tx.send(CacheConsumeEvent::EndLocation(end_location)).await {
+        if let Err(err) = tx.send(CacheConsumeEvent::EndLocation).await {
           warn!("read_objects | An error occurred: {:?}", err);
           return;
         }


### PR DESCRIPTION
### Summary of changes made

- Upstream fetch on cache miss: The relay now iterates group-by-group and sends a FETCH upstream to the publisher for any groups missing from the local cache, rather than serving only from the cache.
- Split fetch_requests into incoming and outgoing: Separated the single fetch_requests map into incoming_fetch_requests (fetches the client sent to the relay) and outgoing_fetch_requests (fetches the relay sent to the client) to distinguish the two directions.
- Use publisher's track alias: Upstream fetch requests now use the publisher's own track alias instead of the relay's internal track ID, so the response stream can be resolved correctly.

### Testing

In order to do testing, I made some local modifications to the client so that the publish-namespace mode now responds to incoming FETCH messages by sending the requested objects back to the relay.

Terminal 1:
  cargo run -p relay -- --cache-size 3

Terminal 2:
  cargo run --bin client -- -c publish-namespace --no-cert-validation --group-count 10 --objects-per-group 5

Terminal 3:
  cargo run --bin client -- -c subscribe --no-cert-validation --duration 15

Terminal 4:
  cargo run --bin client -- -c fetch --no-cert-validation --start-group 0 --end-group 10

There were logs on the relay side that I had added to confirm that cache hits and cache misses were being handled properly.
