### PR TITLE
refactor: remove track forwarding preference

### DIFF
--- a/apps/client/src/cli.rs
+++ b/apps/client/src/cli.rs
@@ -33,10 +33,10 @@ impl From<CliGroupOrder> for GroupOrder {
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum ForwardingPreference {
-  /// Send objects via unidirectional streams with subgroup headers
+pub enum DeliveryMode {
+  /// Send/receive objects via unidirectional streams with subgroup headers
   Subgroup,
-  /// Send objects via QUIC datagrams
+  /// Send/receive objects via QUIC datagrams
   Datagram,
 }
 
@@ -80,9 +80,9 @@ pub struct Cli {
   #[arg(long, default_value_t = false)]
   pub no_cert_validation: bool,
 
-  /// Forwarding preference (subgroup, datagram)
+  /// Delivery mode: how objects are sent/received (subgroup streams or QUIC datagrams)
   #[arg(long, value_enum, default_value = "subgroup")]
-  pub forwarding_preference: ForwardingPreference,
+  pub delivery_mode: DeliveryMode,
 
   /// Number of groups to send (publish only)
   #[arg(long, default_value_t = 100)]

--- a/apps/client/src/main.rs
+++ b/apps/client/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), anyhow::Error> {
       let config = publisher::PublishConfig {
         namespace: cli.namespace,
         track_name: cli.track_name,
-        forwarding_preference: cli.forwarding_preference,
+        delivery_mode: cli.delivery_mode,
         group_count: cli.group_count,
         interval: cli.interval,
         objects_per_group: cli.objects_per_group,
@@ -61,7 +61,7 @@ async fn main() -> Result<(), anyhow::Error> {
     Command::PublishNamespace => {
       let config = publisher::PublishNamespaceConfig {
         namespace: cli.namespace,
-        forwarding_preference: cli.forwarding_preference,
+        delivery_mode: cli.delivery_mode,
         group_count: cli.group_count,
         interval: cli.interval,
         objects_per_group: cli.objects_per_group,
@@ -74,7 +74,7 @@ async fn main() -> Result<(), anyhow::Error> {
       let config = subscriber::SubscribeConfig {
         namespace: cli.namespace,
         track_name: cli.track_name,
-        forwarding_preference: cli.forwarding_preference,
+        delivery_mode: cli.delivery_mode,
         duration: cli.duration,
         subscriber_priority: cli.subscriber_priority,
         group_order: cli.group_order.into(),

--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cli::ForwardingPreference;
+use crate::cli::DeliveryMode;
 use crate::connection::MoqConnection;
 use crate::utils::should_log;
 use anyhow::Result;
@@ -39,7 +39,7 @@ use tracing::{debug, error, info};
 pub struct PublishConfig {
   pub namespace: String,
   pub track_name: String,
-  pub forwarding_preference: ForwardingPreference,
+  pub delivery_mode: DeliveryMode,
   pub group_count: u64,
   pub interval: u64,
   pub objects_per_group: u64,
@@ -51,7 +51,7 @@ pub struct PublishConfig {
 
 pub struct PublishNamespaceConfig {
   pub namespace: String,
-  pub forwarding_preference: ForwardingPreference,
+  pub delivery_mode: DeliveryMode,
   pub group_count: u64,
   pub interval: u64,
   pub objects_per_group: u64,
@@ -71,7 +71,7 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
   publish_namespace(&mut control_stream, &ns).await?;
 
   let data_config = DataConfig {
-    forwarding_preference: config.forwarding_preference,
+    delivery_mode: config.delivery_mode,
     group_count: config.group_count,
     interval: config.interval,
     objects_per_group: config.objects_per_group,
@@ -152,7 +152,7 @@ pub async fn run(moq: MoqConnection, config: PublishConfig) -> Result<()> {
   let ns = Tuple::from_utf8_path(&config.namespace);
 
   let data_config = DataConfig {
-    forwarding_preference: config.forwarding_preference,
+    delivery_mode: config.delivery_mode,
     group_count: config.group_count,
     interval: config.interval,
     objects_per_group: config.objects_per_group,
@@ -214,7 +214,7 @@ async fn publish_namespace(
 
 #[derive(Clone)]
 struct DataConfig {
-  forwarding_preference: ForwardingPreference,
+  delivery_mode: DeliveryMode,
   group_count: u64,
   interval: u64,
   objects_per_group: u64,
@@ -264,8 +264,8 @@ async fn send_data(
   track_alias: u64,
   config: &DataConfig,
 ) -> Result<()> {
-  match config.forwarding_preference {
-    ForwardingPreference::Datagram => {
+  match config.delivery_mode {
+    DeliveryMode::Datagram => {
       send_datagrams(
         connection,
         track_alias,
@@ -277,7 +277,7 @@ async fn send_data(
       )
       .await
     }
-    ForwardingPreference::Subgroup => {
+    DeliveryMode::Subgroup => {
       send_via_streams(
         connection,
         track_alias,

--- a/apps/client/src/subscriber.rs
+++ b/apps/client/src/subscriber.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cli::ForwardingPreference;
+use crate::cli::DeliveryMode;
 use crate::connection::MoqConnection;
 use crate::stats::ReceptionStats;
 use crate::utils::should_log;
@@ -73,7 +73,7 @@ async fn subscribe_track(
 pub struct SubscribeConfig {
   pub namespace: String,
   pub track_name: String,
-  pub forwarding_preference: ForwardingPreference,
+  pub delivery_mode: DeliveryMode,
   pub duration: u64,
   pub subscriber_priority: u8,
   pub group_order: GroupOrder,
@@ -111,11 +111,9 @@ pub async fn run(moq: MoqConnection, config: SubscribeConfig) -> Result<()> {
     None
   };
 
-  match config.forwarding_preference {
-    ForwardingPreference::Datagram => {
-      receive_datagrams(&connection, track_alias, config.duration).await
-    }
-    ForwardingPreference::Subgroup => {
+  match config.delivery_mode {
+    DeliveryMode::Datagram => receive_datagrams(&connection, track_alias, config.duration).await,
+    DeliveryMode::Subgroup => {
       receive_streams(&connection, track_alias, extra_alias, config.duration).await
     }
   }

--- a/apps/meet/src/composables/useVideoPipeline.ts
+++ b/apps/meet/src/composables/useVideoPipeline.ts
@@ -68,14 +68,14 @@ export function setupTracks(
   const audioContentSource = new LiveTrackSource(audioStream);
   moqClient.addOrUpdateTrack({
     fullTrackName: audioFullTrackName,
-    forwardingPreference: ObjectForwardingPreference.Subgroup,
+
     trackSource: { live: audioContentSource },
     publisherPriority: 128,
   });
   const videoContentSource = new LiveTrackSource(videoStream);
   moqClient.addOrUpdateTrack({
     fullTrackName: videoFullTrackName,
-    forwardingPreference: ObjectForwardingPreference.Subgroup,
+
     trackSource: { live: videoContentSource },
     publisherPriority: 128,
   });

--- a/apps/meet/src/moq/signalling.ts
+++ b/apps/meet/src/moq/signalling.ts
@@ -70,7 +70,6 @@ export async function setupSignalling(
   const textSource = new LiveTrackSource(signalStream);
   moqClient.addOrUpdateTrack({
     fullTrackName: signalFTN,
-    forwardingPreference: ObjectForwardingPreference.Subgroup,
     trackSource: { live: textSource },
     publisherPriority: 1,
     trackAlias: 1000n, // need to use the same track alias

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -18,7 +18,7 @@ use moqtail::model::{
   control::{
     constant::SUPPORTED_VERSIONS, control_message::ControlMessage, server_setup::ServerSetup,
   },
-  data::{constant::ObjectForwardingPreference, datagram::Datagram},
+  data::datagram::Datagram,
   error::TerminationCode,
 };
 use moqtail::transport::{
@@ -345,10 +345,6 @@ impl Session {
 
                 if let Some(track) = context_clone.track_manager.get_track_by_alias(context_clone.connection_id, datagram_obj.track_alias).await {
                   let track = track.read().await;
-                  // Set forwarding preference to Datagram
-                  track.set_forwarding_preference(ObjectForwardingPreference::Datagram).await;
-
-                  // Call new_datagram
                   if let Err(e) = track.new_datagram(&datagram_obj).await {
                     error!("Failed to process datagram: {:?}", e);
                   }

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -24,7 +24,6 @@ use anyhow::Result;
 use moqtail::model::common::location::Location;
 use moqtail::model::common::reason_phrase::ReasonPhrase;
 use moqtail::model::control::constant::RequestErrorCode;
-use moqtail::model::data::constant::ObjectForwardingPreference;
 use moqtail::model::data::datagram::Datagram;
 use moqtail::model::data::full_track_name::FullTrackName;
 use moqtail::model::data::object::Object;
@@ -83,7 +82,6 @@ pub struct Track {
   pub largest_location: Arc<RwLock<Location>>,
   pub object_logger: ObjectLogger,
   config: &'static AppConfig,
-  pub forwarding_preference: Arc<RwLock<ObjectForwardingPreference>>,
   pub status: Arc<RwLock<TrackStatus>>,
   pub status_notify: Arc<Notify>,
   /// Subscribers waiting for track confirmation: (request_id, connection_id).
@@ -115,7 +113,6 @@ impl Track {
       largest_location: Arc::new(RwLock::new(Location::new(0, 0))),
       object_logger: ObjectLogger::new(config.log_folder.clone()),
       config,
-      forwarding_preference: Arc::new(RwLock::new(ObjectForwardingPreference::Subgroup)),
       status: Arc::new(RwLock::new(initial_status)),
       status_notify: Arc::new(Notify::new()),
       pending_subscribers: Arc::new(RwLock::new(Vec::new())),
@@ -208,10 +205,6 @@ impl Track {
 
   pub async fn get_status(&self) -> TrackStatus {
     self.status.read().await.clone()
-  }
-
-  pub async fn set_forwarding_preference(&self, preference: ObjectForwardingPreference) {
-    *self.forwarding_preference.write().await = preference;
   }
 
   pub async fn add_subscription(

--- a/libs/moqtail-rs/src/model/data/track.rs
+++ b/libs/moqtail-rs/src/model/data/track.rs
@@ -14,11 +14,10 @@
 
 use std::collections::BTreeMap;
 
-use super::{constant::ObjectForwardingPreference, full_track_name::FullTrackName, group::Group};
+use super::{full_track_name::FullTrackName, group::Group};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Track {
   pub full_track_name: FullTrackName,
   pub groups: BTreeMap<u64, Group>,
-  pub forwarding_preference: ObjectForwardingPreference,
 }

--- a/libs/moqtail-ts/src/client/client.ts
+++ b/libs/moqtail-ts/src/client/client.ts
@@ -838,7 +838,6 @@ export class MOQtailClient {
    * // Register the track for live subscription
    * client.addOrUpdateTrack({
    *   fullTrackName: { namespace: ["camera"], name: "main" },
-   *   forwardingPreference: ObjectForwardingPreference.Latest,
    *   trackSource: { live: liveReadableStream },
    *   publisherPriority: 0 // highest priority
    * });
@@ -848,7 +847,6 @@ export class MOQtailClient {
    * const cache = new MemoryObjectCache(); // Caches are not yet fully supported
    * client.addOrUpdateTrack({
    *   fullTrackName: { namespace: ["camera"], name: "main" },
-   *   forwardingPreference: ObjectForwardingPreference.Latest,
    *   trackSource: { live: liveReadableStream, past: cache },
    *   publisherPriority: 8
    * });

--- a/libs/moqtail-ts/src/client/track/track.ts
+++ b/libs/moqtail-ts/src/client/track/track.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FullTrackName, ObjectForwardingPreference } from '@/model'
+import { FullTrackName } from '@/model'
 import { TrackSource } from './content_source'
 import { TrackExtension } from '../../model/extension_header/track_extension'
 
@@ -27,7 +27,6 @@ import { TrackExtension } from '../../model/extension_header/track_extension'
  * const liveStream: ReadableStream<MoqtObject> = buildCameraStream()
  * const track: Track = {
  *   fullTrackName,
- *   forwardingPreference: ObjectForwardingPreference.Latest,
  *   trackSource: { live: liveStream },
  *   publisherPriority: 0
  * }
@@ -40,7 +39,6 @@ import { TrackExtension } from '../../model/extension_header/track_extension'
  * recording.forEach(obj => cache.add(obj))
  * const track: Track = {
  *   fullTrackName,
- *   forwardingPreference: ObjectForwardingPreference.All,
  *   trackSource: { past: cache },
  *   publisherPriority: 64
  * }
@@ -53,7 +51,6 @@ import { TrackExtension } from '../../model/extension_header/track_extension'
  * const liveStream = buildLiveReadableStream()
  * const track: Track = {
  *   fullTrackName,
- *   forwardingPreference: ObjectForwardingPreference.Latest,
  *   trackSource: { past: cache, live: liveStream },
  *   publisherPriority: 8
  * }
@@ -65,11 +62,6 @@ export type Track = {
    * Globally unique identifier for the track.
    */
   fullTrackName: FullTrackName
-
-  /**
-   * Hint controlling which objects SHOULD be forwarded / prioritized.
-   */
-  forwardingPreference: ObjectForwardingPreference
 
   /**
    * Accessors for live and/or past objects belonging to this track.


### PR DESCRIPTION
In Draft-16, track forwarding preference was removed. It is carried in the object header. This PR removes the dead code related to track forwarding preference  and renames the client arguments.