### PR TITLE
Fix joining fetch

### DIFF
--- a/.changeset/fix-joining-fetch-range.md
+++ b/.changeset/fix-joining-fetch-range.md
@@ -1,0 +1,8 @@
+---
+'relay': patch
+---
+
+Fix Joining Fetch range calculation per draft §9.16.2.
+
+- **End location**: The relay now correctly sets End Location to `{LargestObject.Group, LargestObject.Object + 1}` (exclusive), so a Joining Fetch with `joining_start = 0` delivers all objects from the I-frame through the current LargestObject — previously the end was `{LargestObject.Group, 0}`, making the range empty for `joining_start = 0` and omitting the current partial group for any other value.
+- **LargestObject in SubscribeOk**: When a subscriber arrives for an already-confirmed track, the relay now injects the track's current `LargestObject` position as a `MessageParameter::LargestObject` in the SubscribeOk, allowing the subscriber to decide whether to issue a Joining Fetch.

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -130,7 +130,7 @@ pub async fn handle(
             };
 
             let start_location = Location::new(start_group, 0);
-            let end_location = Location::new(largest_location.group, 0);
+            let end_location = Location::new(largest_location.group, largest_location.object + 1);
             (
               Some(track_lock.clone()),
               Some(start_location),

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -18,6 +18,7 @@ use crate::server::session::Session;
 use crate::server::session_context::{PendingRequest, SessionContext};
 use crate::server::track::{Track, TrackStatus};
 use core::result::Result;
+use moqtail::model::common::location::Location;
 use moqtail::model::control::constant::RequestErrorCode;
 use moqtail::model::control::request_error::RequestError;
 use moqtail::model::control::subscribe::Subscribe;
@@ -209,10 +210,16 @@ async fn handle_subscribe_message(
           client.connection_id
         );
         let cached_extensions = { track.track_extensions.read().await.clone() };
+        let largest_loc = {
+          let ll = track.largest_location.read().await;
+          Location::new(ll.group, ll.object)
+        };
+        let mut params = subscribe_parameters;
+        params.push(MessageParameter::new_largest_object(largest_loc));
         let subscribe_ok = moqtail::model::control::subscribe_ok::SubscribeOk::new(
           sub.request_id,
           track.relay_track_id,
-          subscribe_parameters,
+          params,
           cached_extensions,
         );
         control_stream_handler.send_impl(&subscribe_ok).await


### PR DESCRIPTION
1.  Per draft §9.16.2.1, End Location = {Subscribe Largest Location.Object + 1}. Previous code used {largest_location.group, 0} which made the fetch range empty when joining_start = 0 (start == end), and missed the current partial group for any joining_start value.
2. When a subscriber arrives for an already-confirmed track, inject the track's current largest_location as MessageParameter::LargestObject into the SubscribeOk. This lets the subscriber know B's current position so it can decide whether to issue a Joining Fetch.

