### PR TITLE
fix(relay): send FETCH_OK for all non-empty fetch ranges

### DIFF
--- a/.changeset/fix-relay-fetch-ok-missing.md
+++ b/.changeset/fix-relay-fetch-ok-missing.md
@@ -1,0 +1,5 @@
+---
+'relay': patch
+---
+
+Fix relay not sending FETCH_OK for non-empty fetch ranges. The relay previously only sent FETCH_OK when the requested range was empty; for any fetch that returned objects the control-stream response was omitted, causing subscribers to block indefinitely waiting for it.

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -198,6 +198,20 @@ pub async fn handle(
         }
       }
 
+      // Send FetchOk immediately on the control stream before delivering objects.
+      {
+        let fetch_ok = FetchOk::new(
+          request_id,
+          false,
+          end_location.clone().unwrap(),
+          vec![],
+          vec![],
+        );
+        client
+          .queue_message(ControlMessage::FetchOk(Box::new(fetch_ok)))
+          .await;
+      }
+
       // Register a cancel channel for this fetch request
       let (cancel_tx, mut cancel_rx) = watch::channel(false);
       {


### PR DESCRIPTION
The relay only sent FETCH_OK when the requested range was empty. For fetches that returned objects, the control-stream response was never sent, causing subscribers to block indefinitely.

