### PR TITLE
fix(relay): deliver mid-subgroup objects to late subscribers

### DIFF
--- a/.changeset/relay-mid-subgroup-join.md
+++ b/.changeset/relay-mid-subgroup-join.md
@@ -1,0 +1,5 @@
+---
+'relay': patch
+---
+
+Fix silent object drops for subscribers joining a track mid-subgroup. New subscribers had no open QUIC send stream for an in-progress subgroup, so objects with no header info were silently discarded. The relay now caches the original subgroup header when the first object of each subgroup arrives and uses it to open a send stream for late joiners. The cache entry is evicted when the publisher unistream closes.

--- a/.changeset/relay-subscription-pending-stream.md
+++ b/.changeset/relay-subscription-pending-stream.md
@@ -1,0 +1,5 @@
+---
+'relay': patch
+---
+
+When a subscription's `forward` parameter transitions from false to true via REQUEST_UPDATE mid-group, the relay now immediately opens a QUIC send stream for the subscriber using the subgroup header that arrived while forwarding was paused. Previously, if no new group boundary arrived after the toggle, the subscriber would miss the remainder of the current subgroup.

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -298,6 +298,13 @@ pub struct Subscription {
   object_logger: ObjectLogger,
   config: &'static AppConfig,
   check_switch_context_on_next_object: Arc<AtomicBool>,
+  /// Subgroup header cached while forward=false. Cleared when forward→true (stream opened)
+  /// or when a new group starts (old group ended without forward ever becoming true).
+  pending_header: Arc<Mutex<Option<(StreamId, HeaderInfo)>>>,
+  /// Shared map of open publisher subgroup streams → original subgroup header.
+  /// Used to open a QUIC send stream for a new mid-group subscriber with the exact
+  /// original header rather than a synthesized one.
+  active_headers: crate::server::track::ActiveHeaders,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -313,6 +320,7 @@ impl Subscription {
     client_connection_id: usize,
     log_folder: String,
     config: &'static AppConfig,
+    active_headers: crate::server::track::ActiveHeaders,
   ) -> Self {
     Self {
       relay_track_id,
@@ -328,6 +336,8 @@ impl Subscription {
       object_logger: ObjectLogger::new(log_folder),
       config,
       check_switch_context_on_next_object: Arc::new(AtomicBool::new(false)),
+      pending_header: Arc::new(Mutex::new(None)),
+      active_headers,
     }
   }
 
@@ -341,6 +351,7 @@ impl Subscription {
     client_connection_id: usize,
     log_folder: String,
     config: &'static AppConfig,
+    active_headers: crate::server::track::ActiveHeaders,
   ) -> Self {
     let event_rx = Arc::new(Mutex::new(Some(event_rx)));
     let sub = Self::create_instance(
@@ -354,6 +365,7 @@ impl Subscription {
       client_connection_id,
       log_folder,
       config,
+      active_headers,
     );
 
     info!(
@@ -508,59 +520,89 @@ impl Subscription {
   // Returns Ok if the update is successful
   // Returns error if the update is invalid
   pub async fn update_subscription(&self, request_update: RequestUpdate) -> Result<()> {
-    let mut state = self.subscription_state.write().await;
+    let forward_becoming_true = {
+      let mut state = self.subscription_state.write().await;
 
-    // Extract filter_type, start_location and end_group from SubscriptionFilter parameter
-    let (new_filter_type, new_start_location, new_end_group) = request_update
-      .parameters
-      .iter()
-      .find_map(|p| {
-        if let MessageParameter::SubscriptionFilter {
-          filter_type,
-          start_location,
-          end_group,
-        } = p
-        {
-          Some((Some(*filter_type), start_location.clone(), *end_group))
-        } else {
-          None
-        }
-      })
-      .unwrap_or((None, None, None));
+      // Extract filter_type, start_location and end_group from SubscriptionFilter parameter
+      let (new_filter_type, new_start_location, new_end_group) = request_update
+        .parameters
+        .iter()
+        .find_map(|p| {
+          if let MessageParameter::SubscriptionFilter {
+            filter_type,
+            start_location,
+            end_group,
+          } = p
+          {
+            Some((Some(*filter_type), start_location.clone(), *end_group))
+          } else {
+            None
+          }
+        })
+        .unwrap_or((None, None, None));
 
-    if let Some(ref new_loc) = new_start_location {
-      state.start_location = Some(new_loc.clone());
-    }
+      if let Some(ref new_loc) = new_start_location {
+        state.start_location = Some(new_loc.clone());
+      }
 
-    // Update explicit subscription state fields if they are present in the parameters
-    for param in &request_update.parameters {
-      match param {
-        MessageParameter::SubscriberPriority { priority } => {
-          state.subscriber_priority = *priority;
+      // Update explicit subscription state fields if they are present in the parameters.
+      // Track whether forward transitions false→true so we can flush pending_header below.
+      let mut transition = false;
+      for param in &request_update.parameters {
+        match param {
+          MessageParameter::SubscriberPriority { priority } => {
+            state.subscriber_priority = *priority;
+          }
+          MessageParameter::Forward { forward } => {
+            if *forward && !state.forward {
+              transition = true;
+            }
+            state.forward = *forward;
+          }
+          _ => {}
         }
-        MessageParameter::Forward { forward } => {
-          state.forward = *forward;
+      }
+
+      if let Some(ft) = new_filter_type {
+        state.filter_type = ft;
+      }
+      if let Some(eg) = new_end_group {
+        state.end_group = eg;
+      }
+
+      // Update parameters. If a parameter included in SUBSCRIBE is not present in
+      // REQUEST_UPDATE, its value remains unchanged. There is no mechanism
+      // to remove a parameter from a request.
+      apply_message_parameter_update(&mut state.subscribe_parameters, request_update.parameters);
+
+      info!(
+        "update_subscription | new subscription state for relay_track_id={}: {:?}",
+        self.relay_track_id, state
+      );
+
+      transition
+      // write lock on subscription_state is dropped here
+    };
+
+    // If forward just became true, open the stream for the current mid-group header
+    // that was cached while forward=false.
+    if forward_becoming_true {
+      let pending = self.pending_header.lock().await.take();
+      if let Some((pending_stream_id, pending_header_info)) = pending {
+        info!(
+          "update_subscription | forward became true, opening pending stream {} for subscriber={} relay_track_id={}",
+          pending_stream_id, self.client_connection_id, self.relay_track_id
+        );
+        if self.handle_header(pending_header_info).await.is_ok() {
+          self
+            .send_stream_last_object_ids
+            .write()
+            .await
+            .insert(pending_stream_id, None);
         }
-        _ => {}
       }
     }
 
-    if let Some(ft) = new_filter_type {
-      state.filter_type = ft;
-    }
-    if let Some(eg) = new_end_group {
-      state.end_group = eg;
-    }
-
-    // Update parameters. If a parameter included in SUBSCRIBE is not present in
-    // REQUEST_UPDATE, its value remains unchanged. There is no mechanism
-    // to remove a parameter from a request.
-    apply_message_parameter_update(&mut state.subscribe_parameters, request_update.parameters);
-
-    info!(
-      "update_subscription | new subscription state for relay_track_id={}: {:?}",
-      self.relay_track_id, state
-    );
     Ok(())
   }
 
@@ -878,12 +920,25 @@ impl Subscription {
           }
 
           if !state.forward {
+            // Cache the subgroup header so we can open the stream immediately
+            // if forward transitions to true mid-group (sub-update-forward method).
+            if let Some(ref header) = header_info {
+              let mut pending = self.pending_header.lock().await;
+              *pending = Some((stream_id.clone(), header.clone()));
+            }
             return;
           }
         }
 
+        // Entering forward=true: clear any stale pending header (group boundary case).
+        // If forward was already true, pending_header is None and this is a no-op.
+        {
+          let mut pending = self.pending_header.lock().await;
+          pending.take();
+        }
+
         // Handle header info if this is the first object
-        let mut send_stream = if let Some(header) = header_info {
+        let send_stream = if let Some(header) = header_info {
           if let HeaderInfo::Subgroup { header: _ } = header {
             info!(
               "Creating stream - subscriber={} relay_track_id={} now={} received time={} object: {:?} header: {:?}",
@@ -922,23 +977,28 @@ impl Subscription {
             None
           }
         } else {
-          self.subscriber.get_stream(&stream_id).await
+          match self.subscriber.get_stream(&stream_id).await {
+            Some(s) => Some(s),
+            None => {
+              // New subscriber joined mid-subgroup. Look up the original header
+              // from the track-level cache and open a QUIC send stream with it.
+              let cached = self.active_headers.read().await.get(&stream_id).cloned();
+              if let Some(h) = cached {
+                info!(
+                  "mid-subgroup join: opening stream from cached header for subscriber={} relay_track_id={} stream_id={}",
+                  self.client_connection_id, self.relay_track_id, stream_id
+                );
+                self
+                  .handle_header(h)
+                  .await
+                  .ok()
+                  .map(|(_, send_stream)| send_stream)
+              } else {
+                None
+              }
+            }
+          }
         };
-
-        if send_stream.is_none() {
-          // wait a little bit and try again
-          warn!(
-            "Send stream not found, retrying - subscriber={} stream_id={} relay_track_id={} now={} received time={} object: {:?}",
-            self.client_connection_id,
-            stream_id,
-            self.relay_track_id,
-            utils::passed_time_since_start(),
-            object_received_time,
-            object.location
-          );
-          tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-          send_stream = self.subscriber.get_stream(&stream_id).await;
-        }
 
         if let Some(send_stream) = send_stream {
           // Get the previous object ID for this stream

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -990,7 +990,7 @@ impl Subscription {
                 .get(&stream_id)
                 .cloned();
               if let Some(h) = cached {
-                info!(
+                debug!(
                   "mid-subgroup join: opening stream from cached header for subscriber={} relay_track_id={} stream_id={}",
                   self.client_connection_id, self.relay_track_id, stream_id
                 );

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -17,6 +17,7 @@ use crate::server::client::switch_context::SwitchStatus;
 use crate::server::config::AppConfig;
 use crate::server::object_logger::ObjectLogger;
 use crate::server::stream_id::StreamId;
+use crate::server::track::ActiveSubgroupHeaderMap;
 use crate::server::track::TrackEvent;
 use crate::server::track_cache::CacheConsumeEvent;
 use crate::server::track_cache::TrackCache;
@@ -298,13 +299,13 @@ pub struct Subscription {
   object_logger: ObjectLogger,
   config: &'static AppConfig,
   check_switch_context_on_next_object: Arc<AtomicBool>,
-  /// Subgroup header cached while forward=false. Cleared when forward→true (stream opened)
+  /// Subgroup header cached while forward=false. Cleared when forward becomes true (stream opened)
   /// or when a new group starts (old group ended without forward ever becoming true).
   pending_header: Arc<Mutex<Option<(StreamId, HeaderInfo)>>>,
-  /// Shared map of open publisher subgroup streams → original subgroup header.
+  /// Shared map of open publisher subgroup streams and their original subgroup header.
   /// Used to open a QUIC send stream for a new mid-group subscriber with the exact
   /// original header rather than a synthesized one.
-  active_headers: crate::server::track::ActiveHeaders,
+  active_subgroup_headers: ActiveSubgroupHeaderMap,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -320,7 +321,7 @@ impl Subscription {
     client_connection_id: usize,
     log_folder: String,
     config: &'static AppConfig,
-    active_headers: crate::server::track::ActiveHeaders,
+    active_subgroup_headers: ActiveSubgroupHeaderMap,
   ) -> Self {
     Self {
       relay_track_id,
@@ -337,7 +338,7 @@ impl Subscription {
       config,
       check_switch_context_on_next_object: Arc::new(AtomicBool::new(false)),
       pending_header: Arc::new(Mutex::new(None)),
-      active_headers,
+      active_subgroup_headers,
     }
   }
 
@@ -351,7 +352,7 @@ impl Subscription {
     client_connection_id: usize,
     log_folder: String,
     config: &'static AppConfig,
-    active_headers: crate::server::track::ActiveHeaders,
+    active_subgroup_headers: ActiveSubgroupHeaderMap,
   ) -> Self {
     let event_rx = Arc::new(Mutex::new(Some(event_rx)));
     let sub = Self::create_instance(
@@ -365,7 +366,7 @@ impl Subscription {
       client_connection_id,
       log_folder,
       config,
-      active_headers,
+      active_subgroup_headers,
     );
 
     info!(
@@ -546,7 +547,7 @@ impl Subscription {
       }
 
       // Update explicit subscription state fields if they are present in the parameters.
-      // Track whether forward transitions false→true so we can flush pending_header below.
+      // Track whether forward transitions false to true so we can flush pending_header below.
       let mut transition = false;
       for param in &request_update.parameters {
         match param {
@@ -982,7 +983,12 @@ impl Subscription {
             None => {
               // New subscriber joined mid-subgroup. Look up the original header
               // from the track-level cache and open a QUIC send stream with it.
-              let cached = self.active_headers.read().await.get(&stream_id).cloned();
+              let cached = self
+                .active_subgroup_headers
+                .read()
+                .await
+                .get(&stream_id)
+                .cloned();
               if let Some(h) = cached {
                 info!(
                   "mid-subgroup join: opening stream from cached header for subscriber={} relay_track_id={} stream_id={}",

--- a/apps/relay/src/server/subscription_manager.rs
+++ b/apps/relay/src/server/subscription_manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::server::subscription::SubscriptionOrigin;
+use crate::server::{subscription::SubscriptionOrigin, track::ActiveSubgroupHeaderMap};
 
 use super::client::MOQTClient;
 use super::config::AppConfig;
@@ -98,7 +98,7 @@ impl SubscriptionManager {
     subscriber: Arc<MOQTClient>,
     origin_message: SubscriptionOrigin,
     cache: super::track_cache::TrackCache,
-    active_headers: super::track::ActiveHeaders,
+    active_subgroup_headers: ActiveSubgroupHeaderMap,
   ) -> Result<Arc<RwLock<Subscription>>, anyhow::Error> {
     let connection_id = { subscriber.connection_id };
 
@@ -120,7 +120,7 @@ impl SubscriptionManager {
       connection_id,
       self.log_folder.clone(),
       self.config,
-      active_headers,
+      active_subgroup_headers,
     );
 
     let mut subscriptions = self.subscriptions.write().await;

--- a/apps/relay/src/server/subscription_manager.rs
+++ b/apps/relay/src/server/subscription_manager.rs
@@ -98,6 +98,7 @@ impl SubscriptionManager {
     subscriber: Arc<MOQTClient>,
     origin_message: SubscriptionOrigin,
     cache: super::track_cache::TrackCache,
+    active_headers: super::track::ActiveHeaders,
   ) -> Result<Arc<RwLock<Subscription>>, anyhow::Error> {
     let connection_id = { subscriber.connection_id };
 
@@ -119,6 +120,7 @@ impl SubscriptionManager {
       connection_id,
       self.log_folder.clone(),
       self.config,
+      active_headers,
     );
 
     let mut subscriptions = self.subscriptions.write().await;

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -30,10 +30,13 @@ use moqtail::model::data::object::Object;
 use moqtail::model::extension_header::track_extension::TrackExtension;
 use moqtail::model::parameter::message_parameter::MessageParameter;
 use moqtail::transport::data_stream_handler::HeaderInfo;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tokio::sync::{Notify, RwLock};
 use tracing::{debug, error, info, warn};
+
+/// Shared map of open publisher subgroup streams → original subgroup header.
+pub type ActiveHeaders = Arc<RwLock<HashMap<StreamId, HeaderInfo>>>;
 
 /// Lifecycle status of a track on the relay.
 #[derive(Debug, Clone)]
@@ -88,6 +91,12 @@ pub struct Track {
   pub pending_subscribers: Arc<RwLock<Vec<(u64, usize)>>>,
   /// Cached track extensions from PUBLISH or SUBSCRIBE_OK (relays MUST cache).
   pub track_extensions: Arc<RwLock<Vec<TrackExtension>>>,
+  /// Original subgroup headers for open publisher streams, keyed by stream_id.
+  /// Used so new mid-group subscribers can open a QUIC send stream with the
+  /// exact original header rather than a synthesized one.
+  /// Inserted when the first object of a subgroup arrives; removed when the
+  /// publisher's unistream closes (stream_closed signal).
+  pub active_headers: Arc<RwLock<HashMap<StreamId, HeaderInfo>>>,
 }
 
 // TODO: this track implementation should be static? At least
@@ -117,6 +126,7 @@ impl Track {
       status_notify: Arc::new(Notify::new()),
       pending_subscribers: Arc::new(RwLock::new(Vec::new())),
       track_extensions: Arc::new(RwLock::new(Vec::new())),
+      active_headers: Arc::new(RwLock::new(HashMap::new())),
     }
   }
 
@@ -241,7 +251,12 @@ impl Track {
 
     let subscription = self
       .subscription_manager
-      .add_subscription(subscriber, origin_enum, self.cache.clone())
+      .add_subscription(
+        subscriber,
+        origin_enum,
+        self.cache.clone(),
+        Arc::clone(&self.active_headers),
+      )
       .await?;
 
     if is_switch {
@@ -281,7 +296,7 @@ impl Track {
       utils::passed_time_since_start()
     );
 
-    if header_info.is_some() {
+    if let Some(h) = header_info {
       info!(
         "new group: relay_track_id={} location: {:?} stream_id={} time={}",
         self.relay_track_id,
@@ -289,6 +304,11 @@ impl Track {
         stream_id,
         utils::passed_time_since_start()
       );
+      self
+        .active_headers
+        .write()
+        .await
+        .insert(stream_id.clone(), h.clone());
     }
 
     // Send single Object event with optional header info
@@ -413,6 +433,8 @@ impl Track {
   }
 
   pub async fn stream_closed(&self, stream_id: &StreamId) -> Result<(), anyhow::Error> {
+    self.active_headers.write().await.remove(stream_id);
+
     let event = TrackEvent::StreamClosed {
       stream_id: stream_id.clone(),
     };

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -35,8 +35,7 @@ use std::sync::Arc;
 use tokio::sync::{Notify, RwLock};
 use tracing::{debug, error, info, warn};
 
-/// Shared map of open publisher subgroup streams → original subgroup header.
-pub type ActiveHeaders = Arc<RwLock<HashMap<StreamId, HeaderInfo>>>;
+pub type ActiveSubgroupHeaderMap = Arc<RwLock<HashMap<StreamId, HeaderInfo>>>;
 
 /// Lifecycle status of a track on the relay.
 #[derive(Debug, Clone)]
@@ -92,11 +91,10 @@ pub struct Track {
   /// Cached track extensions from PUBLISH or SUBSCRIBE_OK (relays MUST cache).
   pub track_extensions: Arc<RwLock<Vec<TrackExtension>>>,
   /// Original subgroup headers for open publisher streams, keyed by stream_id.
-  /// Used so new mid-group subscribers can open a QUIC send stream with the
-  /// exact original header rather than a synthesized one.
+  /// Used so new mid-group subscribers can open a QUIC send stream
   /// Inserted when the first object of a subgroup arrives; removed when the
   /// publisher's unistream closes (stream_closed signal).
-  pub active_headers: Arc<RwLock<HashMap<StreamId, HeaderInfo>>>,
+  pub active_subgroup_headers: ActiveSubgroupHeaderMap,
 }
 
 // TODO: this track implementation should be static? At least
@@ -126,7 +124,7 @@ impl Track {
       status_notify: Arc::new(Notify::new()),
       pending_subscribers: Arc::new(RwLock::new(Vec::new())),
       track_extensions: Arc::new(RwLock::new(Vec::new())),
-      active_headers: Arc::new(RwLock::new(HashMap::new())),
+      active_subgroup_headers: Arc::new(RwLock::new(HashMap::new())),
     }
   }
 
@@ -255,7 +253,7 @@ impl Track {
         subscriber,
         origin_enum,
         self.cache.clone(),
-        Arc::clone(&self.active_headers),
+        Arc::clone(&self.active_subgroup_headers),
       )
       .await?;
 
@@ -305,7 +303,7 @@ impl Track {
         utils::passed_time_since_start()
       );
       self
-        .active_headers
+        .active_subgroup_headers
         .write()
         .await
         .insert(stream_id.clone(), h.clone());
@@ -433,7 +431,7 @@ impl Track {
   }
 
   pub async fn stream_closed(&self, stream_id: &StreamId) -> Result<(), anyhow::Error> {
-    self.active_headers.write().await.remove(stream_id);
+    self.active_subgroup_headers.write().await.remove(stream_id);
 
     let event = TrackEvent::StreamClosed {
       stream_id: stream_id.clone(),


### PR DESCRIPTION
## Summary

- New subscribers joining a track mid-subgroup had no open QUIC send stream for the in-progress subgroup
- Objects arriving with `header_info=None` were silently dropped: `get_stream()` returned `None` and there was no fallback
- Fixed by caching the original `SubgroupHeader` in an `active_headers` map on `Track` (keyed by `StreamId`) when the first object of a new subgroup arrives
- Entry is evicted when the publisher unistream closes (via `stream_closed` signal)
- In `Subscription::handle_track_event()`, when `get_stream()` returns `None` for a mid-subgroup object, the cached header is used to open a new QUIC send stream so the subscriber receives all objects from the current subgroup's start

