### PR TITLE
feat: introduce raw QUIC support

### DIFF
--- a/apps/client/src/connection.rs
+++ b/apps/client/src/connection.rs
@@ -19,6 +19,7 @@ use moqtail::model::error::TerminationCode;
 use moqtail::model::{
   control::client_setup::ClientSetup, parameter::setup_parameter::SetupParameter,
 };
+use moqtail::transport::connection::TransportConnection;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,7 +32,7 @@ use wtransport::{ClientConfig, Endpoint, tls};
 const CLIENT_SUPPORTED_VERSIONS: &str = "moqt-16";
 
 pub struct MoqConnection {
-  pub connection: Arc<wtransport::Connection>,
+  pub connection: Arc<TransportConnection>,
   pub control_stream: ControlStreamHandler,
 }
 
@@ -80,13 +81,15 @@ impl MoqConnection {
       .add_header("wt-available-protocols", wt_available_protocols_str)
       .build();
 
-    let connection = Arc::new(endpoint.connect(options).await?);
+    let connection = Arc::new(TransportConnection::WebTransport(
+      endpoint.connect(options).await?,
+    ));
 
     info!("Connected! Connection ID: {}", connection.stable_id());
 
     // Open bidirectional stream for control messages
     info!("Opening control stream...");
-    let (send_stream, recv_stream) = connection.open_bi().await?.await?;
+    let (send_stream, recv_stream) = connection.open_bi().await?;
     let mut control_stream = ControlStreamHandler::new(send_stream, recv_stream);
 
     // Send ClientSetup

--- a/apps/client/src/fetcher.rs
+++ b/apps/client/src/fetcher.rs
@@ -175,7 +175,7 @@ pub async fn run(moq: MoqConnection, config: FetchConfig) -> Result<()> {
   tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
   info!("Closing connection...");
-  connection.close(0u32.into(), b"Done");
+  connection.close(0u32, b"Done");
 
   let _ = receive_task.await;
   info!("Fetch complete");

--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -29,6 +29,7 @@ use moqtail::model::data::object::Object;
 use moqtail::model::data::subgroup_header::SubgroupHeader;
 use moqtail::model::data::subgroup_object::SubgroupObject;
 use moqtail::model::parameter::message_parameter::MessageParameter;
+use moqtail::transport::connection::TransportConnection;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use moqtail::transport::data_stream_handler::{HeaderInfo, SendDataStream};
 use std::sync::Arc;
@@ -138,7 +139,7 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
   tokio::time::sleep(Duration::from_secs(2)).await;
 
   info!("Closing connection...");
-  connection.close(0u32.into(), b"Done");
+  connection.close(0u32, b"Done");
 
   Ok(())
 }
@@ -176,7 +177,7 @@ pub async fn run(moq: MoqConnection, config: PublishConfig) -> Result<()> {
   tokio::time::sleep(Duration::from_secs(2)).await;
 
   info!("Closing connection...");
-  connection.close(0u32.into(), b"Done");
+  connection.close(0u32, b"Done");
 
   Ok(())
 }
@@ -223,7 +224,7 @@ struct DataConfig {
 }
 
 async fn publish_track(
-  connection: &Arc<wtransport::Connection>,
+  connection: &Arc<TransportConnection>,
   control_stream: &mut ControlStreamHandler,
   namespace: &Tuple,
   track_name: &str,
@@ -260,7 +261,7 @@ async fn publish_track(
 }
 
 async fn send_data(
-  connection: &Arc<wtransport::Connection>,
+  connection: &Arc<TransportConnection>,
   track_alias: u64,
   config: &DataConfig,
 ) -> Result<()> {
@@ -293,7 +294,7 @@ async fn send_data(
 }
 
 async fn send_datagrams(
-  connection: &wtransport::Connection,
+  connection: &TransportConnection,
   track_alias: u64,
   group_count: u64,
   interval_ms: u64,
@@ -352,7 +353,7 @@ async fn send_datagrams(
 }
 
 async fn send_via_streams(
-  connection: &wtransport::Connection,
+  connection: &TransportConnection,
   track_alias: u64,
   group_count: u64,
   interval_ms: u64,
@@ -368,7 +369,7 @@ async fn send_via_streams(
 
   for group_id in 0..group_count {
     info!("Opening stream for group {}", group_id);
-    let stream = connection.open_uni().await?.await?;
+    let stream = connection.open_uni().await?;
 
     let sub_header = SubgroupHeader::new_with_explicit_id(
       track_alias,

--- a/apps/client/src/subscriber.rs
+++ b/apps/client/src/subscriber.rs
@@ -23,6 +23,7 @@ use moqtail::model::control::control_message::ControlMessage;
 use moqtail::model::control::subscribe::Subscribe;
 use moqtail::model::data::datagram::Datagram;
 use moqtail::model::parameter::message_parameter::MessageParameter;
+use moqtail::transport::connection::TransportConnection;
 use moqtail::transport::data_stream_handler::RecvDataStream;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -120,7 +121,7 @@ pub async fn run(moq: MoqConnection, config: SubscribeConfig) -> Result<()> {
 }
 
 async fn receive_datagrams(
-  connection: &Arc<wtransport::Connection>,
+  connection: &Arc<TransportConnection>,
   track_alias: u64,
   duration: u64,
 ) -> Result<()> {
@@ -133,8 +134,7 @@ async fn receive_datagrams(
     loop {
       match connection_clone.receive_datagram().await {
         Ok(datagram) => {
-          let bytes = bytes::Bytes::from(datagram.payload().to_vec());
-          let mut bytes_mut = bytes.clone();
+          let mut bytes_mut = datagram.clone();
 
           match Datagram::deserialize(&mut bytes_mut) {
             Ok(obj) => {
@@ -195,7 +195,7 @@ async fn receive_datagrams(
   if duration > 0 {
     tokio::time::sleep(tokio::time::Duration::from_secs(duration)).await;
     info!("Duration elapsed, closing connection...");
-    connection.close(0u32.into(), b"Done");
+    connection.close(0u32, b"Done");
   }
 
   let stats = datagram_task.await?;
@@ -208,7 +208,7 @@ async fn receive_datagrams(
 }
 
 async fn receive_streams(
-  connection: &Arc<wtransport::Connection>,
+  connection: &Arc<TransportConnection>,
   primary_alias: u64,
   extra_alias: Option<(String, u64)>,
   duration: u64,
@@ -284,7 +284,7 @@ async fn receive_streams(
   if duration > 0 {
     tokio::time::sleep(tokio::time::Duration::from_secs(duration)).await;
     info!("Duration elapsed, closing connection...");
-    connection.close(0u32.into(), b"Done");
+    connection.close(0u32, b"Done");
   }
 
   let stats = stream_task.await?;

--- a/apps/relay/src/server/client.rs
+++ b/apps/relay/src/server/client.rs
@@ -30,7 +30,10 @@ use moqtail::{
     control::{client_setup::ClientSetup, control_message::ControlMessage},
     data::full_track_name::FullTrackName,
   },
-  transport::data_stream_handler::{FetchRequest, SubscribeRequest},
+  transport::{
+    connection::{TransportConnection, TransportSendStream, TransportWriteError},
+    data_stream_handler::{FetchRequest, SubscribeRequest},
+  },
 };
 use switch_context::SwitchContext;
 
@@ -43,7 +46,6 @@ use tokio::sync::Notify;
 use tokio::sync::{Mutex, RwLock, watch};
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
-use wtransport::{Connection, SendStream, error::StreamWriteError};
 
 /// Token-bucket rate limiter. All streams of one subscriber share a single
 /// bucket so they compete for bandwidth — the QUIC scheduler then drains
@@ -89,14 +91,14 @@ impl TokenBucket {
 /// Should be a power of 2 for optimal modulo performance.
 pub const SEND_STREAM_PARTITION_COUNT: usize = 16;
 
-pub type SendStreamMap = HashMap<String, Arc<Mutex<SendStream>>>;
+pub type SendStreamMap = HashMap<String, Arc<Mutex<TransportSendStream>>>;
 pub type SendStreamLock = Arc<RwLock<SendStreamMap>>;
 pub type SendStreamList = Vec<SendStreamLock>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct MOQTClient {
   pub connection_id: usize,
-  pub connection: Arc<Connection>,
+  pub connection: Arc<TransportConnection>,
   #[allow(dead_code)]
   pub client_setup: Arc<ClientSetup>,
   pub announced_track_namespaces: Arc<RwLock<Vec<Tuple>>>, // the track namespaces the publisher announced
@@ -135,7 +137,7 @@ pub(crate) struct MOQTClient {
 impl MOQTClient {
   pub(crate) fn new(
     connection_id: usize,
-    connection: Arc<Connection>,
+    connection: Arc<TransportConnection>,
     client_setup: Arc<ClientSetup>,
   ) -> Self {
     let mut send_streams = Vec::with_capacity(SEND_STREAM_PARTITION_COUNT);
@@ -243,7 +245,7 @@ impl MOQTClient {
   fn get_stream_map(
     &self,
     stream_id: &StreamId,
-  ) -> Arc<RwLock<HashMap<String, Arc<Mutex<SendStream>>>>> {
+  ) -> Arc<RwLock<HashMap<String, Arc<Mutex<TransportSendStream>>>>> {
     let partition_index = self.get_partition_index(stream_id);
     debug!(
       "get_stream_map | stream_id: {} partition_index: {}",
@@ -252,7 +254,7 @@ impl MOQTClient {
     self.send_streams[partition_index].clone()
   }
 
-  pub async fn get_stream(&self, stream_id: &StreamId) -> Option<Arc<Mutex<SendStream>>> {
+  pub async fn get_stream(&self, stream_id: &StreamId) -> Option<Arc<Mutex<TransportSendStream>>> {
     let send_stream_map = self.get_stream_map(stream_id);
     let send_streams = send_stream_map.read().await;
     let send_stream = send_streams.get(stream_id.get_stream_id().as_str());
@@ -264,21 +266,17 @@ impl MOQTClient {
     stream_id: &StreamId,
     header_payload: Bytes,
     priority: i32, // Priority for the stream
-  ) -> Result<Arc<Mutex<SendStream>>> {
+  ) -> Result<Arc<Mutex<TransportSendStream>>> {
     let send_stream = {
       let send_stream_map = self.get_stream_map(stream_id);
       let mut send_streams = send_stream_map.write().await;
       match send_streams.entry(stream_id.get_stream_id().to_string()) {
         std::collections::hash_map::Entry::Vacant(entry) => {
-          let result = self
+          let send_stream = self
             .connection
             .open_uni()
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to open send stream 1: {:?}", e))?;
-
-          let send_stream = result
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to open send stream 2: {:?}", e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to open send stream: {:?}", e))?;
 
           send_stream.set_priority(priority);
           let s = Arc::new(Mutex::new(send_stream));
@@ -374,7 +372,7 @@ impl MOQTClient {
   pub async fn remove_stream_by_stream_id(
     &self,
     stream_id: &StreamId,
-  ) -> Option<Arc<Mutex<SendStream>>> {
+  ) -> Option<Arc<Mutex<TransportSendStream>>> {
     let send_stream_map = self.get_stream_map(stream_id);
     let mut send_streams = send_stream_map.write().await;
     send_streams.remove(stream_id.get_stream_id().as_str())
@@ -385,7 +383,7 @@ impl MOQTClient {
     stream_id: &StreamId,
     object_id: u64,
     object: Bytes,
-    the_stream: Option<Arc<Mutex<SendStream>>>,
+    the_stream: Option<Arc<Mutex<TransportSendStream>>>,
   ) -> Result<(), anyhow::Error> {
     debug!(
       "write_stream_object | Writing object to stream ({} - {}) connection_id: {}",
@@ -416,19 +414,16 @@ impl MOQTClient {
       match stream.write_all(&object).await {
         Ok(..) => {}
         Err(e) => {
-          match &e {
-            StreamWriteError::Closed | StreamWriteError::Stopped(_) => {
-              warn!(
-                "write_stream_object | Send stream is closed or stopped ({})",
-                stream_id.get_stream_id()
-              );
-              drop(stream);
-              // remove this from the streams
-              let stream_map = self.get_stream_map(stream_id);
-              let mut send_streams = stream_map.write().await;
-              send_streams.remove(stream_id.get_stream_id().as_str());
-            }
-            _ => {}
+          if let TransportWriteError::ClosedOrStopped = &e {
+            warn!(
+              "write_stream_object | Send stream is closed or stopped ({})",
+              stream_id.get_stream_id()
+            );
+            drop(stream);
+            // remove this from the streams
+            let stream_map = self.get_stream_map(stream_id);
+            let mut send_streams = stream_map.write().await;
+            send_streams.remove(stream_id.get_stream_id().as_str());
           }
         }
       };

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -29,7 +29,6 @@ use moqtail::model::{common::reason_phrase::ReasonPhrase, control::constant::Fet
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use moqtail::transport::data_stream_handler::{FetchRequest, HeaderInfo};
 use std::sync::Arc;
-use tokio::io::AsyncWriteExt;
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info, warn};
 
@@ -498,7 +497,7 @@ pub async fn handle(
         if cancelled {
           // Close the stream promptly as per the spec
           if let Some(the_stream) = send_stream {
-            if let Err(e) = the_stream.lock().await.shutdown().await {
+            if let Err(e) = the_stream.lock().await.finish().await {
               error!(
                 "handle_fetch_messages | Error closing stream on cancel: {:?}",
                 e
@@ -529,7 +528,7 @@ pub async fn handle(
           // 2. Open Stream, Write Header, and Close (FIN)
           if let Some(the_stream) = stream_fn(client.clone(), &stream_id).await {
             let mut stream_lock = the_stream.lock().await;
-            if let Err(e) = stream_lock.shutdown().await {
+            if let Err(e) = stream_lock.finish().await {
               error!(
                 "handle_fetch_messages | Error closing empty fetch stream: {:?}",
                 e
@@ -541,7 +540,7 @@ pub async fn handle(
           // close the stream instantly
           if let Some(the_stream) = send_stream {
             // gracefully finish the stream here
-            if let Err(e) = the_stream.lock().await.shutdown().await {
+            if let Err(e) = the_stream.lock().await.finish().await {
               error!("handle_fetch_messages | Error closing stream: {:?}", e);
               // return Err(TerminationCode::InternalError);
             } else {

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use anyhow::Result;
-use bytes::Bytes;
 use moqtail::model::{
   control::{
     constant::SUPPORTED_VERSIONS, control_message::ControlMessage, server_setup::ServerSetup,
@@ -22,6 +21,9 @@ use moqtail::model::{
   error::TerminationCode,
 };
 use moqtail::transport::{
+  connection::{
+    TransportConnection, TransportConnectionError, TransportRecvStream, TransportSendStream,
+  },
   control_stream_handler::ControlStreamHandler,
   data_stream_handler::{HeaderInfo, RecvDataStream},
 };
@@ -31,7 +33,7 @@ use std::{
 };
 use tokio::sync::RwLock;
 use tracing::{Instrument, debug, error, info, info_span, warn};
-use wtransport::{RecvStream, SendStream, endpoint::IncomingSession, error::ConnectionError};
+use wtransport::endpoint::IncomingSession;
 
 use crate::server::{Server, stream_id::StreamId};
 
@@ -98,7 +100,7 @@ impl Session {
     let relay_pending_requests = server.relay_pending_requests.clone();
     let upstream_fetch_senders = server.upstream_fetch_senders.clone();
     let relay_next_request_id = server.relay_next_request_id.clone();
-    let connection = session_request.accept().await?;
+    let connection = TransportConnection::WebTransport(session_request.accept().await?);
 
     let request_maps = RequestMaps {
       relay_pending_requests,
@@ -165,8 +167,8 @@ impl Session {
 
   async fn handle_control_messages(
     context: Arc<SessionContext>,
-    send_stream: SendStream,
-    recv_stream: RecvStream,
+    send_stream: TransportSendStream,
+    recv_stream: TransportRecvStream,
   ) -> core::result::Result<(), TerminationCode> {
     info!("new control message stream");
     let mut control_stream_handler = ControlStreamHandler::new(send_stream, recv_stream);
@@ -178,7 +180,7 @@ impl Session {
     {
       Ok(client) => client,
       Err(e) => {
-        context.connection.close(0u32.into(), b"Setup failed");
+        context.connection.close(0u32, b"Setup failed");
         return Err(e);
       }
     };
@@ -260,7 +262,7 @@ impl Session {
   fn close_session(context: Arc<SessionContext>, error_code: TerminationCode, msg: &str) {
     context
       .connection
-      .close(error_code.to_u32().into(), msg.as_bytes());
+      .close(error_code.to_u32(), msg.as_bytes());
   }
 
   // TODO: in an error close the connection
@@ -324,7 +326,7 @@ impl Session {
           let datagram_bytes = match datagram_result {
             Ok(bytes) => bytes,
             Err(e) => {
-              if matches!(e, ConnectionError::ApplicationClosed(_)) {
+              if matches!(e, TransportConnectionError::ApplicationClosed) {
                 continue; // Connection closed, exit the loop
               }
               error!("Failed to receive datagram from client {}: {:?}", connection_id, e);
@@ -336,8 +338,7 @@ impl Session {
             debug!("Received datagram from client {}", connection_id);
 
             // Parse the datagram
-            let bytes = Bytes::from(datagram_bytes.payload().to_vec());
-            let mut bytes = bytes;
+            let mut bytes = datagram_bytes;
             match Datagram::deserialize(&mut bytes) {
               Ok(datagram_obj) => {
                 debug!("Parsed datagram: track_alias={}, group_id={}, object_id={}",
@@ -364,8 +365,8 @@ impl Session {
 
   async fn handle_request_stream(
     context: Arc<SessionContext>,
-    send_stream: SendStream,
-    recv_stream: RecvStream,
+    send_stream: TransportSendStream,
+    recv_stream: TransportRecvStream,
   ) {
     let client = match context.get_client().await {
       Some(c) => c,
@@ -565,7 +566,10 @@ impl Session {
     Ok(())
   }
 
-  async fn handle_uni_stream(context: Arc<SessionContext>, stream: RecvStream) -> Result<()> {
+  async fn handle_uni_stream(
+    context: Arc<SessionContext>,
+    stream: TransportRecvStream,
+  ) -> Result<()> {
     debug!("accepted unidirectional stream");
     let client = context.get_client().await;
     let client = match client {

--- a/apps/relay/src/server/session_context.rs
+++ b/apps/relay/src/server/session_context.rs
@@ -22,8 +22,8 @@ use std::{
 use tokio::sync::{RwLock, mpsc};
 
 use moqtail::model::data::fetch_object::FetchObjectPayload;
-use wtransport::Connection;
 
+use moqtail::transport::connection::TransportConnection;
 use moqtail::transport::data_stream_handler::{FetchRequest, SubscribeRequest};
 
 use super::{
@@ -86,7 +86,7 @@ pub struct SessionContext {
   pub(crate) relay_pending_requests: Arc<RwLock<BTreeMap<u64, PendingRequest>>>,
   pub(crate) connection_id: usize,
   pub(crate) client: Arc<RwLock<Option<Arc<MOQTClient>>>>, // the client that is connected to this session
-  pub(crate) connection: Connection,
+  pub(crate) connection: TransportConnection,
   pub(crate) server_config: &'static AppConfig,
   pub(crate) is_connection_closed: Arc<AtomicBool>,
   pub(crate) relay_next_request_id: Arc<AtomicU64>,
@@ -100,7 +100,7 @@ impl SessionContext {
     client_manager: Arc<RwLock<ClientManager>>,
     track_manager: TrackManager,
     request_maps: RequestMaps,
-    connection: Connection,
+    connection: TransportConnection,
     relay_next_request_id: Arc<AtomicU64>,
   ) -> Self {
     Self {

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -40,6 +40,7 @@ use moqtail::model::data::subgroup_header::SubgroupHeader;
 use moqtail::model::parameter::message_parameter::{
   MessageParameter, apply_message_parameter_update,
 };
+use moqtail::transport::connection::TransportSendStream;
 use moqtail::transport::data_stream_handler::HeaderInfo;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -50,7 +51,6 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::trace;
 use tracing::warn;
 use tracing::{debug, error, info};
-use wtransport::SendStream;
 
 #[derive(Debug, Clone)]
 pub enum SubscriptionOrigin {
@@ -1131,7 +1131,7 @@ impl Subscription {
   async fn handle_header(
     &self,
     header_info: HeaderInfo,
-  ) -> Result<(StreamId, Arc<Mutex<SendStream>>)> {
+  ) -> Result<(StreamId, Arc<Mutex<TransportSendStream>>)> {
     // Handle the header information
     debug!("Handling header: {:?}", header_info);
     let stream_id = self.get_stream_id(&header_info);
@@ -1192,7 +1192,7 @@ impl Subscription {
     object: Object,
     previous_object_id: Option<u64>,
     stream_id: &StreamId,
-    send_stream: Arc<Mutex<SendStream>>,
+    send_stream: Arc<Mutex<TransportSendStream>>,
   ) -> Result<()> {
     debug!(
       "Handling object relay_track_id={} location: {:?} stream_id={} diff_ms={}",

--- a/libs/moqtail-rs/src/transport.rs
+++ b/libs/moqtail-rs/src/transport.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod connection;
 pub mod control_stream_handler;
 pub mod data_stream_handler;

--- a/libs/moqtail-rs/src/transport/connection.rs
+++ b/libs/moqtail-rs/src/transport/connection.rs
@@ -1,0 +1,451 @@
+// Copyright 2026 The MOQtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Transport-agnostic wrappers over the two QUIC-based backends MOQtail speaks:
+//! WebTransport (via `wtransport`) and raw QUIC (via `wtransport::quinn`, the exact
+//! quinn crate wtransport uses internally). Both backends have near-identical APIs
+//! (wtransport's stream types are literal newtypes over quinn's), so these enums just
+//! pick the right inner call and normalize the handful of places where the two
+//! diverge (error types, and `finish`/`set_priority` sync-vs-async).
+
+use bytes::Bytes;
+use std::net::SocketAddr;
+use thiserror::Error;
+use tokio::io::AsyncWriteExt;
+use wtransport::quinn;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportKind {
+  WebTransport,
+  Quic,
+}
+
+impl std::fmt::Display for TransportKind {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      TransportKind::WebTransport => write!(f, "webtransport"),
+      TransportKind::Quic => write!(f, "quic"),
+    }
+  }
+}
+
+#[derive(Debug, Error)]
+pub enum TransportConnectionError {
+  #[error("application closed")]
+  ApplicationClosed,
+  #[error("{0}")]
+  Other(String),
+}
+
+impl From<wtransport::error::ConnectionError> for TransportConnectionError {
+  fn from(e: wtransport::error::ConnectionError) -> Self {
+    match e {
+      wtransport::error::ConnectionError::ApplicationClosed(_) => Self::ApplicationClosed,
+      other => Self::Other(format!("{other:?}")),
+    }
+  }
+}
+
+impl From<quinn::ConnectionError> for TransportConnectionError {
+  fn from(e: quinn::ConnectionError) -> Self {
+    match e {
+      quinn::ConnectionError::ApplicationClosed(_) => Self::ApplicationClosed,
+      other => Self::Other(format!("{other:?}")),
+    }
+  }
+}
+
+impl From<wtransport::error::StreamOpeningError> for TransportConnectionError {
+  fn from(e: wtransport::error::StreamOpeningError) -> Self {
+    Self::Other(format!("{e:?}"))
+  }
+}
+
+impl From<wtransport::error::SendDatagramError> for TransportConnectionError {
+  fn from(e: wtransport::error::SendDatagramError) -> Self {
+    Self::Other(format!("{e:?}"))
+  }
+}
+
+impl From<quinn::SendDatagramError> for TransportConnectionError {
+  fn from(e: quinn::SendDatagramError) -> Self {
+    Self::Other(format!("{e:?}"))
+  }
+}
+
+#[derive(Debug, Error)]
+pub enum TransportWriteError {
+  #[error("stream closed or stopped")]
+  ClosedOrStopped,
+  #[error("{0}")]
+  Other(String),
+}
+
+impl From<wtransport::error::StreamWriteError> for TransportWriteError {
+  fn from(e: wtransport::error::StreamWriteError) -> Self {
+    use wtransport::error::StreamWriteError as E;
+    match e {
+      E::Closed | E::Stopped(_) => Self::ClosedOrStopped,
+      other => Self::Other(format!("{other:?}")),
+    }
+  }
+}
+
+impl From<quinn::WriteError> for TransportWriteError {
+  fn from(e: quinn::WriteError) -> Self {
+    use quinn::WriteError as E;
+    match e {
+      E::ClosedStream | E::Stopped(_) => Self::ClosedOrStopped,
+      other => Self::Other(format!("{other:?}")),
+    }
+  }
+}
+
+impl From<quinn::ClosedStream> for TransportWriteError {
+  fn from(_: quinn::ClosedStream) -> Self {
+    Self::ClosedOrStopped
+  }
+}
+
+#[derive(Debug, Error)]
+pub enum TransportReadError {
+  #[error("not connected")]
+  NotConnected,
+  #[error("{0}")]
+  Other(String),
+}
+
+impl From<wtransport::error::StreamReadError> for TransportReadError {
+  fn from(e: wtransport::error::StreamReadError) -> Self {
+    use wtransport::error::StreamReadError as E;
+    match e {
+      E::NotConnected => Self::NotConnected,
+      other => Self::Other(format!("{other:?}")),
+    }
+  }
+}
+
+impl From<quinn::ReadError> for TransportReadError {
+  fn from(e: quinn::ReadError) -> Self {
+    use quinn::ReadError as E;
+    match e {
+      E::ConnectionLost(_) | E::ClosedStream => Self::NotConnected,
+      other => Self::Other(format!("{other:?}")),
+    }
+  }
+}
+
+#[derive(Debug)]
+pub enum TransportSendStream {
+  WebTransport(wtransport::SendStream),
+  Quic(quinn::SendStream),
+}
+
+impl TransportSendStream {
+  pub async fn write_all(&mut self, buf: &[u8]) -> Result<(), TransportWriteError> {
+    match self {
+      Self::WebTransport(s) => s.write_all(buf).await.map_err(Into::into),
+      Self::Quic(s) => s.write_all(buf).await.map_err(Into::into),
+    }
+  }
+
+  pub async fn finish(&mut self) -> Result<(), TransportWriteError> {
+    match self {
+      Self::WebTransport(s) => s.finish().await.map_err(Into::into),
+      Self::Quic(s) => s.finish().map_err(Into::into),
+    }
+  }
+
+  pub async fn flush(&mut self) -> Result<(), TransportWriteError> {
+    let result = match self {
+      Self::WebTransport(s) => s.flush().await,
+      Self::Quic(s) => s.flush().await,
+    };
+    result.map_err(|e| TransportWriteError::Other(e.to_string()))
+  }
+
+  /// Best-effort: if the stream is already closed, setting priority is a no-op.
+  pub fn set_priority(&self, priority: i32) {
+    match self {
+      Self::WebTransport(s) => s.set_priority(priority),
+      Self::Quic(s) => {
+        let _ = s.set_priority(priority);
+      }
+    }
+  }
+}
+
+#[derive(Debug)]
+pub enum TransportRecvStream {
+  WebTransport(wtransport::RecvStream),
+  Quic(quinn::RecvStream),
+}
+
+impl TransportRecvStream {
+  pub async fn read(&mut self, buf: &mut [u8]) -> Result<Option<usize>, TransportReadError> {
+    match self {
+      Self::WebTransport(s) => s.read(buf).await.map_err(Into::into),
+      Self::Quic(s) => s.read(buf).await.map_err(Into::into),
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+pub enum TransportConnection {
+  WebTransport(wtransport::Connection),
+  Quic(quinn::Connection),
+}
+
+impl TransportConnection {
+  pub fn kind(&self) -> TransportKind {
+    match self {
+      Self::WebTransport(_) => TransportKind::WebTransport,
+      Self::Quic(_) => TransportKind::Quic,
+    }
+  }
+
+  pub fn stable_id(&self) -> usize {
+    match self {
+      Self::WebTransport(c) => c.stable_id(),
+      Self::Quic(c) => c.stable_id(),
+    }
+  }
+
+  pub fn remote_address(&self) -> SocketAddr {
+    match self {
+      Self::WebTransport(c) => c.remote_address(),
+      Self::Quic(c) => c.remote_address(),
+    }
+  }
+
+  /// Closes the connection with an application error code and reason.
+  pub fn close(&self, error_code: u32, reason: &[u8]) {
+    match self {
+      Self::WebTransport(c) => c.close(error_code.into(), reason),
+      Self::Quic(c) => c.close(error_code.into(), reason),
+    }
+  }
+
+  /// Waits for the connection to be closed, for any reason.
+  pub async fn closed(&self) {
+    match self {
+      Self::WebTransport(c) => {
+        c.closed().await;
+      }
+      Self::Quic(c) => {
+        c.closed().await;
+      }
+    }
+  }
+
+  pub async fn open_bi(
+    &self,
+  ) -> Result<(TransportSendStream, TransportRecvStream), TransportConnectionError> {
+    match self {
+      Self::WebTransport(c) => {
+        let (send, recv) = c.open_bi().await?.await?;
+        Ok((
+          TransportSendStream::WebTransport(send),
+          TransportRecvStream::WebTransport(recv),
+        ))
+      }
+      Self::Quic(c) => {
+        let (send, recv) = c.open_bi().await?;
+        Ok((
+          TransportSendStream::Quic(send),
+          TransportRecvStream::Quic(recv),
+        ))
+      }
+    }
+  }
+
+  pub async fn accept_bi(
+    &self,
+  ) -> Result<(TransportSendStream, TransportRecvStream), TransportConnectionError> {
+    match self {
+      Self::WebTransport(c) => {
+        let (send, recv) = c.accept_bi().await?;
+        Ok((
+          TransportSendStream::WebTransport(send),
+          TransportRecvStream::WebTransport(recv),
+        ))
+      }
+      Self::Quic(c) => {
+        let (send, recv) = c.accept_bi().await?;
+        Ok((
+          TransportSendStream::Quic(send),
+          TransportRecvStream::Quic(recv),
+        ))
+      }
+    }
+  }
+
+  pub async fn open_uni(&self) -> Result<TransportSendStream, TransportConnectionError> {
+    match self {
+      Self::WebTransport(c) => {
+        let send = c.open_uni().await?.await?;
+        Ok(TransportSendStream::WebTransport(send))
+      }
+      Self::Quic(c) => {
+        let send = c.open_uni().await?;
+        Ok(TransportSendStream::Quic(send))
+      }
+    }
+  }
+
+  pub async fn accept_uni(&self) -> Result<TransportRecvStream, TransportConnectionError> {
+    match self {
+      Self::WebTransport(c) => Ok(TransportRecvStream::WebTransport(c.accept_uni().await?)),
+      Self::Quic(c) => Ok(TransportRecvStream::Quic(c.accept_uni().await?)),
+    }
+  }
+
+  pub async fn receive_datagram(&self) -> Result<Bytes, TransportConnectionError> {
+    match self {
+      Self::WebTransport(c) => Ok(Bytes::from(c.receive_datagram().await?.payload().to_vec())),
+      Self::Quic(c) => Ok(c.read_datagram().await?),
+    }
+  }
+
+  pub fn send_datagram(&self, payload: Bytes) -> Result<(), TransportConnectionError> {
+    match self {
+      Self::WebTransport(c) => c.send_datagram(payload).map_err(Into::into),
+      Self::Quic(c) => c.send_datagram(payload).map_err(Into::into),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::error::Error;
+  use std::sync::Arc;
+  use wtransport::endpoint::IntoConnectOptions;
+
+  const TEST_ALPN: &[u8] = b"test-moqt";
+
+  async fn webtransport_pair() -> Result<(TransportConnection, TransportConnection), Box<dyn Error>>
+  {
+    let server_identity = wtransport::Identity::self_signed(std::iter::once("localhost"))?;
+    let server_cert_hash = server_identity.certificate_chain().as_slice()[0].hash();
+
+    let server_config = wtransport::ServerConfig::builder()
+      .with_bind_address("127.0.0.1:0".parse()?)
+      .with_identity(server_identity)
+      .build();
+    let server_endpoint = wtransport::Endpoint::server(server_config)?;
+    let server_addr = server_endpoint.local_addr()?;
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+      let incoming = server_endpoint.accept().await;
+      let session_request = incoming.await.expect("session request");
+      let connection = session_request.accept().await.expect("accept");
+      let _ = tx.send(connection);
+    });
+
+    let client_config = wtransport::ClientConfig::builder()
+      .with_bind_default()
+      .with_server_certificate_hashes(vec![server_cert_hash])
+      .build();
+    let client_endpoint = wtransport::Endpoint::client(client_config)?;
+    let client = client_endpoint
+      .connect(format!("https://{}:{}", server_addr.ip(), server_addr.port()).into_options())
+      .await?;
+
+    let server = rx.await?;
+
+    Ok((
+      TransportConnection::WebTransport(client),
+      TransportConnection::WebTransport(server),
+    ))
+  }
+
+  async fn quic_pair() -> Result<(TransportConnection, TransportConnection), Box<dyn Error>> {
+    let server_identity = wtransport::Identity::self_signed(std::iter::once("localhost"))?;
+    let server_cert_hash = server_identity.certificate_chain().as_slice()[0].hash();
+
+    let mut server_tls = wtransport::tls::server::build_default_tls_config(server_identity);
+    server_tls.alpn_protocols = vec![TEST_ALPN.to_vec()];
+    let quic_server_config = quinn::crypto::rustls::QuicServerConfig::try_from(server_tls)?;
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(quic_server_config));
+    let server_endpoint = quinn::Endpoint::server(server_config, "127.0.0.1:0".parse()?)?;
+    let server_addr = server_endpoint.local_addr()?;
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+      let incoming = server_endpoint.accept().await.expect("incoming");
+      let connection = incoming.await.expect("connection");
+      let _ = tx.send(connection);
+    });
+
+    let mut client_tls = wtransport::tls::client::build_default_tls_config(
+      Arc::new(wtransport::tls::rustls::RootCertStore::empty()),
+      Some(Arc::new(
+        wtransport::tls::client::NoServerVerification::new(),
+      )),
+    );
+    client_tls.alpn_protocols = vec![TEST_ALPN.to_vec()];
+    let _ = server_cert_hash; // NoServerVerification skips cert checks for this test
+    let quic_client_config = quinn::crypto::rustls::QuicClientConfig::try_from(client_tls)?;
+    let client_config = quinn::ClientConfig::new(Arc::new(quic_client_config));
+
+    let client_endpoint = quinn::Endpoint::client("127.0.0.1:0".parse()?)?;
+    let client = client_endpoint
+      .connect_with(client_config, server_addr, "localhost")?
+      .await?;
+
+    let server = rx.await?;
+
+    Ok((
+      TransportConnection::Quic(client),
+      TransportConnection::Quic(server),
+    ))
+  }
+
+  async fn roundtrip_bi(client: TransportConnection, server: TransportConnection) {
+    // Raw QUIC sends nothing on the wire for an opened-but-unwritten stream (unlike
+    // WebTransport, whose open_bi() writes a stream-type header immediately), so write
+    // before waiting on the peer's accept_bi() or it can idle out waiting for a stream
+    // it was never told about.
+    let (mut client_send, _client_recv) = client.open_bi().await.expect("client open_bi");
+    client_send.write_all(b"hello").await.expect("write_all");
+
+    let (_server_send, mut server_recv) = server.accept_bi().await.expect("server accept_bi");
+
+    let mut buf = [0u8; 5];
+    let mut read = 0;
+    while read < buf.len() {
+      let n = server_recv
+        .read(&mut buf[read..])
+        .await
+        .expect("read")
+        .expect("stream open");
+      read += n;
+    }
+    assert_eq!(&buf, b"hello");
+  }
+
+  #[tokio::test]
+  async fn webtransport_backend_roundtrip() {
+    let (client, server) = webtransport_pair().await.expect("webtransport_pair");
+    roundtrip_bi(client, server).await;
+  }
+
+  #[tokio::test]
+  async fn quic_backend_roundtrip() {
+    let (client, server) = quic_pair().await.expect("quic_pair");
+    roundtrip_bi(client, server).await;
+  }
+}

--- a/libs/moqtail-rs/src/transport/control_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/control_stream_handler.rs
@@ -15,26 +15,25 @@
 use bytes::{Buf, BufMut, BytesMut};
 use tokio::time::{Duration, Instant, sleep_until};
 use tracing::{error, info, warn};
-use wtransport::error::StreamReadError;
-use wtransport::{RecvStream, SendStream};
 
 use crate::model::control::control_message::{ControlMessage, ControlMessageTrait};
 use crate::model::error::{ParseError, TerminationCode};
+use crate::transport::connection::{TransportReadError, TransportRecvStream, TransportSendStream};
 
 const CONTROL_MESSAGE_TIMEOUT: Duration = Duration::from_secs(5);
 
 const MTU_SIZE: usize = 1500; // Standard MTU size, max 2^16-1
 
 pub struct ControlStreamHandler {
-  send: SendStream,
-  recv: RecvStream,
+  send: TransportSendStream,
+  recv: TransportRecvStream,
   recv_bytes: BytesMut,
   recv_buf: Box<[u8; MTU_SIZE]>,
   partial_message_deadline: Option<Instant>,
 }
 
 impl ControlStreamHandler {
-  pub fn new(send: SendStream, recv: RecvStream) -> Self {
+  pub fn new(send: TransportSendStream, recv: TransportRecvStream) -> Self {
     Self {
       send,
       recv,
@@ -135,7 +134,7 @@ impl ControlStreamHandler {
   /// Handle the result of a stream read operation
   fn handle_read_result(
     &mut self,
-    res: Result<Option<usize>, wtransport::error::StreamReadError>,
+    res: Result<Option<usize>, TransportReadError>,
     is_partial_message: bool,
   ) -> Result<(), TerminationCode> {
     match res {
@@ -160,7 +159,7 @@ impl ControlStreamHandler {
       }
       Err(e) => {
         match e {
-          StreamReadError::NotConnected => {
+          TransportReadError::NotConnected => {
             info!("Client disconnected while reading control stream");
             // Client has disconnected - this is not an error, return NoError
             // so the caller knows not to try closing the connection
@@ -205,7 +204,7 @@ mod tests {
   use tokio::sync::Mutex;
   use tokio::time::sleep;
   use wtransport::endpoint::IntoConnectOptions;
-  use wtransport::{ClientConfig, Connection, Endpoint, Identity};
+  use wtransport::{ClientConfig, Connection, Endpoint, Identity, SendStream};
 
   struct TestSetup {
     client: Connection,
@@ -312,7 +311,10 @@ mod tests {
       // Set control stream to max priority
       server_send.set_priority(i32::MAX);
 
-      let plane = ControlStreamHandler::new(client_send, client_recv);
+      let plane = ControlStreamHandler::new(
+        TransportSendStream::WebTransport(client_send),
+        TransportRecvStream::WebTransport(client_recv),
+      );
       Ok((plane, server_send))
     }
   }

--- a/libs/moqtail-rs/src/transport/data_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/data_stream_handler.rs
@@ -18,12 +18,9 @@ use std::time::Duration;
 use bytes::{Buf, BufMut, BytesMut};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::io::AsyncWriteExt;
 use tokio::sync::{Mutex, Notify, RwLock};
 use tokio::task::yield_now;
 use tokio::time::{Instant, sleep_until};
-use wtransport::error::StreamReadError;
-use wtransport::{RecvStream, SendStream};
 
 use crate::model::control::fetch::Fetch;
 use crate::model::control::subscribe::Subscribe;
@@ -34,6 +31,7 @@ use crate::model::data::object::Object;
 use crate::model::data::subgroup_header::SubgroupHeader;
 use crate::model::data::subgroup_object::SubgroupObject;
 use crate::model::error::ParseError;
+use crate::transport::connection::{TransportReadError, TransportRecvStream, TransportSendStream};
 use tracing::{debug, error, info, trace};
 
 type ObjectParseResult =
@@ -119,7 +117,7 @@ impl SubscribeRequest {
 ///
 /// ```
 pub struct SendDataStream {
-  send_stream: Arc<Mutex<SendStream>>,
+  send_stream: Arc<Mutex<TransportSendStream>>,
   header_info: HeaderInfo,
   fetch_prev_ctx: Option<FetchObjectContext>,
 }
@@ -128,7 +126,7 @@ pub struct SendDataStream {
 // Suggestion: SubgroupHeader should start with Request ID and discard track_alias
 impl SendDataStream {
   pub async fn new(
-    send_stream: Arc<Mutex<SendStream>>,
+    send_stream: Arc<Mutex<TransportSendStream>>,
     header_info: HeaderInfo,
   ) -> Result<Self, ParseError> {
     let mut buf = BytesMut::new();
@@ -241,7 +239,7 @@ pub enum RecvDataStreamReadError {
 /// }
 /// ```
 pub struct RecvDataStream {
-  recv_stream: Arc<Mutex<RecvStream>>,
+  recv_stream: Arc<Mutex<TransportRecvStream>>,
   header_info: Arc<Mutex<Option<HeaderInfo>>>,
   pending_fetches: Arc<RwLock<BTreeMap<u64, FetchRequest>>>, // Mutable borrow to potentially remove entry
   objects: Arc<RwLock<VecDeque<Object>>>,                    // Buffer for parsed objects
@@ -252,7 +250,7 @@ pub struct RecvDataStream {
 
 impl RecvDataStream {
   pub fn new(
-    recv_stream: RecvStream,
+    recv_stream: TransportRecvStream,
     pending_fetches: Arc<RwLock<BTreeMap<u64, FetchRequest>>>, // Mutable borrow to potentially remove entry
   ) -> Self {
     Self {
@@ -273,7 +271,7 @@ impl RecvDataStream {
   }
 
   async fn read(
-    recv_stream: Arc<Mutex<RecvStream>>,
+    recv_stream: Arc<Mutex<TransportRecvStream>>,
     is_closed: Arc<AtomicBool>,
     the_header_info: Arc<Mutex<Option<HeaderInfo>>>,
     pending_fetches: Arc<RwLock<BTreeMap<u64, FetchRequest>>>,
@@ -396,7 +394,7 @@ impl RecvDataStream {
               Err(e) => {
                 debug!("RecvDataStream::read() Read error: {:?}", e);
                 is_closed.store(true, Ordering::Relaxed);
-                if e == StreamReadError::NotConnected {
+                if matches!(e, TransportReadError::NotConnected) {
                   return Err(RecvDataStreamReadError::StreamClosed);
                 }
                 return Err(RecvDataStreamReadError::ParseError(ParseError::Other { context: "RecvDataStream::new(header_read)", msg:e.to_string() }));
@@ -1027,7 +1025,7 @@ mod tests {
     );
 
     let sender = SendDataStream::new(
-      Arc::new(Mutex::new(send)),
+      Arc::new(Mutex::new(TransportSendStream::WebTransport(send))),
       HeaderInfo::Fetch {
         header: fetch_header,
         fetch_request: fetch_req.clone(),
@@ -1041,7 +1039,7 @@ mod tests {
 
     let pending_fetches = Arc::new(RwLock::new(pending_fetches));
 
-    let receiver = RecvDataStream::new(recv, pending_fetches);
+    let receiver = RecvDataStream::new(TransportRecvStream::WebTransport(recv), pending_fetches);
 
     // Serialize object and send in two parts
     let bytes = FetchObject::Object(fetch_obj.clone())


### PR DESCRIPTION
### Description

Add TransportConnection/TransportSendStream/TransportRecvStream in libs/moqtail-rs, wrapping wtransport and raw quinn (re-exported as wtransport::quinn) behind one API, and thread them through the lib's stream handlers, the relay, and the client. This is a pure refactor: every connection is still constructed as the WebTransport variant, so behavior is unchanged. It's groundwork for adding a raw QUIC listener alongside WebTransport on the relay.
