### PR TITLE
fix: treat empty extensions as absent

### DIFF
--- a/.changeset/puny-ties-beam.md
+++ b/.changeset/puny-ties-beam.md
@@ -1,6 +1,5 @@
 ---
 'moqtail-ts': minor
-'moqtail-rs': minor
 'moqtail': patch
 ---
 

--- a/.changeset/puny-ties-beam.md
+++ b/.changeset/puny-ties-beam.md
@@ -1,5 +1,6 @@
 ---
-'client-js': minor
+'moqtail-ts': minor
+'moqtail-rs': minor
 'moqtail': patch
 ---
 

--- a/.changeset/puny-ties-beam.md
+++ b/.changeset/puny-ties-beam.md
@@ -1,0 +1,6 @@
+---
+'client-js': minor
+'moqtail': patch
+---
+
+Normalize empty subgroup extension headers to null so [] serializes the same as no headers.

--- a/libs/moqtail-rs/src/model/data/subgroup_object.rs
+++ b/libs/moqtail-rs/src/model/data/subgroup_object.rs
@@ -35,7 +35,7 @@ impl SubgroupObject {
   pub fn serialize(
     &self,
     previous_object_id: Option<u64>,
-    _has_extensions: bool,
+    has_extensions: bool,
   ) -> Result<Bytes, ParseError> {
     let mut buf = BytesMut::new();
 
@@ -52,14 +52,19 @@ impl SubgroupObject {
 
     buf.put_vi(object_id_delta)?;
 
-    if let Some(ext_headers) = &self.extension_headers {
-      if ext_headers.is_empty() {
-        buf.put_vi(0)?;
-      } else {
-        let ext_buf = serialize_object_extensions(ext_headers)?;
-        buf.put_vi(ext_buf.len())?;
-        buf.extend_from_slice(&ext_buf);
-      }
+    let extension_headers = self.extension_headers.as_deref().unwrap_or(&[]);
+
+    if !has_extensions && !extension_headers.is_empty() {
+      return Err(ParseError::ProtocolViolation {
+        context: "SubgroupObject::serialize(extension_headers)",
+        details: "extension headers are present but header type has no extensions".to_string(),
+      });
+    }
+
+    if has_extensions {
+      let ext_buf = serialize_object_extensions(extension_headers)?;
+      buf.put_vi(ext_buf.len())?;
+      buf.extend_from_slice(&ext_buf);
     }
 
     if let Some(payload) = &self.payload
@@ -203,6 +208,32 @@ mod tests {
     let deserialized = SubgroupObject::deserialize(&mut buf, &Some(prev_object_id), true).unwrap();
     assert_eq!(deserialized, subgroup_object);
     assert!(!buf.has_remaining());
+  }
+
+  #[test]
+  fn test_serializes_empty_extension_headers_as_absent() {
+    let object_id: u64 = 10;
+    let payload = Some(Bytes::from_static(&[0xab]));
+
+    let with_no_headers = SubgroupObject {
+      object_id,
+      extension_headers: None,
+      object_status: None,
+      payload: payload.clone(),
+    }
+    .serialize(None, false)
+    .unwrap();
+
+    let with_empty_headers = SubgroupObject {
+      object_id,
+      extension_headers: Some(vec![]),
+      object_status: None,
+      payload,
+    }
+    .serialize(None, false)
+    .unwrap();
+
+    assert_eq!(with_empty_headers, with_no_headers);
   }
 
   #[test]

--- a/libs/moqtail-ts/src/model/data/subgroup_object.ts
+++ b/libs/moqtail-ts/src/model/data/subgroup_object.ts
@@ -18,6 +18,13 @@ import { BaseByteBuffer, ByteBuffer, FrozenByteBuffer } from '../common/byte_buf
 import { KeyValuePair, deserializeKvpListUntilEmpty, serializeKvpList } from '../common/pair'
 import { ObjectStatus } from './constant'
 
+function normalizeExtensionHeaders(extensionHeaders: KeyValuePair[] | null): KeyValuePair[] | null {
+  if (extensionHeaders === null || extensionHeaders.length === 0) {
+    return null
+  }
+  return extensionHeaders
+}
+
 export class SubgroupObject {
   public readonly objectId: bigint
 
@@ -35,7 +42,7 @@ export class SubgroupObject {
     extensionHeaders: KeyValuePair[] | null,
     objectStatus: ObjectStatus,
   ): SubgroupObject {
-    return new SubgroupObject(objectId, extensionHeaders, objectStatus, null)
+    return new SubgroupObject(objectId, normalizeExtensionHeaders(extensionHeaders), objectStatus, null)
   }
 
   static newWithPayload(
@@ -43,7 +50,7 @@ export class SubgroupObject {
     extensionHeaders: KeyValuePair[] | null,
     payload: Uint8Array,
   ): SubgroupObject {
-    return new SubgroupObject(objectId, extensionHeaders, null, payload)
+    return new SubgroupObject(objectId, normalizeExtensionHeaders(extensionHeaders), null, payload)
   }
 
   serialize(previousObjectId: bigint | undefined): FrozenByteBuffer {
@@ -54,7 +61,7 @@ export class SubgroupObject {
 
     const buf = new ByteBuffer()
     buf.putVI(objectIdDelta)
-    if (this.extensionHeaders) {
+    if (this.extensionHeaders !== null) {
       buf.putLengthPrefixedBytes(serializeKvpList(this.extensionHeaders).toUint8Array())
     }
     if (this.payload) {
@@ -87,7 +94,7 @@ export class SubgroupObject {
     } else {
       payload = buf.getBytes(payloadLen)
     }
-    return new SubgroupObject(objectId, extensionHeaders, objectStatus, payload)
+    return new SubgroupObject(objectId, normalizeExtensionHeaders(extensionHeaders), objectStatus, payload)
   }
 }
 
@@ -107,6 +114,15 @@ if (import.meta.vitest) {
       expect(parsed.extensionHeaders).toEqual(extensionHeaders)
       expect(parsed.payload).toEqual(payload)
       expect(frozen.remaining).toBe(0)
+    })
+    test('serializes empty extension headers as absent', () => {
+      const objectId = 10n
+      const payload = new Uint8Array([0xab])
+
+      const withNoHeaders = SubgroupObject.newWithPayload(objectId, null, payload).serialize(undefined).toUint8Array()
+      const withEmptyHeaders = SubgroupObject.newWithPayload(objectId, [], payload).serialize(undefined).toUint8Array()
+
+      expect(Array.from(withEmptyHeaders)).toEqual(Array.from(withNoHeaders))
     })
     test('excess roundtrip', () => {
       const objectId = 10n


### PR DESCRIPTION
fixes #147 

**TS:** Normalizes empty subgroup extension header arrays to null, so [] serializes exactly like no headers.
**Rust:** Treats Some(vec![]) as absent during subgroup object serialization, preventing an extra empty extension length byte from being written.

Added test scenarios for both.