### PR TITLE
fix(ci): replace global corepack install with corepack enable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
           cache: 'npm'
 
       - run: npm clean-install
-      - run: npm install --global corepack@latest
-      - run: corepack npm audit signatures
+      - run: corepack enable
+      - run: npm audit signatures
 
       - name: Cache Rust Workspace
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
replace global corepack install with corepack enable release workflow

Node.js 24 ships corepack built-in; installing it globally via npm fails with exit code 1 in GitHub Actions. Switch to `corepack enable` to activate the built-in shim, then run `npm audit signatures` directly.
