### PR TITLE
fix(ts): use bitmask dispatch for subgroup header detection

### DIFF
--- a/.changeset/fix-subgroup-header-bitmask-dispatch.md
+++ b/.changeset/fix-subgroup-header-bitmask-dispatch.md
@@ -1,0 +1,5 @@
+---
+'moqtail': patch
+---
+
+Fix `Header.deserialize` rejecting subgroup headers with default publisher priority. The dispatch previously used an explicit switch covering only `0x10–0x15` and `0x18–0x1D`, missing the `0x30–0x35` and `0x38–0x3D` ranges (DEFAULT_PRIORITY bit set). Replaced with bitmask detection matching the Rust validator.

--- a/libs/moqtail-ts/src/model/data/header.ts
+++ b/libs/moqtail-ts/src/model/data/header.ts
@@ -18,6 +18,7 @@ import { FetchHeader } from './fetch_header'
 import { SubgroupHeader } from './subgroup_header'
 import { FrozenByteBuffer, BaseByteBuffer } from '../common/byte_buffer'
 import { InvalidTypeError } from '../error'
+import { SubgroupHeaderType } from './constant'
 
 export type Header = FetchHeader | SubgroupHeader
 
@@ -41,24 +42,12 @@ export namespace Header {
     buf.checkpoint()
     const type = buf.getNumberVI()
     buf.restore()
-    switch (type) {
-      case 0x05:
-        return FetchHeader.deserialize(buf)
-      case 0x10:
-      case 0x11:
-      case 0x12:
-      case 0x13:
-      case 0x14:
-      case 0x15:
-      case 0x18:
-      case 0x19:
-      case 0x1a:
-      case 0x1b:
-      case 0x1c:
-      case 0x1d:
-        return SubgroupHeader.deserialize(buf)
-      default:
-        throw new InvalidTypeError('Header::deserialize(type)', `Unknown header type: ${type}`)
+    if (type === 0x05) {
+      return FetchHeader.deserialize(buf)
+    } else if ((type & SubgroupHeaderType.REQUIRED_BIT) !== 0 && (type & 0xc0) === 0) {
+      return SubgroupHeader.deserialize(buf)
+    } else {
+      throw new InvalidTypeError('Header::deserialize(type)', `Unknown header type: ${type}`)
     }
   }
 }


### PR DESCRIPTION
Fixes #210 