### PR TITLE
Helper to validate different priority in same subgroup in FETCH response

### DIFF
--- a/.changeset/clean-balloons-enjoy.md
+++ b/.changeset/clean-balloons-enjoy.md
@@ -1,0 +1,5 @@
+---
+'moqtail-rs': patch
+---
+
+helper function to validate subgroup priority in FETCH

--- a/libs/moqtail-rs/src/transport/data_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/data_stream_handler.rs
@@ -41,25 +41,44 @@ type ObjectParseResult =
 const DATA_STREAM_TIMEOUT: Duration = Duration::from_secs(15);
 const MTU_SIZE: usize = 1500; // Standard MTU size
 
-fn validate_fetch_subgroup_priority(
-  payload: &FetchObjectPayload,
-  subgroup_priorities: &mut HashMap<u64, u8>,
-) -> Result<(), ParseError> {
-  if payload.forwarding_preference != ObjectForwardingPreference::Subgroup {
-    return Ok(());
-  }
+#[derive(Default)]
+struct FetchReadState {
+  prev_ctx: Option<FetchObjectContext>,
+  subgroup_priorities: FetchSubgroupPriorityState,
+}
 
-  match subgroup_priorities.insert(payload.subgroup_id, payload.publisher_priority) {
-    Some(previous_priority) if previous_priority != payload.publisher_priority => {
-      Err(ParseError::ProtocolViolation {
-        context: "RecvDataStream::read_object(fetch_malformed_track)",
-        details: format!(
-          "FETCH object for subgroup_id {} changed publisher_priority from {} to {}",
-          payload.subgroup_id, previous_priority, payload.publisher_priority
-        ),
-      })
+#[derive(Default)]
+struct FetchSubgroupPriorityState {
+  group_id: Option<u64>,
+  priorities: HashMap<u64, u8>,
+}
+
+impl FetchSubgroupPriorityState {
+  fn validate(&mut self, payload: &FetchObjectPayload) -> Result<(), ParseError> {
+    if self.group_id != Some(payload.group_id) {
+      self.group_id = Some(payload.group_id);
+      self.priorities.clear();
     }
-    _ => Ok(()),
+
+    if payload.forwarding_preference != ObjectForwardingPreference::Subgroup {
+      return Ok(());
+    }
+
+    match self
+      .priorities
+      .insert(payload.subgroup_id, payload.publisher_priority)
+    {
+      Some(previous_priority) if previous_priority != payload.publisher_priority => {
+        Err(ParseError::ProtocolViolation {
+          context: "RecvDataStream::read_object(fetch_malformed_track)",
+          details: format!(
+            "FETCH object for subgroup_id {} changed publisher_priority from {} to {}",
+            payload.subgroup_id, previous_priority, payload.publisher_priority
+          ),
+        })
+      }
+      _ => Ok(()),
+    }
   }
 }
 
@@ -313,8 +332,7 @@ impl RecvDataStream {
     let mut timeout_at = Instant::now() + DATA_STREAM_TIMEOUT;
 
     let mut previous_object_id: Option<u64> = None;
-    let mut fetch_prev_ctx: Option<FetchObjectContext> = None;
-    let mut fetch_subgroup_priorities: HashMap<u64, u8> = HashMap::new();
+    let mut fetch_state = FetchReadState::default();
 
     loop {
       let bytes_cursor = recv_bytes.clone().freeze();
@@ -351,8 +369,7 @@ impl RecvDataStream {
             is_closed.clone(),
             objects.clone(),
             &previous_object_id,
-            &fetch_prev_ctx,
-            &mut fetch_subgroup_priorities,
+            &mut fetch_state,
             malformed_track.clone(),
           )
           .await
@@ -365,7 +382,7 @@ impl RecvDataStream {
           if c > 0 {
             previous_object_id = object_id;
             if new_fetch_ctx.is_some() {
-              fetch_prev_ctx = new_fetch_ctx;
+              fetch_state.prev_ctx = new_fetch_ctx;
             }
             notify.notify_waiters();
             recv_bytes.advance(c);
@@ -516,8 +533,7 @@ impl RecvDataStream {
     is_closed: Arc<AtomicBool>,
     objects: Arc<RwLock<VecDeque<Object>>>,
     previous_object_id: &Option<u64>,
-    fetch_prev_ctx: &Option<FetchObjectContext>,
-    fetch_subgroup_priorities: &mut HashMap<u64, u8>,
+    fetch_state: &mut FetchReadState,
     malformed_track: Arc<AtomicBool>,
   ) -> Result<(usize, Option<u64>, Option<FetchObjectContext>), ParseError> {
     if !bytes_cursor.is_empty() {
@@ -525,14 +541,12 @@ impl RecvDataStream {
 
       let parse_result: ObjectParseResult = match header_info {
         HeaderInfo::Fetch { .. } => {
-          FetchObject::deserialize(&mut bytes_cursor, fetch_prev_ctx.as_ref()).and_then(
+          FetchObject::deserialize(&mut bytes_cursor, fetch_state.prev_ctx.as_ref()).and_then(
             |fetch_obj| {
               let new_ctx = fetch_obj.context();
               match fetch_obj {
                 FetchObject::Object(payload) => {
-                  if let Err(e) =
-                    validate_fetch_subgroup_priority(&payload, fetch_subgroup_priorities)
-                  {
+                  if let Err(e) = fetch_state.subgroup_priorities.validate(&payload) {
                     malformed_track.store(true, Ordering::Relaxed);
                     return Err(e);
                   }

--- a/libs/moqtail-rs/src/transport/data_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/data_stream_handler.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::time::Duration;
 
 use bytes::{Buf, BufMut, BytesMut};
@@ -24,9 +24,9 @@ use tokio::time::{Instant, sleep_until};
 
 use crate::model::control::fetch::Fetch;
 use crate::model::control::subscribe::Subscribe;
-use crate::model::data::constant::FetchHeaderType;
+use crate::model::data::constant::{FetchHeaderType, ObjectForwardingPreference};
 use crate::model::data::fetch_header::FetchHeader;
-use crate::model::data::fetch_object::{FetchObject, FetchObjectContext};
+use crate::model::data::fetch_object::{FetchObject, FetchObjectContext, FetchObjectPayload};
 use crate::model::data::object::Object;
 use crate::model::data::subgroup_header::SubgroupHeader;
 use crate::model::data::subgroup_object::SubgroupObject;
@@ -40,6 +40,28 @@ type ObjectParseResult =
 // Timeout for header and subsequent objects
 const DATA_STREAM_TIMEOUT: Duration = Duration::from_secs(15);
 const MTU_SIZE: usize = 1500; // Standard MTU size
+
+fn validate_fetch_subgroup_priority(
+  payload: &FetchObjectPayload,
+  subgroup_priorities: &mut HashMap<u64, u8>,
+) -> Result<(), ParseError> {
+  if payload.forwarding_preference != ObjectForwardingPreference::Subgroup {
+    return Ok(());
+  }
+
+  match subgroup_priorities.insert(payload.subgroup_id, payload.publisher_priority) {
+    Some(previous_priority) if previous_priority != payload.publisher_priority => {
+      Err(ParseError::ProtocolViolation {
+        context: "RecvDataStream::read_object(fetch_malformed_track)",
+        details: format!(
+          "FETCH object for subgroup_id {} changed publisher_priority from {} to {}",
+          payload.subgroup_id, previous_priority, payload.publisher_priority
+        ),
+      })
+    }
+    _ => Ok(()),
+  }
+}
 
 // Stores the context derived from the initial header message
 #[derive(Debug, Clone)]
@@ -244,6 +266,7 @@ pub struct RecvDataStream {
   pending_fetches: Arc<RwLock<BTreeMap<u64, FetchRequest>>>, // Mutable borrow to potentially remove entry
   objects: Arc<RwLock<VecDeque<Object>>>,                    // Buffer for parsed objects
   is_closed: Arc<AtomicBool>,
+  malformed_track: Arc<AtomicBool>,
   started_read_task: Arc<AtomicBool>,
   notify: Arc<Notify>,
 }
@@ -259,9 +282,14 @@ impl RecvDataStream {
       pending_fetches,
       objects: Arc::new(RwLock::new(VecDeque::new())), // Initialize the object buffer
       is_closed: Arc::new(AtomicBool::new(false)),
+      malformed_track: Arc::new(AtomicBool::new(false)),
       started_read_task: Arc::new(AtomicBool::new(false)),
       notify: Arc::new(Notify::new()),
     }
+  }
+
+  pub fn is_malformed_track(&self) -> bool {
+    self.malformed_track.load(Ordering::Relaxed)
   }
 
   pub async fn get_header_info(&self) -> Option<HeaderInfo> {
@@ -276,6 +304,7 @@ impl RecvDataStream {
     the_header_info: Arc<Mutex<Option<HeaderInfo>>>,
     pending_fetches: Arc<RwLock<BTreeMap<u64, FetchRequest>>>,
     objects: Arc<RwLock<VecDeque<Object>>>,
+    malformed_track: Arc<AtomicBool>,
     notify: Arc<Notify>,
   ) -> Result<(), RecvDataStreamReadError> {
     let mut header_info = None;
@@ -285,6 +314,7 @@ impl RecvDataStream {
 
     let mut previous_object_id: Option<u64> = None;
     let mut fetch_prev_ctx: Option<FetchObjectContext> = None;
+    let mut fetch_subgroup_priorities: HashMap<u64, u8> = HashMap::new();
 
     loop {
       let bytes_cursor = recv_bytes.clone().freeze();
@@ -322,6 +352,8 @@ impl RecvDataStream {
             objects.clone(),
             &previous_object_id,
             &fetch_prev_ctx,
+            &mut fetch_subgroup_priorities,
+            malformed_track.clone(),
           )
           .await
           .map_err(|e| {
@@ -485,6 +517,8 @@ impl RecvDataStream {
     objects: Arc<RwLock<VecDeque<Object>>>,
     previous_object_id: &Option<u64>,
     fetch_prev_ctx: &Option<FetchObjectContext>,
+    fetch_subgroup_priorities: &mut HashMap<u64, u8>,
+    malformed_track: Arc<AtomicBool>,
   ) -> Result<(usize, Option<u64>, Option<FetchObjectContext>), ParseError> {
     if !bytes_cursor.is_empty() {
       let original_remaining = bytes_cursor.remaining();
@@ -496,6 +530,12 @@ impl RecvDataStream {
               let new_ctx = fetch_obj.context();
               match fetch_obj {
                 FetchObject::Object(payload) => {
+                  if let Err(e) =
+                    validate_fetch_subgroup_priority(&payload, fetch_subgroup_priorities)
+                  {
+                    malformed_track.store(true, Ordering::Relaxed);
+                    return Err(e);
+                  }
                   // TODO: Get track alias from fetch_request
                   let object = Object::try_from_fetch(payload, 0)?;
                   Ok((None, new_ctx, Some(object)))
@@ -566,6 +606,7 @@ impl RecvDataStream {
     {
       let recv_stream = self.recv_stream.clone();
       let is_closed = self.is_closed.clone();
+      let malformed_track = self.malformed_track.clone();
       let pending_fetches = self.pending_fetches.clone();
       let objects = self.objects.clone();
       let header_info = self.header_info.clone();
@@ -580,6 +621,7 @@ impl RecvDataStream {
           header_info,
           pending_fetches,
           objects,
+          malformed_track,
           notify,
         )
         .await


### PR DESCRIPTION
When reading a FETCH response stream, we now remember the Publisher Priority used for each Subgroup ID. We do not decide what the client or relay should do next in this commit. We only detect the malformed condition and records it so later commits can take action.
