### PR TITLE
fix(relay): send wt-protocol response header with RFC 8941 quoting

### DIFF
--- a/.changeset/relay-wt-protocol-response-header.md
+++ b/.changeset/relay-wt-protocol-response-header.md
@@ -1,0 +1,5 @@
+---
+'relay': patch
+---
+
+Send the negotiated WebTransport subprotocol back to the client. The relay built the `wt-protocol` response header but then called `accept()`, which discards it — the extended-CONNECT 200 response carried no `wt-protocol` header at all, and the value was also formatted as a bare token instead of the RFC 8941 quoted sf-string form. Clients that require the subprotocol echo fail version negotiation against the relay. The relay now replies via `accept_with_headers()` with the selected version in quoted form (e.g. `"moqt-16"`), matching the quoted items the client offered in `wt-available-protocols`.

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -95,12 +95,17 @@ impl Session {
       }
     };
 
-    let mut response_headers: HashMap<String, String> = HashMap::new();
-    response_headers.insert("wt-protocol".to_string(), selected_version);
+    let response_headers = Self::wt_protocol_response_headers(&selected_version);
 
-    // in the headers, we expect wt-available-protocols
-
-    let connection = TransportConnection::WebTransport(session_request.accept().await?);
+    // accept_with_headers(), not accept(): accept() replies 200 without any
+    // extra headers, so the negotiated subprotocol would never be echoed back
+    // and clients that require the `wt-protocol` response header fail version
+    // negotiation.
+    let connection = TransportConnection::WebTransport(
+      session_request
+        .accept_with_headers(response_headers)
+        .await?,
+    );
     Self::start(connection, server).await
   }
 
@@ -807,6 +812,19 @@ impl Session {
     })
   }
 
+  /// Builds the extended-CONNECT response headers that echo the negotiated
+  /// WebTransport subprotocol back to the client. `wt-protocol` is an RFC 8941
+  /// sf-string and must be serialized in quoted form (e.g. `"moqt-16"`),
+  /// matching the quoted items the client sent in `wt-available-protocols`.
+  /// Strict clients reject the bare-token form as an invalid Structured Field
+  /// and tear down the CONNECT.
+  fn wt_protocol_response_headers(selected_version: &str) -> HashMap<String, String> {
+    HashMap::from([(
+      "wt-protocol".to_string(),
+      format!("\"{}\"", selected_version),
+    )])
+  }
+
   async fn negotiate(
     context: Arc<SessionContext>,
     control_stream_handler: &mut ControlStreamHandler,
@@ -909,5 +927,39 @@ impl Session {
         Err(TerminationCode::InternalError)
       }
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn wt_protocol_response_header_is_sf_quoted() {
+    let headers = Session::wt_protocol_response_headers("moqt-16");
+    assert_eq!(
+      headers.get("wt-protocol").map(String::as_str),
+      Some("\"moqt-16\"")
+    );
+  }
+
+  #[test]
+  fn wt_protocol_response_header_echoes_client_quoted_item() {
+    // Round-trip: the response header must carry the exact quoted sf-string
+    // item the client offered in wt-available-protocols.
+    let mut request_headers = HashMap::new();
+    request_headers.insert(
+      "wt-available-protocols".to_string(),
+      "\"moqt-16\", \"moqt-15\"".to_string(),
+    );
+
+    let client_protocols = Session::parse_available_protocols(&request_headers);
+    let selected = Session::select_protocol(&client_protocols).expect("moqt-16 is supported");
+    let response_headers = Session::wt_protocol_response_headers(selected);
+
+    assert!(
+      client_protocols.contains(response_headers.get("wt-protocol").unwrap()),
+      "response wt-protocol must match one of the client's quoted offers"
+    );
   }
 }


### PR DESCRIPTION
## Bug

`Session::accept_webtransport` builds the `wt-protocol` response header and
then throws it away:

- `apps/relay/src/server/session.rs:98-99` (main @ 4d5f001): `response_headers`
  is populated with `wt-protocol: <selected_version>` …
- `apps/relay/src/server/session.rs:103`: … but the accept call is
  `session_request.accept()`, which takes no arguments — the extended-CONNECT
  `200` response is sent with no `wt-protocol` header at all, and the HashMap
  is silently dropped (no compiler warning, since `insert` "uses" it).

Two defects hide in those lines:

1. **The header is never sent.** `wtransport` (the pinned 0.7.1) has
   `SessionRequest::accept_with_headers()` for exactly this.
2. **The value is a bare token.** `wt-protocol` is an RFC 8941 Structured
   Field sf-string per the WebTransport-HTTP/3 subprotocol negotiation, so
   the serialized form must be quoted: `"moqt-16"`, not `moqt-16`. The relay
   already expects the quoted form from clients — `select_protocol`
   (`apps/relay/src/server/session.rs:801-808`) matches offers against
   `format!("\"{}\"", v)`, and the repo's own Rust client sends quoted items
   (`apps/client/src/connection.rs:137-144`, "strings should be surrounded by
   quotes") — so the response side was asymmetric.

## Interop impact

- Browser clients pass `protocols: [...]` to `new WebTransport(url, opts)`
  (as `libs/moqtail-ts/src/client/client.ts:446-453` does). The selection is
  surfaced via `WebTransport.protocol`, parsed from the `wt-protocol`
  response header as a Structured Field. With no echoed header the session
  reports no negotiated subprotocol; clients that key MOQT version selection
  off it cannot proceed.
- Rust MoQ clients in the `web-transport-quinn` family read the response
  header to learn the negotiated protocol. Missing header ⇒ `protocol =
  None` ⇒ version negotiation fails (surfaces as e.g. `connect error:
  unsupported versions` from moq-rs/libmoq-based publishers even though the
  CONNECT itself completed).
- Strict Structured-Field parsers (e.g. `web-transport-proto`'s `sfv`
  parser) reject the bare-token form outright as an invalid `wt-protocol`
  header and tear down the CONNECT — so even a naive "just send the string"
  fix would still break these clients without the quoting.

The in-repo `apps/client` doesn't currently read the response header, which
is why this isn't visible in same-repo testing.

## Fix

- Reply via `session_request.accept_with_headers(response_headers)`.
- Serialize the value in RFC 8941 quoted form, via a small
  `wt_protocol_response_headers()` helper so it's unit-testable.
- Remove the stale `// in the headers, we expect wt-available-protocols`
  comment (request parsing happens earlier, in `parse_available_protocols`).

## Tests

- `wt_protocol_response_header_is_sf_quoted` — asserts the header value is
  the quoted sf-string (`"moqt-16"`).
- `wt_protocol_response_header_echoes_client_quoted_item` — round-trip
  through `parse_available_protocols` → `select_protocol` →
  `wt_protocol_response_headers`, asserting the response value is exactly
  one of the client's quoted offers.

Ran locally (macOS, stable toolchain):

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p relay --all-targets --all-features -- -D warnings` — clean
- `cargo test -p relay` — 32 passed, 0 failed (includes the 2 new tests)

Changeset included (`'relay': patch`).
