### PR TITLE
refactor(moqtail-rs): rename Extension Headers to Properties

### DIFF
--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -308,7 +308,7 @@ async fn send_datagrams(
         group_id,
         object_id,
         Some(publisher_priority), // publisher_priority
-        None,                     // extension_headers
+        None,                     // properties
         Bytes::from(payload),
         false, // end_of_group
       );
@@ -380,7 +380,7 @@ async fn send_via_streams(
 
       let subgroup_obj = SubgroupObject {
         object_id,
-        extension_headers: Some(vec![]),
+        properties: Some(vec![]),
         object_status: None,
         payload: Some(Bytes::from(payload)),
       };

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -138,7 +138,7 @@ pub async fn handle(
           track
             .add_publisher(context.connection_id, track_alias)
             .await;
-          track.set_track_extensions(m.track_extensions.clone()).await;
+          track.set_track_properties(m.track_properties.clone()).await;
         }
 
         client

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -209,7 +209,7 @@ async fn handle_subscribe_message(
           "Track confirmed, sending SubscribeOk to subscriber {}",
           client.connection_id
         );
-        let cached_extensions = { track.track_extensions.read().await.clone() };
+        let cached_properties = { track.track_properties.read().await.clone() };
         let largest_loc = {
           let ll = track.largest_location.read().await;
           Location::new(ll.group, ll.object)
@@ -220,7 +220,7 @@ async fn handle_subscribe_message(
           sub.request_id,
           track.relay_track_id,
           params,
-          cached_extensions,
+          cached_properties,
         );
         control_stream_handler.send_impl(&subscribe_ok).await
       }
@@ -328,7 +328,7 @@ async fn handle_subscribe_ok_message(
         context.connection_id,
         msg.track_alias,
         msg.subscribe_parameters.clone(),
-        msg.track_extensions.clone(),
+        msg.track_properties.clone(),
       )
       .await;
     track.relay_track_id
@@ -351,15 +351,15 @@ async fn handle_subscribe_ok_message(
       mngr.get(sub_request.requested_by).await
     };
     if let Some(subscriber) = subscriber {
-      let cached_extensions = {
+      let cached_properties = {
         let track = track_arc.read().await;
-        track.track_extensions.read().await.clone()
+        track.track_properties.read().await.clone()
       };
       let subscribe_ok = moqtail::model::control::subscribe_ok::SubscribeOk::new(
         sub_request.original_request_id,
         relay_track_id,
         msg.subscribe_parameters.clone(),
-        cached_extensions,
+        cached_properties,
       );
       info!(
         "sending SubscribeOk to creator subscriber: {:?}",
@@ -390,15 +390,15 @@ async fn handle_subscribe_ok_message(
         mngr.get(subscriber_connection_id).await
       };
       if let Some(subscriber) = subscriber {
-        let cached_extensions = {
+        let cached_properties = {
           let track = track_arc.read().await;
-          track.track_extensions.read().await.clone()
+          track.track_properties.read().await.clone()
         };
         let subscribe_ok = moqtail::model::control::subscribe_ok::SubscribeOk::new(
           subscriber_request_id,
           relay_track_id,
           msg.subscribe_parameters.clone(),
-          cached_extensions,
+          cached_properties,
         );
         info!(
           "sending SubscribeOk to pending subscriber: {:?}",

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -422,7 +422,7 @@ impl Subscription {
 
                           // TODO: check this. If is_some returns true, we may not need
                           // to check the length.
-                          let has_extensions = object.extension_headers.as_ref().is_some();
+                          let has_properties = object.properties.as_ref().is_some();
 
                           // create a fake subgroup header using the object attributes
                           // TODO: It think contains_end_of_group should be checked by looking at
@@ -433,7 +433,7 @@ impl Subscription {
                               object.group_id,
                               object.subgroup_id,
                               Some(object.publisher_priority),
-                              has_extensions,
+                              has_properties,
                               false,
                             ),
                           };
@@ -1207,8 +1207,8 @@ impl Subscription {
     // This loop will keep the stream open and process incoming objects
     // TODO: revisit this logic to handle also fetch requests
     if let Ok(sub_object) = object.try_into_subgroup() {
-      let has_extensions = sub_object.extension_headers.is_some();
-      let object_bytes = match sub_object.serialize(previous_object_id, has_extensions) {
+      let has_properties = sub_object.properties.is_some();
+      let object_bytes = match sub_object.serialize(previous_object_id, has_properties) {
         Ok(data) => data,
         Err(e) => {
           error!(

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -27,8 +27,8 @@ use moqtail::model::control::constant::RequestErrorCode;
 use moqtail::model::data::datagram::Datagram;
 use moqtail::model::data::full_track_name::FullTrackName;
 use moqtail::model::data::object::Object;
-use moqtail::model::extension_header::track_extension::TrackExtension;
 use moqtail::model::parameter::message_parameter::MessageParameter;
+use moqtail::model::property::track_property::TrackProperty;
 use moqtail::transport::data_stream_handler::HeaderInfo;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -88,8 +88,8 @@ pub struct Track {
   pub status_notify: Arc<Notify>,
   /// Subscribers waiting for track confirmation: (request_id, connection_id).
   pub pending_subscribers: Arc<RwLock<Vec<(u64, usize)>>>,
-  /// Cached track extensions from PUBLISH or SUBSCRIBE_OK (relays MUST cache).
-  pub track_extensions: Arc<RwLock<Vec<TrackExtension>>>,
+  /// Cached track properties from PUBLISH or SUBSCRIBE_OK (relays MUST cache).
+  pub track_properties: Arc<RwLock<Vec<TrackProperty>>>,
   /// Original subgroup headers for open publisher streams, keyed by stream_id.
   /// Used so new mid-group subscribers can open a QUIC send stream
   /// Inserted when the first object of a subgroup arrives; removed when the
@@ -123,7 +123,7 @@ impl Track {
       status: Arc::new(RwLock::new(initial_status)),
       status_notify: Arc::new(Notify::new()),
       pending_subscribers: Arc::new(RwLock::new(Vec::new())),
-      track_extensions: Arc::new(RwLock::new(Vec::new())),
+      track_properties: Arc::new(RwLock::new(Vec::new())),
       active_subgroup_headers: Arc::new(RwLock::new(HashMap::new())),
     }
   }
@@ -175,7 +175,7 @@ impl Track {
     publisher_connection_id: usize,
     publisher_track_alias: u64,
     subscribe_parameters: Vec<MessageParameter>,
-    extensions: Vec<TrackExtension>,
+    properties: Vec<TrackProperty>,
   ) {
     {
       let mut aliases = self.publisher_aliases.write().await;
@@ -186,7 +186,7 @@ impl Track {
       subscribe_parameters,
     };
     drop(status);
-    *self.track_extensions.write().await = extensions;
+    *self.track_properties.write().await = properties;
     self.status_notify.notify_waiters();
 
     info!(
@@ -195,9 +195,9 @@ impl Track {
     );
   }
 
-  /// Updates the cached track extensions (per spec: most recent set replaces any previous).
-  pub async fn set_track_extensions(&self, extensions: Vec<TrackExtension>) {
-    *self.track_extensions.write().await = extensions;
+  /// Updates the cached track properties (per spec: most recent set replaces any previous).
+  pub async fn set_track_properties(&self, properties: Vec<TrackProperty>) {
+    *self.track_properties.write().await = properties;
   }
 
   /// Transition from Pending to Rejected. Notifies waiters.

--- a/docs/draft16to18tasks.md
+++ b/docs/draft16to18tasks.md
@@ -465,7 +465,7 @@ extraction remains.
 > 📎 **A.2 : 7401** — "Copy DELIVERY_TIMEOUT min requirement from parameter to property (#1427)"
 
 - **Files:** `model/parameter/constant.rs` (`MessageParameterType`);
-  `model/extension_header/constant.rs:55-63` (`TrackExtensionType`)
+  `model/property/constant.rs:55-63` (`TrackPropertyType`) — renamed by RS-8
 - **Change — Parameters** (vs §15.7; current enum has 9 of 13):
   | Type | Name | Status |
   |---|---|---|

--- a/libs/moqtail-rs/src/model.rs
+++ b/libs/moqtail-rs/src/model.rs
@@ -17,5 +17,5 @@ pub mod common;
 pub mod control;
 pub mod data;
 pub mod error;
-pub mod extension_header;
 pub mod parameter;
+pub mod property;

--- a/libs/moqtail-rs/src/model/control/fetch_ok.rs
+++ b/libs/moqtail-rs/src/model/control/fetch_ok.rs
@@ -17,11 +17,11 @@ use super::control_message::ControlMessageTrait;
 use crate::model::common::location::Location;
 use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::error::ParseError;
-use crate::model::extension_header::track_extension::{
-  TrackExtension, deserialize_track_extensions, serialize_track_extensions,
-};
 use crate::model::parameter::message_parameter::{
   MessageParameter, deserialize_message_parameters, serialize_message_parameters,
+};
+use crate::model::property::track_property::{
+  TrackProperty, deserialize_track_properties, serialize_track_properties,
 };
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
@@ -31,7 +31,7 @@ pub struct FetchOk {
   pub end_of_track: bool,
   pub end_location: Location,
   pub subscribe_parameters: Vec<MessageParameter>,
-  pub track_extensions: Vec<TrackExtension>,
+  pub track_properties: Vec<TrackProperty>,
 }
 
 impl FetchOk {
@@ -40,14 +40,14 @@ impl FetchOk {
     end_of_track: bool,
     end_location: Location,
     subscribe_parameters: Vec<MessageParameter>,
-    track_extensions: Vec<TrackExtension>,
+    track_properties: Vec<TrackProperty>,
   ) -> Self {
     Self {
       request_id,
       end_of_track,
       end_location,
       subscribe_parameters,
-      track_extensions,
+      track_properties,
     }
   }
 }
@@ -64,8 +64,8 @@ impl ControlMessageTrait for FetchOk {
     payload.put_vi(self.subscribe_parameters.len())?;
     payload.extend_from_slice(&serialize_message_parameters(&self.subscribe_parameters)?);
 
-    // Track Extensions (no length prefix; bounded by outer message Length field)
-    payload.extend_from_slice(&serialize_track_extensions(&self.track_extensions)?);
+    // Track Properties (no length prefix; bounded by outer message Length field)
+    payload.extend_from_slice(&serialize_track_properties(&self.track_properties)?);
 
     let payload_len: u16 = payload
       .len()
@@ -109,15 +109,15 @@ impl ControlMessageTrait for FetchOk {
     let subscribe_parameters =
       deserialize_message_parameters(payload, param_count, ControlMessageType::FetchOk)?;
 
-    // Track Extensions: consume whatever remains in the payload
-    let track_extensions = deserialize_track_extensions(payload)?;
+    // Track Properties: consume whatever remains in the payload
+    let track_properties = deserialize_track_properties(payload)?;
 
     Ok(Box::new(FetchOk {
       request_id,
       end_of_track,
       end_location,
       subscribe_parameters,
-      track_extensions,
+      track_properties,
     }))
   }
 
@@ -143,7 +143,7 @@ mod tests {
         object: 57,
       },
       subscribe_parameters: vec![],
-      track_extensions: vec![],
+      track_properties: vec![],
     };
     let mut buf = fetch_ok.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();
@@ -165,7 +165,7 @@ mod tests {
         object: 57,
       },
       subscribe_parameters: vec![MessageParameter::new_group_order(GroupOrder::Ascending)],
-      track_extensions: vec![],
+      track_properties: vec![],
     };
     let mut buf = fetch_ok.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();
@@ -178,7 +178,7 @@ mod tests {
   }
 
   #[test]
-  fn test_roundtrip_with_track_extensions() {
+  fn test_roundtrip_with_track_properties() {
     let fetch_ok = FetchOk {
       request_id: 12345,
       end_of_track: false,
@@ -187,9 +187,9 @@ mod tests {
         object: 0,
       },
       subscribe_parameters: vec![],
-      track_extensions: vec![
-        TrackExtension::MaxCacheDuration { duration_ms: 60000 },
-        TrackExtension::DefaultPublisherGroupOrder {
+      track_properties: vec![
+        TrackProperty::MaxCacheDuration { duration_ms: 60000 },
+        TrackProperty::DefaultPublisherGroupOrder {
           order: GroupOrder::Ascending,
         },
       ],
@@ -214,7 +214,7 @@ mod tests {
         object: 57,
       },
       subscribe_parameters: vec![],
-      track_extensions: vec![],
+      track_properties: vec![],
     };
 
     let serialized = fetch_ok.serialize().unwrap();
@@ -245,7 +245,7 @@ mod tests {
         object: 57,
       },
       subscribe_parameters: vec![],
-      track_extensions: vec![],
+      track_properties: vec![],
     };
     let mut buf = fetch_ok.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();

--- a/libs/moqtail-rs/src/model/control/publish.rs
+++ b/libs/moqtail-rs/src/model/control/publish.rs
@@ -17,11 +17,11 @@ use super::control_message::ControlMessageTrait;
 use crate::model::common::tuple::{Tuple, TupleField};
 use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::error::ParseError;
-use crate::model::extension_header::track_extension::{
-  TrackExtension, deserialize_track_extensions, serialize_track_extensions,
-};
 use crate::model::parameter::message_parameter::{
   MessageParameter, deserialize_message_parameters, serialize_message_parameters,
+};
+use crate::model::property::track_property::{
+  TrackProperty, deserialize_track_properties, serialize_track_properties,
 };
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
@@ -32,7 +32,7 @@ pub struct Publish {
   pub track_name: TupleField,
   pub track_alias: u64,
   pub parameters: Vec<MessageParameter>,
-  pub track_extensions: Vec<TrackExtension>,
+  pub track_properties: Vec<TrackProperty>,
 }
 
 impl Publish {
@@ -42,7 +42,7 @@ impl Publish {
     track_name: TupleField,
     track_alias: u64,
     parameters: Vec<MessageParameter>,
-    track_extensions: Vec<TrackExtension>,
+    track_properties: Vec<TrackProperty>,
   ) -> Self {
     Self {
       request_id,
@@ -50,7 +50,7 @@ impl Publish {
       track_name,
       track_alias,
       parameters,
-      track_extensions,
+      track_properties,
     }
   }
 }
@@ -74,8 +74,8 @@ impl ControlMessageTrait for Publish {
     payload.put_vi(self.parameters.len() as u64)?;
     payload.extend_from_slice(&serialize_message_parameters(&self.parameters)?);
 
-    // Track Extensions (no length prefix; bounded by outer message Length field)
-    payload.extend_from_slice(&serialize_track_extensions(&self.track_extensions)?);
+    // Track Properties (no length prefix; bounded by outer message Length field)
+    payload.extend_from_slice(&serialize_track_properties(&self.track_properties)?);
 
     let payload_len: u16 = payload
       .len()
@@ -113,8 +113,8 @@ impl ControlMessageTrait for Publish {
     let parameters =
       deserialize_message_parameters(payload, param_count, ControlMessageType::Publish)?;
 
-    // Track Extensions: consume whatever remains in the payload
-    let track_extensions = deserialize_track_extensions(payload)?;
+    // Track Properties: consume whatever remains in the payload
+    let track_properties = deserialize_track_properties(payload)?;
 
     Ok(Box::new(Publish {
       request_id,
@@ -122,7 +122,7 @@ impl ControlMessageTrait for Publish {
       track_name,
       track_alias,
       parameters,
-      track_extensions,
+      track_properties,
     }))
   }
 
@@ -136,8 +136,8 @@ mod tests {
   use super::*;
   use crate::model::common::location::Location;
   use crate::model::control::constant::GroupOrder;
-  use crate::model::extension_header::track_extension::TrackExtension;
   use crate::model::parameter::message_parameter::MessageParameter;
+  use crate::model::property::track_property::TrackProperty;
   use bytes::Buf;
 
   #[test]
@@ -190,7 +190,7 @@ mod tests {
   }
 
   #[test]
-  fn test_roundtrip_with_track_extensions() {
+  fn test_roundtrip_with_track_properties() {
     let publish = Publish::new(
       1,
       Tuple::from_utf8_path("ns/track"),
@@ -198,8 +198,8 @@ mod tests {
       7,
       vec![],
       vec![
-        TrackExtension::DeliveryTimeout { timeout_ms: 3000 },
-        TrackExtension::DefaultPublisherPriority { priority: 100 },
+        TrackProperty::DeliveryTimeout { timeout_ms: 3000 },
+        TrackProperty::DefaultPublisherPriority { priority: 100 },
       ],
     );
 

--- a/libs/moqtail-rs/src/model/control/subscribe_ok.rs
+++ b/libs/moqtail-rs/src/model/control/subscribe_ok.rs
@@ -16,11 +16,11 @@ use super::constant::ControlMessageType;
 use super::control_message::ControlMessageTrait;
 use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::error::ParseError;
-use crate::model::extension_header::track_extension::{
-  TrackExtension, deserialize_track_extensions, serialize_track_extensions,
-};
 use crate::model::parameter::message_parameter::{
   MessageParameter, deserialize_message_parameters, serialize_message_parameters,
+};
+use crate::model::property::track_property::{
+  TrackProperty, deserialize_track_properties, serialize_track_properties,
 };
 use bytes::{BufMut, Bytes, BytesMut};
 
@@ -29,7 +29,7 @@ pub struct SubscribeOk {
   pub request_id: u64,
   pub track_alias: u64,
   pub subscribe_parameters: Vec<MessageParameter>,
-  pub track_extensions: Vec<TrackExtension>,
+  pub track_properties: Vec<TrackProperty>,
 }
 
 impl SubscribeOk {
@@ -37,13 +37,13 @@ impl SubscribeOk {
     request_id: u64,
     track_alias: u64,
     subscribe_parameters: Vec<MessageParameter>,
-    track_extensions: Vec<TrackExtension>,
+    track_properties: Vec<TrackProperty>,
   ) -> Self {
     Self {
       request_id,
       track_alias,
       subscribe_parameters,
-      track_extensions,
+      track_properties,
     }
   }
 }
@@ -60,8 +60,8 @@ impl ControlMessageTrait for SubscribeOk {
     payload.put_vi(self.subscribe_parameters.len() as u64)?;
     payload.extend_from_slice(&serialize_message_parameters(&self.subscribe_parameters)?);
 
-    // Track Extensions (no length prefix; bounded by outer message Length field)
-    payload.extend_from_slice(&serialize_track_extensions(&self.track_extensions)?);
+    // Track Properties (no length prefix; bounded by outer message Length field)
+    payload.extend_from_slice(&serialize_track_properties(&self.track_properties)?);
 
     let payload_len: u16 = payload
       .len()
@@ -87,14 +87,14 @@ impl ControlMessageTrait for SubscribeOk {
     let subscribe_parameters =
       deserialize_message_parameters(payload, param_count, ControlMessageType::SubscribeOk)?;
 
-    // Track Extensions: consume whatever remains in the payload
-    let track_extensions = deserialize_track_extensions(payload)?;
+    // Track Properties: consume whatever remains in the payload
+    let track_properties = deserialize_track_properties(payload)?;
 
     Ok(Box::new(SubscribeOk {
       request_id,
       track_alias,
       subscribe_parameters,
-      track_extensions,
+      track_properties,
     }))
   }
 
@@ -108,7 +108,7 @@ mod tests {
   use super::*;
   use crate::model::common::location::Location;
   use crate::model::control::constant::GroupOrder;
-  use crate::model::extension_header::track_extension::TrackExtension;
+  use crate::model::property::track_property::TrackProperty;
   use bytes::Buf;
 
   #[test]
@@ -125,7 +125,7 @@ mod tests {
         }),
         MessageParameter::new_expires(100),
       ],
-      track_extensions: vec![],
+      track_properties: vec![],
     };
     // Wire encoding canonicalizes parameter order ascending by type (delta-encoding requirement).
     subscribe_ok
@@ -143,7 +143,7 @@ mod tests {
   }
 
   #[test]
-  fn test_roundtrip_with_track_extensions() {
+  fn test_roundtrip_with_track_properties() {
     let subscribe_ok = SubscribeOk {
       request_id: 999,
       track_alias: 42,
@@ -151,9 +151,9 @@ mod tests {
         MessageParameter::new_expires(0),
         MessageParameter::new_group_order(GroupOrder::Descending),
       ],
-      track_extensions: vec![
-        TrackExtension::DeliveryTimeout { timeout_ms: 500 },
-        TrackExtension::DynamicGroups { enabled: true },
+      track_properties: vec![
+        TrackProperty::DeliveryTimeout { timeout_ms: 500 },
+        TrackProperty::DynamicGroups { enabled: true },
       ],
     };
 
@@ -179,7 +179,7 @@ mod tests {
           object: 0,
         }),
       ],
-      track_extensions: vec![],
+      track_properties: vec![],
     };
 
     let serialized = subscribe_ok.serialize().unwrap();
@@ -212,7 +212,7 @@ mod tests {
           object: 0,
         }),
       ],
-      track_extensions: vec![],
+      track_properties: vec![],
     };
     let mut buf = subscribe_ok.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();

--- a/libs/moqtail-rs/src/model/data/constant.rs
+++ b/libs/moqtail-rs/src/model/data/constant.rs
@@ -23,7 +23,7 @@ pub enum FetchHeaderType {
 /// Subgroup Header Type
 ///
 /// Type bit layout (0b00X1XXXX):
-/// - Bit 0 (0x01): EXTENSIONS - Extensions present in all objects
+/// - Bit 0 (0x01): PROPERTIES - Properties present in all objects
 /// - Bits 1-2 (0x06): SUBGROUP_ID_MODE - How subgroup ID is encoded
 ///   - 0b00 (0x00): Subgroup ID = 0 (absent from header)
 ///   - 0b01 (0x02): Subgroup ID = First Object ID (absent from header)
@@ -39,8 +39,8 @@ pub enum FetchHeaderType {
 pub struct SubgroupHeaderType(u8);
 
 impl SubgroupHeaderType {
-  /// Extensions present in all objects (bit 0)
-  pub const EXTENSIONS: u8 = 0x01;
+  /// Properties present in all objects (bit 0)
+  pub const PROPERTIES: u8 = 0x01;
   /// Mask for SUBGROUP_ID_MODE (bits 1-2)
   pub const SUBGROUP_ID_MODE_MASK: u8 = 0x06;
   /// This subgroup contains the final object in the group (bit 3)
@@ -83,9 +83,9 @@ impl SubgroupHeaderType {
     self.0
   }
 
-  /// Check if extensions are present (bit 0 set)
-  pub fn has_extensions(&self) -> bool {
-    self.0 & Self::EXTENSIONS != 0
+  /// Check if properties are present (bit 0 set)
+  pub fn has_properties(&self) -> bool {
+    self.0 & Self::PROPERTIES != 0
   }
 
   /// Check if subgroup ID is explicit in header (SUBGROUP_ID_MODE = 0b10)
@@ -117,14 +117,14 @@ impl SubgroupHeaderType {
   /// Create type from property flags.
   /// subgroup_id_mode: 0=zero, 1=firstObjId, 2=explicit
   pub fn from_properties(
-    has_extensions: bool,
+    has_properties: bool,
     subgroup_id_mode: u8,
     contains_end_of_group: bool,
     has_default_priority: bool,
   ) -> Self {
     let mut v: u8 = Self::REQUIRED_BIT;
-    if has_extensions {
-      v |= Self::EXTENSIONS;
+    if has_properties {
+      v |= Self::PROPERTIES;
     }
     v |= (subgroup_id_mode & 0x03) << 1; // bits 1-2
     if contains_end_of_group {
@@ -195,7 +195,7 @@ impl From<ObjectStatus> for u64 {
 /// Draft-16 Object Datagram Type (bitmask newtype).
 ///
 /// Type bit layout (form `0b00X0XXXX`):
-/// - Bit 0 (0x01): EXTENSIONS — Extensions field present
+/// - Bit 0 (0x01): PROPERTIES — Properties field present
 /// - Bit 1 (0x02): END_OF_GROUP — Last object in group
 /// - Bit 2 (0x04): ZERO_OBJECT_ID — Object ID omitted (assumed 0)
 /// - Bit 3 (0x08): DEFAULT_PRIORITY — Publisher Priority omitted (inherited)
@@ -208,7 +208,7 @@ impl From<ObjectStatus> for u64 {
 pub struct ObjectDatagramType(u8);
 
 impl ObjectDatagramType {
-  pub const EXTENSIONS: u8 = 0x01;
+  pub const PROPERTIES: u8 = 0x01;
   pub const END_OF_GROUP: u8 = 0x02;
   pub const ZERO_OBJECT_ID: u8 = 0x04;
   pub const DEFAULT_PRIORITY: u8 = 0x08;
@@ -240,9 +240,9 @@ impl ObjectDatagramType {
     self.0
   }
 
-  /// Check if extensions are present (bit 0).
-  pub fn has_extensions(&self) -> bool {
-    self.0 & Self::EXTENSIONS != 0
+  /// Check if properties are present (bit 0).
+  pub fn has_properties(&self) -> bool {
+    self.0 & Self::PROPERTIES != 0
   }
 
   /// Check if this is end of group (bit 1).
@@ -270,15 +270,15 @@ impl ObjectDatagramType {
   /// Create type from property flags.
   /// Returns error if STATUS and END_OF_GROUP are both true.
   pub fn from_properties(
-    has_extensions: bool,
+    has_properties: bool,
     end_of_group: bool,
     object_id_is_zero: bool,
     default_priority: bool,
     is_status: bool,
   ) -> Result<Self, ParseError> {
     let mut v: u8 = 0;
-    if has_extensions {
-      v |= Self::EXTENSIONS;
+    if has_properties {
+      v |= Self::PROPERTIES;
     }
     if end_of_group {
       v |= Self::END_OF_GROUP;

--- a/libs/moqtail-rs/src/model/data/datagram.rs
+++ b/libs/moqtail-rs/src/model/data/datagram.rs
@@ -16,8 +16,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::error::ParseError;
-use crate::model::extension_header::object_extension::{
-  ObjectExtension, deserialize_object_extensions, serialize_object_extensions,
+use crate::model::property::object_property::{
+  ObjectProperty, deserialize_object_properties, serialize_object_properties,
 };
 
 use super::constant::{ObjectDatagramType, ObjectStatus};
@@ -25,7 +25,7 @@ use super::constant::{ObjectDatagramType, ObjectStatus};
 /// Draft-16 unified Object Datagram.
 ///
 /// Type bit layout (form 0b00X0XXXX):
-/// - Bit 0 (0x01): EXTENSIONS - Extensions field present
+/// - Bit 0 (0x01): PROPERTIES - Properties field present
 /// - Bit 1 (0x02): END_OF_GROUP - Last object in group
 /// - Bit 2 (0x04): ZERO_OBJECT_ID - Object ID omitted (assumed 0)
 /// - Bit 3 (0x08): DEFAULT_PRIORITY - Publisher Priority omitted (inherited)
@@ -39,7 +39,7 @@ pub struct Datagram {
   pub group_id: u64,
   pub object_id: u64,
   pub publisher_priority: Option<u8>,
-  pub extension_headers: Option<Vec<ObjectExtension>>,
+  pub properties: Option<Vec<ObjectProperty>>,
   pub payload: Option<Bytes>,
   pub object_status: Option<ObjectStatus>,
   pub end_of_group: bool,
@@ -52,7 +52,7 @@ impl Datagram {
     group_id: u64,
     object_id: u64,
     publisher_priority: Option<u8>,
-    extension_headers: Option<Vec<ObjectExtension>>,
+    properties: Option<Vec<ObjectProperty>>,
     payload: Bytes,
     end_of_group: bool,
   ) -> Self {
@@ -61,7 +61,7 @@ impl Datagram {
       group_id,
       object_id,
       publisher_priority,
-      extension_headers,
+      properties,
       payload: Some(payload),
       object_status: None,
       end_of_group,
@@ -75,7 +75,7 @@ impl Datagram {
     group_id: u64,
     object_id: u64,
     publisher_priority: Option<u8>,
-    extension_headers: Option<Vec<ObjectExtension>>,
+    properties: Option<Vec<ObjectProperty>>,
     object_status: ObjectStatus,
   ) -> Self {
     Datagram {
@@ -83,14 +83,14 @@ impl Datagram {
       group_id,
       object_id,
       publisher_priority,
-      extension_headers,
+      properties,
       payload: None,
       object_status: Some(object_status),
       end_of_group: false,
     }
   }
 
-  /// Create a simple payload datagram without extensions.
+  /// Create a simple payload datagram without properties.
   pub fn new(
     track_alias: u64,
     group_id: u64,
@@ -103,7 +103,7 @@ impl Datagram {
       group_id,
       object_id,
       publisher_priority: Some(publisher_priority),
-      extension_headers: None,
+      properties: None,
       payload: Some(payload),
       object_status: None,
       end_of_group: false,
@@ -113,13 +113,13 @@ impl Datagram {
   pub fn serialize(&self) -> Result<Bytes, ParseError> {
     let mut buf = BytesMut::new();
 
-    let has_extensions = self.extension_headers.is_some();
+    let has_properties = self.properties.is_some();
     let object_id_is_zero = self.object_id == 0;
     let default_priority = self.publisher_priority.is_none();
     let is_status = self.object_status.is_some();
 
     let dtype = ObjectDatagramType::from_properties(
-      has_extensions,
+      has_properties,
       self.end_of_group,
       object_id_is_zero,
       default_priority,
@@ -141,9 +141,9 @@ impl Datagram {
       buf.put_u8(priority);
     }
 
-    // Write extension headers if present
-    if let Some(ext_headers) = &self.extension_headers {
-      let payload_buf = serialize_object_extensions(ext_headers)?;
+    // Write properties if present
+    if let Some(ext_headers) = &self.properties {
+      let payload_buf = serialize_object_properties(ext_headers)?;
       buf.put_vi(payload_buf.len())?;
       buf.extend_from_slice(&payload_buf);
     }
@@ -187,14 +187,14 @@ impl Datagram {
       None
     };
 
-    // Read extension headers if type indicates they're present
-    let extension_headers = if msg_type.has_extensions() {
+    // Read properties if type indicates they're present
+    let properties = if msg_type.has_properties() {
       let ext_len = bytes.get_vi()?;
 
       if ext_len == 0 {
         return Err(ParseError::ProtocolViolation {
-          context: "Datagram::deserialize(extension_length)",
-          details: "Extension headers present but length is 0".to_string(),
+          context: "Datagram::deserialize(properties_length)",
+          details: "Properties present but length is 0".to_string(),
         });
       }
 
@@ -210,14 +210,14 @@ impl Datagram {
 
       if bytes.remaining() < ext_len {
         return Err(ParseError::NotEnoughBytes {
-          context: "Datagram::deserialize(extension_headers)",
+          context: "Datagram::deserialize(properties)",
           needed: ext_len,
           available: bytes.remaining(),
         });
       }
 
       let mut header_bytes = bytes.copy_to_bytes(ext_len);
-      let headers = deserialize_object_extensions(&mut header_bytes).map_err(|e| {
+      let headers = deserialize_object_properties(&mut header_bytes).map_err(|e| {
         ParseError::ProtocolViolation {
           context: "Datagram::deserialize, can't parse headers",
           details: e.to_string(),
@@ -245,7 +245,7 @@ impl Datagram {
       group_id,
       object_id,
       publisher_priority,
-      extension_headers,
+      properties,
       payload,
       object_status,
       end_of_group,
@@ -272,7 +272,7 @@ mod tests {
     );
 
     let mut buf = datagram.serialize().unwrap();
-    // Type 0x00: no extensions, no end_of_group, object_id present, priority present, not status
+    // Type 0x00: no properties, no end_of_group, object_id present, priority present, not status
     assert_eq!(buf[0], 0x00);
 
     let deserialized = Datagram::deserialize(&mut buf).unwrap();
@@ -281,17 +281,17 @@ mod tests {
   }
 
   #[test]
-  fn test_roundtrip_payload_with_extensions() {
+  fn test_roundtrip_payload_with_properties() {
     let datagram = Datagram::new_payload(
       144,
       9,
       10,
       Some(255),
       Some(vec![
-        ObjectExtension::Unknown {
+        ObjectProperty::Unknown {
           kvp: KeyValuePair::try_new_varint(0, 10).unwrap(),
         },
-        ObjectExtension::Unknown {
+        ObjectProperty::Unknown {
           kvp: KeyValuePair::try_new_bytes(1, Bytes::from_static(b"wololoo")).unwrap(),
         },
       ]),
@@ -300,7 +300,7 @@ mod tests {
     );
 
     let mut buf = datagram.serialize().unwrap();
-    // Type 0x01: extensions present
+    // Type 0x01: properties present
     assert_eq!(buf[0], 0x01);
 
     let deserialized = Datagram::deserialize(&mut buf).unwrap();
@@ -376,13 +376,13 @@ mod tests {
 
   #[test]
   fn test_roundtrip_all_payload_flags() {
-    // extensions + end_of_group + zero_object_id + default_priority = 0x0F
+    // properties + end_of_group + zero_object_id + default_priority = 0x0F
     let datagram = Datagram::new_payload(
       1,
       5,
       0,
       None,
-      Some(vec![ObjectExtension::Unknown {
+      Some(vec![ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_varint(0, 42).unwrap(),
       }]),
       Bytes::from_static(b"payload"),
@@ -402,11 +402,11 @@ mod tests {
   }
 
   #[test]
-  fn test_roundtrip_status_without_extensions() {
+  fn test_roundtrip_status_without_properties() {
     let datagram = Datagram::new_status(144, 9, 10, Some(128), None, ObjectStatus::EndOfGroup);
 
     let mut buf = datagram.serialize().unwrap();
-    // Type 0x20: STATUS set, no extensions
+    // Type 0x20: STATUS set, no properties
     assert_eq!(buf[0], 0x20);
 
     let deserialized = Datagram::deserialize(&mut buf).unwrap();
@@ -415,17 +415,17 @@ mod tests {
   }
 
   #[test]
-  fn test_roundtrip_status_with_extensions() {
+  fn test_roundtrip_status_with_properties() {
     let datagram = Datagram::new_status(
       144,
       9,
       10,
       Some(255),
       Some(vec![
-        ObjectExtension::Unknown {
+        ObjectProperty::Unknown {
           kvp: KeyValuePair::try_new_varint(0, 10).unwrap(),
         },
-        ObjectExtension::Unknown {
+        ObjectProperty::Unknown {
           kvp: KeyValuePair::try_new_bytes(1, Bytes::from_static(b"wololoo")).unwrap(),
         },
       ]),
@@ -433,7 +433,7 @@ mod tests {
     );
 
     let mut buf = datagram.serialize().unwrap();
-    // Type 0x21: STATUS + extensions
+    // Type 0x21: STATUS + properties
     assert_eq!(buf[0], 0x21);
 
     let deserialized = Datagram::deserialize(&mut buf).unwrap();

--- a/libs/moqtail-rs/src/model/data/fetch_object.rs
+++ b/libs/moqtail-rs/src/model/data/fetch_object.rs
@@ -14,8 +14,8 @@
 
 use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::error::ParseError;
-use crate::model::extension_header::object_extension::{
-  ObjectExtension, deserialize_object_extensions, serialize_object_extensions,
+use crate::model::property::object_property::{
+  ObjectProperty, deserialize_object_properties, serialize_object_properties,
 };
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
@@ -26,7 +26,7 @@ const FLAG_SUBGROUP_MODE_MASK: u8 = 0x03;
 const FLAG_OBJECT_ID_PRESENT: u8 = 0x04;
 const FLAG_GROUP_ID_PRESENT: u8 = 0x08;
 const FLAG_PRIORITY_PRESENT: u8 = 0x10;
-const FLAG_EXTENSIONS_PRESENT: u8 = 0x20;
+const FLAG_PROPERTIES_PRESENT: u8 = 0x20;
 const FLAG_DATAGRAM: u8 = 0x40;
 
 const SUBGROUP_MODE_ZERO: u8 = 0b00;
@@ -74,7 +74,7 @@ pub struct FetchObjectPayload {
   pub object_id: u64,
   pub publisher_priority: u8,
   pub forwarding_preference: ObjectForwardingPreference,
-  pub extension_headers: Option<Vec<ObjectExtension>>,
+  pub properties: Option<Vec<ObjectProperty>>,
   /// Draft-16 §10.4.4 FETCH objects carry no Object Status field; zero-length
   /// payload signals a zero-length Normal object.
   pub payload: Bytes,
@@ -154,7 +154,7 @@ impl FetchObject {
     let has_object_id = flags & FLAG_OBJECT_ID_PRESENT != 0;
     let has_group_id = flags & FLAG_GROUP_ID_PRESENT != 0;
     let has_priority = flags & FLAG_PRIORITY_PRESENT != 0;
-    let has_extensions = flags & FLAG_EXTENSIONS_PRESENT != 0;
+    let has_properties = flags & FLAG_PROPERTIES_PRESENT != 0;
     let is_datagram = flags & FLAG_DATAGRAM != 0;
 
     // First object on the stream must not reference prior state.
@@ -245,7 +245,7 @@ impl FetchObject {
         .publisher_priority
     };
 
-    let extension_headers = if has_extensions {
+    let properties = if has_properties {
       let ext_len = bytes.get_vi()?;
       let ext_len: usize =
         ext_len
@@ -258,16 +258,16 @@ impl FetchObject {
           })?;
       if bytes.remaining() < ext_len {
         return Err(ParseError::NotEnoughBytes {
-          context: "FetchObject::deserialize(extensions)",
+          context: "FetchObject::deserialize(properties)",
           needed: ext_len,
           available: bytes.remaining(),
         });
       }
       let mut header_bytes = bytes.copy_to_bytes(ext_len);
-      let headers = deserialize_object_extensions(&mut header_bytes).map_err(|_| {
+      let headers = deserialize_object_properties(&mut header_bytes).map_err(|_| {
         ParseError::ProtocolViolation {
-          context: "FetchObject::deserialize(extensions)",
-          details: "cannot parse object extensions".to_string(),
+          context: "FetchObject::deserialize(properties)",
+          details: "cannot parse object properties".to_string(),
         }
       })?;
       Some(headers)
@@ -309,7 +309,7 @@ impl FetchObject {
       object_id,
       publisher_priority,
       forwarding_preference,
-      extension_headers,
+      properties,
       payload,
     }))
   }
@@ -339,7 +339,7 @@ fn serialize_payload(
     _ => (true, false),
   };
 
-  let has_extensions = matches!(&p.extension_headers, Some(v) if !v.is_empty());
+  let has_properties = matches!(&p.properties, Some(v) if !v.is_empty());
 
   // First object on the stream cannot inherit.
   let (has_group_id, has_object_id, has_priority, subgroup_mode) = if prev.is_none() {
@@ -381,8 +381,8 @@ fn serialize_payload(
   if has_priority {
     flags |= FLAG_PRIORITY_PRESENT;
   }
-  if has_extensions {
-    flags |= FLAG_EXTENSIONS_PRESENT;
+  if has_properties {
+    flags |= FLAG_PROPERTIES_PRESENT;
   }
   if is_datagram {
     flags |= FLAG_DATAGRAM;
@@ -403,8 +403,8 @@ fn serialize_payload(
   if has_priority {
     buf.put_u8(p.publisher_priority);
   }
-  if has_extensions {
-    let ext_buf = serialize_object_extensions(p.extension_headers.as_ref().unwrap())?;
+  if has_properties {
+    let ext_buf = serialize_object_properties(p.properties.as_ref().unwrap())?;
     buf.put_vi(ext_buf.len() as u64)?;
     buf.extend_from_slice(&ext_buf);
   }
@@ -427,11 +427,11 @@ mod tests {
       object_id: 10,
       publisher_priority: 255,
       forwarding_preference: ObjectForwardingPreference::Subgroup,
-      extension_headers: Some(vec![
-        ObjectExtension::Unknown {
+      properties: Some(vec![
+        ObjectProperty::Unknown {
           kvp: KeyValuePair::try_new_varint(0, 10).unwrap(),
         },
-        ObjectExtension::Unknown {
+        ObjectProperty::Unknown {
           kvp: KeyValuePair::try_new_bytes(1, Bytes::from_static(b"wololoo")).unwrap(),
         },
       ]),
@@ -453,9 +453,9 @@ mod tests {
     let first = sample_payload();
     let obj1 = FetchObject::Object(first.clone());
     let mut second = first.clone();
-    // Inheritable: same group, object_id = prior + 1, same subgroup, same priority, no extensions.
+    // Inheritable: same group, object_id = prior + 1, same subgroup, same priority, no properties.
     second.object_id = first.object_id + 1;
-    second.extension_headers = None;
+    second.properties = None;
     second.payload = Bytes::from_static(b"second");
     let obj2 = FetchObject::Object(second);
 

--- a/libs/moqtail-rs/src/model/data/object.rs
+++ b/libs/moqtail-rs/src/model/data/object.rs
@@ -18,7 +18,7 @@ use bytes::Bytes;
 
 use crate::model::common::location::Location;
 use crate::model::error::ParseError;
-use crate::model::extension_header::object_extension::ObjectExtension;
+use crate::model::property::object_property::ObjectProperty;
 
 use super::constant::{ObjectForwardingPreference, ObjectStatus};
 use super::datagram::Datagram;
@@ -33,7 +33,7 @@ pub struct Object {
   pub forwarding_preference: ObjectForwardingPreference,
   pub subgroup_id: Option<u64>,
   pub status: ObjectStatus,
-  pub extensions: Option<Vec<ObjectExtension>>,
+  pub properties: Option<Vec<ObjectProperty>>,
   pub payload: Option<Bytes>,
 }
 impl fmt::Debug for Object {
@@ -45,7 +45,7 @@ impl fmt::Debug for Object {
       .field("forwarding_preference", &self.forwarding_preference)
       .field("subgroup_id", &self.subgroup_id)
       .field("status", &self.status)
-      .field("extensions", &self.extensions)
+      .field("properties", &self.properties)
       .field("payload_length", &self.payload.as_ref().map(|p| p.len()))
       .finish()
   }
@@ -79,7 +79,7 @@ impl Object {
         forwarding_preference: ObjectForwardingPreference::Datagram,
         subgroup_id: None,
         status,
-        extensions: datagram.extension_headers,
+        properties: datagram.properties,
         payload,
       },
       end_of_group,
@@ -103,7 +103,7 @@ impl Object {
       forwarding_preference: ObjectForwardingPreference::Subgroup,
       subgroup_id,
       status: subgroup_obj.object_status.unwrap_or(ObjectStatus::Normal),
-      extensions: subgroup_obj.extension_headers,
+      properties: subgroup_obj.properties,
       payload: subgroup_obj.payload,
     })
   }
@@ -133,7 +133,7 @@ impl Object {
       forwarding_preference: fetch_obj.forwarding_preference,
       subgroup_id,
       status: ObjectStatus::Normal,
-      extensions: fetch_obj.extension_headers,
+      properties: fetch_obj.properties,
       payload,
     })
   }
@@ -184,7 +184,7 @@ impl Object {
         self.location.group,
         self.location.object,
         publisher_priority,
-        self.extensions,
+        self.properties,
         self.status,
       ))
     } else {
@@ -200,7 +200,7 @@ impl Object {
         self.location.group,
         self.location.object,
         publisher_priority,
-        self.extensions,
+        self.properties,
         payload,
         end_of_group,
       ))
@@ -248,7 +248,7 @@ impl Object {
 
     Ok(SubgroupObject {
       object_id: self.location.object,
-      extension_headers: self.extensions,
+      properties: self.properties,
       object_status,
       payload,
     })
@@ -296,7 +296,7 @@ impl Object {
       object_id: self.location.object,
       publisher_priority: self.publisher_priority,
       forwarding_preference: self.forwarding_preference,
-      extension_headers: self.extensions,
+      properties: self.properties,
       payload,
     })
   }

--- a/libs/moqtail-rs/src/model/data/subgroup_header.rs
+++ b/libs/moqtail-rs/src/model/data/subgroup_header.rs
@@ -34,12 +34,12 @@ impl SubgroupHeader {
     track_alias: u64,
     group_id: u64,
     publisher_priority: Option<u8>,
-    has_extensions: bool,
+    has_properties: bool,
     contains_end_of_group: bool,
   ) -> Self {
     let has_default_priority = publisher_priority.is_none();
     let header_type = SubgroupHeaderType::from_properties(
-      has_extensions,
+      has_properties,
       0,
       contains_end_of_group,
       has_default_priority,
@@ -59,12 +59,12 @@ impl SubgroupHeader {
     track_alias: u64,
     group_id: u64,
     publisher_priority: Option<u8>,
-    has_extensions: bool,
+    has_properties: bool,
     contains_end_of_group: bool,
   ) -> Self {
     let has_default_priority = publisher_priority.is_none();
     let header_type = SubgroupHeaderType::from_properties(
-      has_extensions,
+      has_properties,
       1,
       contains_end_of_group,
       has_default_priority,
@@ -85,12 +85,12 @@ impl SubgroupHeader {
     group_id: u64,
     subgroup_id: u64,
     publisher_priority: Option<u8>,
-    has_extensions: bool,
+    has_properties: bool,
     contains_end_of_group: bool,
   ) -> Self {
     let has_default_priority = publisher_priority.is_none();
     let header_type = SubgroupHeaderType::from_properties(
-      has_extensions,
+      has_properties,
       2,
       contains_end_of_group,
       has_default_priority,
@@ -434,13 +434,13 @@ mod tests {
         .contains_end_of_group()
     );
 
-    // Test has_extensions
-    assert!(SubgroupHeaderType::try_new(0x11).unwrap().has_extensions());
-    assert!(SubgroupHeaderType::try_new(0x13).unwrap().has_extensions());
-    assert!(SubgroupHeaderType::try_new(0x15).unwrap().has_extensions());
-    assert!(SubgroupHeaderType::try_new(0x19).unwrap().has_extensions());
-    assert!(SubgroupHeaderType::try_new(0x1B).unwrap().has_extensions());
-    assert!(SubgroupHeaderType::try_new(0x1D).unwrap().has_extensions());
+    // Test has_properties
+    assert!(SubgroupHeaderType::try_new(0x11).unwrap().has_properties());
+    assert!(SubgroupHeaderType::try_new(0x13).unwrap().has_properties());
+    assert!(SubgroupHeaderType::try_new(0x15).unwrap().has_properties());
+    assert!(SubgroupHeaderType::try_new(0x19).unwrap().has_properties());
+    assert!(SubgroupHeaderType::try_new(0x1B).unwrap().has_properties());
+    assert!(SubgroupHeaderType::try_new(0x1D).unwrap().has_properties());
   }
 
   #[test]
@@ -597,7 +597,7 @@ mod tests {
     // Create a subgroup object
     let subgroup_obj = SubgroupObject {
       object_id: 42,
-      extension_headers: None,
+      properties: None,
       payload: Some(Bytes::from_static(b"test payload")),
       object_status: None,
     };
@@ -636,7 +636,7 @@ mod tests {
     let object = Object::try_from_subgroup(
       SubgroupObject {
         object_id: 43,
-        extension_headers: None,
+        properties: None,
         payload: Some(Bytes::from_static(b"test payload 2")),
         object_status: None,
       },
@@ -662,7 +662,7 @@ mod tests {
     let object = Object::try_from_subgroup(
       SubgroupObject {
         object_id: 55,
-        extension_headers: None,
+        properties: None,
         payload: Some(Bytes::from_static(b"test payload 3")),
         object_status: None,
       },

--- a/libs/moqtail-rs/src/model/data/subgroup_object.rs
+++ b/libs/moqtail-rs/src/model/data/subgroup_object.rs
@@ -17,8 +17,8 @@ use tracing::trace;
 
 use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::error::ParseError;
-use crate::model::extension_header::object_extension::{
-  ObjectExtension, deserialize_object_extensions, serialize_object_extensions,
+use crate::model::property::object_property::{
+  ObjectProperty, deserialize_object_properties, serialize_object_properties,
 };
 
 use super::constant::ObjectStatus;
@@ -26,7 +26,7 @@ use super::constant::ObjectStatus;
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubgroupObject {
   pub object_id: u64,
-  pub extension_headers: Option<Vec<ObjectExtension>>,
+  pub properties: Option<Vec<ObjectProperty>>,
   pub object_status: Option<ObjectStatus>,
   pub payload: Option<Bytes>,
 }
@@ -35,7 +35,7 @@ impl SubgroupObject {
   pub fn serialize(
     &self,
     previous_object_id: Option<u64>,
-    has_extensions: bool,
+    has_properties: bool,
   ) -> Result<Bytes, ParseError> {
     let mut buf = BytesMut::new();
 
@@ -47,22 +47,22 @@ impl SubgroupObject {
 
     trace!(
       "SubgroupObject::serialize || object_id_delta: {} prev: {:?} object_id: {} ext_headers: {:?}",
-      object_id_delta, previous_object_id, self.object_id, &self.extension_headers
+      object_id_delta, previous_object_id, self.object_id, &self.properties
     );
 
     buf.put_vi(object_id_delta)?;
 
-    let extension_headers = self.extension_headers.as_deref().unwrap_or(&[]);
+    let properties = self.properties.as_deref().unwrap_or(&[]);
 
-    if !has_extensions && !extension_headers.is_empty() {
+    if !has_properties && !properties.is_empty() {
       return Err(ParseError::ProtocolViolation {
-        context: "SubgroupObject::serialize(extension_headers)",
-        details: "extension headers are present but header type has no extensions".to_string(),
+        context: "SubgroupObject::serialize(properties)",
+        details: "properties are present but header type has no properties".to_string(),
       });
     }
 
-    if has_extensions {
-      let ext_buf = serialize_object_extensions(extension_headers)?;
+    if has_properties {
+      let ext_buf = serialize_object_properties(properties)?;
       buf.put_vi(ext_buf.len())?;
       buf.extend_from_slice(&ext_buf);
     }
@@ -83,7 +83,7 @@ impl SubgroupObject {
   pub fn deserialize(
     bytes: &mut Bytes,
     previous_object_id: &Option<u64>,
-    has_extensions: bool,
+    has_properties: bool,
   ) -> Result<Self, ParseError> {
     let object_id_delta = bytes.get_vi()?;
 
@@ -98,7 +98,7 @@ impl SubgroupObject {
       object_id_delta, previous_object_id, object_id
     );
 
-    let extension_headers = if has_extensions {
+    let properties = if has_properties {
       let ext_len = bytes.get_vi()?;
 
       if ext_len > 0 {
@@ -121,16 +121,16 @@ impl SubgroupObject {
         }
 
         let mut header_bytes = bytes.copy_to_bytes(ext_len);
-        let headers = deserialize_object_extensions(&mut header_bytes).map_err(|_| {
+        let headers = deserialize_object_properties(&mut header_bytes).map_err(|_| {
           ParseError::ProtocolViolation {
             context: "SubgroupObject::deserialize",
-            details: "Failed to parse extension header".to_string(),
+            details: "Failed to parse property".to_string(),
           }
         })?;
         Some(headers)
       } else {
         // TODO: this is a hack to deal with the fact that we can understand
-        // whether we need to serialize this object with extensions
+        // whether we need to serialize this object with properties
         Some(vec![])
       }
     } else {
@@ -166,7 +166,7 @@ impl SubgroupObject {
 
     Ok(SubgroupObject {
       object_id,
-      extension_headers,
+      properties,
       object_status,
       payload,
     })
@@ -184,11 +184,11 @@ mod tests {
   fn test_roundtrip() {
     let object_id: u64 = 10;
     let prev_object_id = 9;
-    let extension_headers = Some(vec![
-      ObjectExtension::Unknown {
+    let properties = Some(vec![
+      ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_varint(0, 10).unwrap(),
       },
-      ObjectExtension::Unknown {
+      ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_bytes(1, Bytes::from_static(b"wololoo")).unwrap(),
       },
     ]);
@@ -197,7 +197,7 @@ mod tests {
 
     let subgroup_object = SubgroupObject {
       object_id,
-      extension_headers,
+      properties,
       payload,
       object_status,
     };
@@ -211,13 +211,13 @@ mod tests {
   }
 
   #[test]
-  fn test_serializes_empty_extension_headers_as_absent() {
+  fn test_serializes_empty_properties_as_absent() {
     let object_id: u64 = 10;
     let payload = Some(Bytes::from_static(&[0xab]));
 
     let with_no_headers = SubgroupObject {
       object_id,
-      extension_headers: None,
+      properties: None,
       object_status: None,
       payload: payload.clone(),
     }
@@ -226,7 +226,7 @@ mod tests {
 
     let with_empty_headers = SubgroupObject {
       object_id,
-      extension_headers: Some(vec![]),
+      properties: Some(vec![]),
       object_status: None,
       payload,
     }
@@ -240,11 +240,11 @@ mod tests {
   fn test_excess_roundtrip() {
     let object_id: u64 = 10;
     let prev_object_id = 9;
-    let extension_headers = Some(vec![
-      ObjectExtension::Unknown {
+    let properties = Some(vec![
+      ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_varint(0, 10).unwrap(),
       },
-      ObjectExtension::Unknown {
+      ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_bytes(1, Bytes::from_static(b"wololoo")).unwrap(),
       },
     ]);
@@ -253,7 +253,7 @@ mod tests {
 
     let subgroup_object = SubgroupObject {
       object_id,
-      extension_headers,
+      properties,
       payload,
       object_status,
     };
@@ -275,11 +275,11 @@ mod tests {
   fn test_partial_message() {
     let object_id: u64 = 10;
     let prev_object_id = 9;
-    let extension_headers = Some(vec![
-      ObjectExtension::Unknown {
+    let properties = Some(vec![
+      ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_varint(0, 10).unwrap(),
       },
-      ObjectExtension::Unknown {
+      ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_bytes(1, Bytes::from_static(b"wololoo")).unwrap(),
       },
     ]);
@@ -288,7 +288,7 @@ mod tests {
 
     let subgroup_object = SubgroupObject {
       object_id,
-      extension_headers,
+      properties,
       payload,
       object_status,
     };

--- a/libs/moqtail-rs/src/model/property.rs
+++ b/libs/moqtail-rs/src/model/property.rs
@@ -14,5 +14,5 @@
 
 pub mod constant;
 pub mod loc;
-pub mod object_extension;
-pub mod track_extension;
+pub mod object_property;
+pub mod track_property;

--- a/libs/moqtail-rs/src/model/property/constant.rs
+++ b/libs/moqtail-rs/src/model/property/constant.rs
@@ -18,44 +18,44 @@ use crate::model::error::ParseError;
 
 #[repr(u64)]
 #[derive(Clone, Debug, Copy, PartialEq)]
-pub enum LOCHeaderExtensionId {
+pub enum LOCPropertyId {
   CaptureTimestamp = 2,  // Section 2.3.1.1 - Common Header
   VideoFrameMarking = 4, // Section 2.3.2.2 - Video Header
   AudioLevel = 6,        // Section 2.3.3.1 - Audio Header
   VideoConfig = 13,      // Section 2.3.2.1 - Video Header
 }
 
-impl TryFrom<u64> for LOCHeaderExtensionId {
+impl TryFrom<u64> for LOCPropertyId {
   type Error = ParseError;
 
   fn try_from(value: u64) -> Result<Self, Self::Error> {
     match value {
-      2 => Ok(LOCHeaderExtensionId::CaptureTimestamp),
-      4 => Ok(LOCHeaderExtensionId::VideoFrameMarking),
-      6 => Ok(LOCHeaderExtensionId::AudioLevel),
-      13 => Ok(LOCHeaderExtensionId::VideoConfig),
+      2 => Ok(LOCPropertyId::CaptureTimestamp),
+      4 => Ok(LOCPropertyId::VideoFrameMarking),
+      6 => Ok(LOCPropertyId::AudioLevel),
+      13 => Ok(LOCPropertyId::VideoConfig),
       _ => Err(ParseError::InvalidType {
-        context: "LOCHeaderExtensionId::try_from(u64)",
+        context: "LOCPropertyId::try_from(u64)",
         details: format!("Invalid type, got {value}"),
       }),
     }
   }
 }
 
-impl From<LOCHeaderExtensionId> for u64 {
-  fn from(value: LOCHeaderExtensionId) -> Self {
+impl From<LOCPropertyId> for u64 {
+  fn from(value: LOCPropertyId) -> Self {
     value as u64
   }
 }
 
-/// MOQT extension header type values.
+/// MOQT property type values.
 /// Even type values use VarInt KVP encoding; odd type values use Bytes KVP encoding.
 #[repr(u64)]
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
-pub enum TrackExtensionType {
+pub enum TrackPropertyType {
   DeliveryTimeout = 0x02,            // Track scope, VarInt (ms, must be > 0)
   MaxCacheDuration = 0x04,           // Track scope, VarInt (ms)
-  ImmutableExtensions = 0x0B,        // Track+Object scope, Bytes (nested KVPs)
+  ImmutableProperties = 0x0B,        // Track+Object scope, Bytes (nested KVPs)
   DefaultPublisherPriority = 0x0E,   // Track scope, VarInt (0-255)
   DefaultPublisherGroupOrder = 0x22, // Track scope, VarInt (1=Ascending, 2=Descending)
   DynamicGroups = 0x30,              // Track scope, VarInt (0 or 1)
@@ -63,29 +63,29 @@ pub enum TrackExtensionType {
   PriorObjectIdGap = 0x3E,           // Object scope, VarInt
 }
 
-impl TryFrom<u64> for TrackExtensionType {
+impl TryFrom<u64> for TrackPropertyType {
   type Error = ParseError;
 
   fn try_from(value: u64) -> Result<Self, Self::Error> {
     match value {
-      0x02 => Ok(TrackExtensionType::DeliveryTimeout),
-      0x04 => Ok(TrackExtensionType::MaxCacheDuration),
-      0x0B => Ok(TrackExtensionType::ImmutableExtensions),
-      0x0E => Ok(TrackExtensionType::DefaultPublisherPriority),
-      0x22 => Ok(TrackExtensionType::DefaultPublisherGroupOrder),
-      0x30 => Ok(TrackExtensionType::DynamicGroups),
-      0x3C => Ok(TrackExtensionType::PriorGroupIdGap),
-      0x3E => Ok(TrackExtensionType::PriorObjectIdGap),
+      0x02 => Ok(TrackPropertyType::DeliveryTimeout),
+      0x04 => Ok(TrackPropertyType::MaxCacheDuration),
+      0x0B => Ok(TrackPropertyType::ImmutableProperties),
+      0x0E => Ok(TrackPropertyType::DefaultPublisherPriority),
+      0x22 => Ok(TrackPropertyType::DefaultPublisherGroupOrder),
+      0x30 => Ok(TrackPropertyType::DynamicGroups),
+      0x3C => Ok(TrackPropertyType::PriorGroupIdGap),
+      0x3E => Ok(TrackPropertyType::PriorObjectIdGap),
       _ => Err(ParseError::InvalidType {
-        context: "TrackExtensionType::try_from(u64)",
-        details: format!("Unknown extension type, got {value}"),
+        context: "TrackPropertyType::try_from(u64)",
+        details: format!("Unknown property type, got {value}"),
       }),
     }
   }
 }
 
-impl From<TrackExtensionType> for u64 {
-  fn from(value: TrackExtensionType) -> Self {
+impl From<TrackPropertyType> for u64 {
+  fn from(value: TrackPropertyType) -> Self {
     value as u64
   }
 }
@@ -95,27 +95,27 @@ mod tests {
   use super::*;
 
   #[test]
-  fn test_track_extension_type_roundtrip() {
+  fn test_track_property_type_roundtrip() {
     let known = [
-      (0x02u64, TrackExtensionType::DeliveryTimeout),
-      (0x04, TrackExtensionType::MaxCacheDuration),
-      (0x0B, TrackExtensionType::ImmutableExtensions),
-      (0x0E, TrackExtensionType::DefaultPublisherPriority),
-      (0x22, TrackExtensionType::DefaultPublisherGroupOrder),
-      (0x30, TrackExtensionType::DynamicGroups),
-      (0x3C, TrackExtensionType::PriorGroupIdGap),
-      (0x3E, TrackExtensionType::PriorObjectIdGap),
+      (0x02u64, TrackPropertyType::DeliveryTimeout),
+      (0x04, TrackPropertyType::MaxCacheDuration),
+      (0x0B, TrackPropertyType::ImmutableProperties),
+      (0x0E, TrackPropertyType::DefaultPublisherPriority),
+      (0x22, TrackPropertyType::DefaultPublisherGroupOrder),
+      (0x30, TrackPropertyType::DynamicGroups),
+      (0x3C, TrackPropertyType::PriorGroupIdGap),
+      (0x3E, TrackPropertyType::PriorObjectIdGap),
     ];
     for (raw, expected) in known {
-      let parsed = TrackExtensionType::try_from(raw).unwrap();
+      let parsed = TrackPropertyType::try_from(raw).unwrap();
       assert_eq!(parsed, expected);
       assert_eq!(u64::from(parsed), raw);
     }
   }
 
   #[test]
-  fn test_track_extension_type_unknown() {
-    assert!(TrackExtensionType::try_from(0xFF).is_err());
-    assert!(TrackExtensionType::try_from(0x00).is_err());
+  fn test_track_property_type_unknown() {
+    assert!(TrackPropertyType::try_from(0xFF).is_err());
+    assert!(TrackPropertyType::try_from(0x00).is_err());
   }
 }

--- a/libs/moqtail-rs/src/model/property/loc.rs
+++ b/libs/moqtail-rs/src/model/property/loc.rs
@@ -17,34 +17,34 @@ use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::error::ParseError;
 use bytes::{Buf, Bytes, BytesMut};
 
-use super::constant::LOCHeaderExtensionId;
+use super::constant::LOCPropertyId;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum LOCHeaderExtension {
+pub enum LOCProperty {
   CaptureTimestamp { value: u64 },
   VideoFrameMarking { value: u64 },
   AudioLevel { value: u64 },
   VideoConfig { value: Bytes },
 }
 
-impl LOCHeaderExtension {
+impl LOCProperty {
   pub fn serialize(&self) -> Result<Bytes, ParseError> {
     let mut buf = BytesMut::new();
     match self {
-      LOCHeaderExtension::CaptureTimestamp { value } => {
-        buf.put_vi(LOCHeaderExtensionId::CaptureTimestamp)?;
+      LOCProperty::CaptureTimestamp { value } => {
+        buf.put_vi(LOCPropertyId::CaptureTimestamp)?;
         buf.put_vi(*value)?;
       }
-      LOCHeaderExtension::VideoFrameMarking { value } => {
-        buf.put_vi(LOCHeaderExtensionId::VideoFrameMarking)?;
+      LOCProperty::VideoFrameMarking { value } => {
+        buf.put_vi(LOCPropertyId::VideoFrameMarking)?;
         buf.put_vi(*value)?;
       }
-      LOCHeaderExtension::AudioLevel { value } => {
-        buf.put_vi(LOCHeaderExtensionId::AudioLevel)?;
+      LOCProperty::AudioLevel { value } => {
+        buf.put_vi(LOCPropertyId::AudioLevel)?;
         buf.put_vi(*value)?;
       }
-      LOCHeaderExtension::VideoConfig { value } => {
-        buf.put_vi(LOCHeaderExtensionId::VideoConfig)?;
+      LOCProperty::VideoConfig { value } => {
+        buf.put_vi(LOCPropertyId::VideoConfig)?;
         buf.put_vi(value.len())?;
         buf.extend_from_slice(value);
       }
@@ -53,65 +53,61 @@ impl LOCHeaderExtension {
   }
   pub fn deserialize(payload: &mut Bytes) -> Result<Self, ParseError> {
     let id = payload.get_vi()?;
-    let loc_header_extension_id = LOCHeaderExtensionId::try_from(id)?;
+    let loc_property_id = LOCPropertyId::try_from(id)?;
 
-    match loc_header_extension_id {
-      LOCHeaderExtensionId::VideoConfig => {
+    match loc_property_id {
+      LOCPropertyId::VideoConfig => {
         let payload_length = payload.get_vi()?;
         let payload_length: usize =
           payload_length
             .try_into()
             .map_err(|e: std::num::TryFromIntError| ParseError::CastingError {
-              context: "LOCHeaderExtension::deserialize(payload_length)",
+              context: "LOCProperty::deserialize(payload_length)",
               from_type: "u64",
               to_type: "usize",
               details: e.to_string(),
             })?;
         let value = payload.copy_to_bytes(payload_length);
-        Ok(LOCHeaderExtension::VideoConfig { value })
+        Ok(LOCProperty::VideoConfig { value })
       }
-      LOCHeaderExtensionId::AudioLevel => {
+      LOCPropertyId::AudioLevel => {
         let value = payload.get_vi()?;
-        Ok(LOCHeaderExtension::AudioLevel { value })
+        Ok(LOCProperty::AudioLevel { value })
       }
-      LOCHeaderExtensionId::CaptureTimestamp => {
+      LOCPropertyId::CaptureTimestamp => {
         let value = payload.get_vi()?;
-        Ok(LOCHeaderExtension::CaptureTimestamp { value })
+        Ok(LOCProperty::CaptureTimestamp { value })
       }
-      LOCHeaderExtensionId::VideoFrameMarking => {
+      LOCPropertyId::VideoFrameMarking => {
         let value = payload.get_vi()?;
-        Ok(LOCHeaderExtension::VideoFrameMarking { value })
+        Ok(LOCProperty::VideoFrameMarking { value })
       }
     }
   }
 }
 
-impl TryFrom<KeyValuePair> for LOCHeaderExtension {
+impl TryFrom<KeyValuePair> for LOCProperty {
   type Error = ParseError;
   fn try_from(pair: KeyValuePair) -> Result<Self, Self::Error> {
     match pair {
       KeyValuePair::VarInt { type_value, value } => {
-        let id = LOCHeaderExtensionId::try_from(type_value)?;
+        let id = LOCPropertyId::try_from(type_value)?;
         match id {
-          LOCHeaderExtensionId::AudioLevel => Ok(LOCHeaderExtension::AudioLevel { value }),
-          LOCHeaderExtensionId::CaptureTimestamp => {
-            Ok(LOCHeaderExtension::CaptureTimestamp { value })
-          }
-          LOCHeaderExtensionId::VideoFrameMarking => {
-            Ok(LOCHeaderExtension::VideoFrameMarking { value })
-          }
+          LOCPropertyId::AudioLevel => Ok(LOCProperty::AudioLevel { value }),
+          LOCPropertyId::CaptureTimestamp => Ok(LOCProperty::CaptureTimestamp { value }),
+          LOCPropertyId::VideoFrameMarking => Ok(LOCProperty::VideoFrameMarking { value }),
           _ => Err(ParseError::InvalidType {
-            context: "LOCHeaderExtension::try_from(KeyValuePair::VarInt)",
+            context: "LOCProperty::try_from(KeyValuePair::VarInt)",
             details: format!("Invalid type, got {type_value}"),
           }),
         }
       }
       KeyValuePair::Bytes { type_value, value } => {
-        let id = LOCHeaderExtensionId::try_from(type_value)?;
+        let id = LOCPropertyId::try_from(type_value)?;
         match id {
-          LOCHeaderExtensionId::VideoConfig => Ok(LOCHeaderExtension::VideoConfig { value }),
+          LOCPropertyId::VideoConfig => Ok(LOCProperty::VideoConfig { value }),
           _ => Err(ParseError::InvalidType {
-            context: "LOCHeaderExtension::try_from(KeyValuePair::Bytes)",
+            context: "LOCProperty::try_from(KeyValuePair::Bytes)",
             details: format!("Invalid type, got {type_value}"),
           }),
         }
@@ -129,10 +125,10 @@ mod tests {
   #[test]
   fn test_roundtrip() {
     let value = 144;
-    let loc = LOCHeaderExtension::AudioLevel { value };
+    let loc = LOCProperty::AudioLevel { value };
 
     let mut buf = loc.serialize().unwrap();
-    let deserialized = LOCHeaderExtension::deserialize(&mut buf).unwrap();
+    let deserialized = LOCProperty::deserialize(&mut buf).unwrap();
     assert_eq!(deserialized, loc);
     assert!(!buf.has_remaining());
   }
@@ -140,7 +136,7 @@ mod tests {
   #[test]
   fn test_excess_roundtrip() {
     let value = 144;
-    let loc = LOCHeaderExtension::AudioLevel { value };
+    let loc = LOCProperty::AudioLevel { value };
 
     let serialized = loc.serialize().unwrap();
     let mut excess = BytesMut::new();
@@ -148,7 +144,7 @@ mod tests {
     excess.extend_from_slice(&[9u8, 1u8, 1u8]);
     let mut buf = excess.freeze();
 
-    let deserialized = LOCHeaderExtension::deserialize(&mut buf).unwrap();
+    let deserialized = LOCProperty::deserialize(&mut buf).unwrap();
     assert_eq!(deserialized, loc);
     assert_eq!(buf.chunk(), &[9u8, 1u8, 1u8]);
   }
@@ -156,11 +152,11 @@ mod tests {
   #[test]
   fn test_partial_message() {
     let value = 144;
-    let loc = LOCHeaderExtension::AudioLevel { value };
+    let loc = LOCProperty::AudioLevel { value };
     let buf = loc.serialize().unwrap();
     let upper = buf.remaining() / 2;
     let mut partial = buf.slice(..upper);
-    let deserialized = LOCHeaderExtension::deserialize(&mut partial);
+    let deserialized = LOCProperty::deserialize(&mut partial);
     assert!(deserialized.is_err());
   }
 }

--- a/libs/moqtail-rs/src/model/property/object_property.rs
+++ b/libs/moqtail-rs/src/model/property/object_property.rs
@@ -12,104 +12,104 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::constant::TrackExtensionType;
+use super::constant::TrackPropertyType;
 use crate::model::common::pair::{
   KeyValuePair, deserialize_kvp_list_until_empty, serialize_kvp_list,
 };
 use crate::model::error::ParseError;
 use bytes::Bytes;
 
-/// Typed representation of a MOQT object-level Extension Header.
+/// Typed representation of a MOQT object-level Property.
 ///
-/// Unknown extension types are preserved as raw KeyValuePairs so that relays
+/// Unknown property types are preserved as raw KeyValuePairs so that relays
 /// can forward them unchanged per spec.
 #[derive(Debug, Clone, PartialEq)]
-pub enum ObjectExtension {
-  ImmutableExtensions { extensions: Vec<KeyValuePair> },
+pub enum ObjectProperty {
+  ImmutableProperties { properties: Vec<KeyValuePair> },
   PriorGroupIdGap { gap: u64 },
   PriorObjectIdGap { gap: u64 },
   Unknown { kvp: KeyValuePair },
 }
 
-impl ObjectExtension {
-  /// Returns the raw wire type value for this extension.
+impl ObjectProperty {
+  /// Returns the raw wire type value for this property.
   pub fn type_value(&self) -> u64 {
     match self {
-      Self::ImmutableExtensions { .. } => TrackExtensionType::ImmutableExtensions as u64,
-      Self::PriorGroupIdGap { .. } => TrackExtensionType::PriorGroupIdGap as u64,
-      Self::PriorObjectIdGap { .. } => TrackExtensionType::PriorObjectIdGap as u64,
+      Self::ImmutableProperties { .. } => TrackPropertyType::ImmutableProperties as u64,
+      Self::PriorGroupIdGap { .. } => TrackPropertyType::PriorGroupIdGap as u64,
+      Self::PriorObjectIdGap { .. } => TrackPropertyType::PriorObjectIdGap as u64,
       Self::Unknown { kvp } => kvp.get_type(),
     }
   }
 
-  /// Serializes this extension to its wire KVP bytes.
+  /// Serializes this property to its wire KVP bytes.
   pub fn serialize(&self) -> Result<Bytes, ParseError> {
     let kvp: KeyValuePair = self.clone().try_into()?;
     kvp.serialize()
   }
 
-  /// Deserializes an ObjectExtension from a pre-parsed KeyValuePair.
+  /// Deserializes an ObjectProperty from a pre-parsed KeyValuePair.
   /// Unknown type values are returned as `Unknown { kvp }` rather than an error.
   pub fn deserialize(kvp: KeyValuePair) -> Result<Self, ParseError> {
     let type_value = kvp.get_type();
-    let ext_type = match TrackExtensionType::try_from(type_value) {
+    let ext_type = match TrackPropertyType::try_from(type_value) {
       Ok(t) => t,
       Err(_) => return Ok(Self::Unknown { kvp }),
     };
 
     match ext_type {
-      TrackExtensionType::ImmutableExtensions => {
-        let bytes = kvp_bytes_value(&kvp, "ObjectExtension::deserialize(ImmutableExtensions)")?;
+      TrackPropertyType::ImmutableProperties => {
+        let bytes = kvp_bytes_value(&kvp, "ObjectProperty::deserialize(ImmutableProperties)")?;
         let mut buf = bytes;
-        let extensions = deserialize_kvp_list_until_empty(&mut buf)?;
-        if extensions
+        let properties = deserialize_kvp_list_until_empty(&mut buf)?;
+        if properties
           .iter()
-          .any(|inner| inner.get_type() == TrackExtensionType::ImmutableExtensions as u64)
+          .any(|inner| inner.get_type() == TrackPropertyType::ImmutableProperties as u64)
         {
           return Err(ParseError::ProtocolViolation {
-            context: "ObjectExtension::deserialize(ImmutableExtensions)",
-            details: "ImmutableExtensions MUST NOT contain another ImmutableExtensions key"
+            context: "ObjectProperty::deserialize(ImmutableProperties)",
+            details: "ImmutableProperties MUST NOT contain another ImmutableProperties key"
               .to_string(),
           });
         }
-        Ok(Self::ImmutableExtensions { extensions })
+        Ok(Self::ImmutableProperties { properties })
       }
-      TrackExtensionType::PriorGroupIdGap => {
-        let value = kvp_varint_value(&kvp, "ObjectExtension::deserialize(PriorGroupIdGap)")?;
+      TrackPropertyType::PriorGroupIdGap => {
+        let value = kvp_varint_value(&kvp, "ObjectProperty::deserialize(PriorGroupIdGap)")?;
         Ok(Self::PriorGroupIdGap { gap: value })
       }
-      TrackExtensionType::PriorObjectIdGap => {
-        let value = kvp_varint_value(&kvp, "ObjectExtension::deserialize(PriorObjectIdGap)")?;
+      TrackPropertyType::PriorObjectIdGap => {
+        let value = kvp_varint_value(&kvp, "ObjectProperty::deserialize(PriorObjectIdGap)")?;
         Ok(Self::PriorObjectIdGap { gap: value })
       }
-      // Track-scope extensions; treated as unknown at object level
+      // Track-scope properties; treated as unknown at object level
       _ => Ok(Self::Unknown { kvp }),
     }
   }
 }
 
-impl TryInto<KeyValuePair> for ObjectExtension {
+impl TryInto<KeyValuePair> for ObjectProperty {
   type Error = ParseError;
 
   fn try_into(self) -> Result<KeyValuePair, Self::Error> {
     match self {
-      Self::ImmutableExtensions { extensions } => KeyValuePair::try_new_bytes(
-        TrackExtensionType::ImmutableExtensions as u64,
-        serialize_kvp_list(&extensions)?,
+      Self::ImmutableProperties { properties } => KeyValuePair::try_new_bytes(
+        TrackPropertyType::ImmutableProperties as u64,
+        serialize_kvp_list(&properties)?,
       ),
       Self::PriorGroupIdGap { gap } => {
-        KeyValuePair::try_new_varint(TrackExtensionType::PriorGroupIdGap as u64, gap)
+        KeyValuePair::try_new_varint(TrackPropertyType::PriorGroupIdGap as u64, gap)
       }
       Self::PriorObjectIdGap { gap } => {
-        KeyValuePair::try_new_varint(TrackExtensionType::PriorObjectIdGap as u64, gap)
+        KeyValuePair::try_new_varint(TrackPropertyType::PriorObjectIdGap as u64, gap)
       }
       Self::Unknown { kvp } => Ok(kvp),
     }
   }
 }
 
-/// Serializes a slice of ObjectExtensions to their concatenated wire KVP bytes.
-pub fn serialize_object_extensions(exts: &[ObjectExtension]) -> Result<Bytes, ParseError> {
+/// Serializes a slice of ObjectProperties to their concatenated wire KVP bytes.
+pub fn serialize_object_properties(exts: &[ObjectProperty]) -> Result<Bytes, ParseError> {
   let kvps: Vec<KeyValuePair> = exts
     .iter()
     .map(|e| e.clone().try_into())
@@ -117,14 +117,12 @@ pub fn serialize_object_extensions(exts: &[ObjectExtension]) -> Result<Bytes, Pa
   serialize_kvp_list(&kvps)
 }
 
-/// Deserializes ObjectExtensions from a byte slice of known length.
+/// Deserializes ObjectProperties from a byte slice of known length.
 /// Reads KVPs until the buffer is empty.
-pub fn deserialize_object_extensions(
-  bytes: &mut Bytes,
-) -> Result<Vec<ObjectExtension>, ParseError> {
+pub fn deserialize_object_properties(bytes: &mut Bytes) -> Result<Vec<ObjectProperty>, ParseError> {
   deserialize_kvp_list_until_empty(bytes)?
     .into_iter()
-    .map(ObjectExtension::deserialize)
+    .map(ObjectProperty::deserialize)
     .collect()
 }
 
@@ -134,7 +132,7 @@ fn kvp_varint_value(kvp: &KeyValuePair, context: &'static str) -> Result<u64, Pa
     KeyValuePair::Bytes { type_value, .. } => Err(ParseError::ProtocolViolation {
       context,
       details: format!(
-        "Extension type 0x{type_value:02X} expects VarInt encoding but received Bytes"
+        "Property type 0x{type_value:02X} expects VarInt encoding but received Bytes"
       ),
     }),
   }
@@ -146,7 +144,7 @@ fn kvp_bytes_value(kvp: &KeyValuePair, context: &'static str) -> Result<Bytes, P
     KeyValuePair::VarInt { type_value, .. } => Err(ParseError::ProtocolViolation {
       context,
       details: format!(
-        "Extension type 0x{type_value:02X} expects Bytes encoding but received VarInt"
+        "Property type 0x{type_value:02X} expects Bytes encoding but received VarInt"
       ),
     }),
   }
@@ -157,52 +155,52 @@ mod tests {
   use super::*;
   use bytes::{Buf, Bytes};
 
-  fn roundtrip(ext: ObjectExtension) -> ObjectExtension {
+  fn roundtrip(ext: ObjectProperty) -> ObjectProperty {
     let serialized = ext.serialize().unwrap();
     let mut buf = serialized;
     let kvp = KeyValuePair::deserialize(&mut buf).unwrap();
     assert!(!buf.has_remaining());
-    ObjectExtension::deserialize(kvp).unwrap()
+    ObjectProperty::deserialize(kvp).unwrap()
   }
 
   #[test]
-  fn test_roundtrip_immutable_extensions() {
+  fn test_roundtrip_immutable_properties() {
     let inner = vec![
       KeyValuePair::try_new_varint(0x10, 7).unwrap(),
       KeyValuePair::try_new_bytes(0x11, Bytes::from_static(b"data")).unwrap(),
     ];
-    let ext = ObjectExtension::ImmutableExtensions {
-      extensions: inner.clone(),
+    let ext = ObjectProperty::ImmutableProperties {
+      properties: inner.clone(),
     };
     assert_eq!(roundtrip(ext.clone()), ext);
   }
 
   #[test]
   fn test_roundtrip_prior_group_id_gap() {
-    let ext = ObjectExtension::PriorGroupIdGap { gap: 3 };
+    let ext = ObjectProperty::PriorGroupIdGap { gap: 3 };
     assert_eq!(roundtrip(ext.clone()), ext);
   }
 
   #[test]
   fn test_roundtrip_prior_object_id_gap() {
-    let ext = ObjectExtension::PriorObjectIdGap { gap: 5 };
+    let ext = ObjectProperty::PriorObjectIdGap { gap: 5 };
     assert_eq!(roundtrip(ext.clone()), ext);
   }
 
   #[test]
   fn test_roundtrip_unknown() {
     let kvp = KeyValuePair::try_new_varint(0xFE, 42).unwrap();
-    let ext = ObjectExtension::Unknown { kvp };
+    let ext = ObjectProperty::Unknown { kvp };
     assert_eq!(roundtrip(ext.clone()), ext);
   }
 
   #[test]
-  fn test_immutable_extensions_nested_is_error() {
+  fn test_immutable_properties_nested_is_error() {
     let inner_immutable = KeyValuePair::try_new_bytes(0x0B, Bytes::from_static(b"")).unwrap();
     let inner_bytes = inner_immutable.serialize().unwrap();
     let outer = KeyValuePair::try_new_bytes(0x0B, inner_bytes).unwrap();
     assert!(matches!(
-      ObjectExtension::deserialize(outer).unwrap_err(),
+      ObjectProperty::deserialize(outer).unwrap_err(),
       ParseError::ProtocolViolation { .. }
     ));
   }
@@ -210,31 +208,31 @@ mod tests {
   #[test]
   fn test_serialize_deserialize_mixed() {
     let exts = vec![
-      ObjectExtension::PriorGroupIdGap { gap: 2 },
-      ObjectExtension::PriorObjectIdGap { gap: 1 },
-      ObjectExtension::Unknown {
+      ObjectProperty::PriorGroupIdGap { gap: 2 },
+      ObjectProperty::PriorObjectIdGap { gap: 1 },
+      ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_varint(0xFC, 0).unwrap(),
       },
     ];
-    let serialized = serialize_object_extensions(&exts).unwrap();
+    let serialized = serialize_object_properties(&exts).unwrap();
     let mut buf = serialized;
-    let deserialized = deserialize_object_extensions(&mut buf).unwrap();
+    let deserialized = deserialize_object_properties(&mut buf).unwrap();
     assert_eq!(deserialized, exts);
   }
 
   #[test]
   fn test_serialize_deserialize_empty() {
-    let serialized = serialize_object_extensions(&[]).unwrap();
+    let serialized = serialize_object_properties(&[]).unwrap();
     assert!(serialized.is_empty());
     let mut buf = serialized;
-    let deserialized = deserialize_object_extensions(&mut buf).unwrap();
+    let deserialized = deserialize_object_properties(&mut buf).unwrap();
     assert!(deserialized.is_empty());
   }
 
   #[test]
-  fn test_immutable_extensions_independent_of_outer_prev_type() {
-    // A low-type extension precedes ImmutableExtensions (0x0B) in the outer
-    // list, so the outer prev_type is nonzero by the time ImmutableExtensions
+  fn test_immutable_properties_independent_of_outer_prev_type() {
+    // A low-type property precedes ImmutableProperties (0x0B) in the outer
+    // list, so the outer prev_type is nonzero by the time ImmutableProperties
     // is reached. The inner KVP list must restart its own delta state from 0,
     // independent of the outer list's running prev_type.
     let inner = vec![
@@ -242,16 +240,16 @@ mod tests {
       KeyValuePair::try_new_bytes(0x03, Bytes::from_static(b"data")).unwrap(),
     ];
     let exts = vec![
-      ObjectExtension::Unknown {
+      ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_varint(0x04, 99).unwrap(),
       },
-      ObjectExtension::ImmutableExtensions {
-        extensions: inner.clone(),
+      ObjectProperty::ImmutableProperties {
+        properties: inner.clone(),
       },
     ];
-    let serialized = serialize_object_extensions(&exts).unwrap();
+    let serialized = serialize_object_properties(&exts).unwrap();
     let mut buf = serialized;
-    let deserialized = deserialize_object_extensions(&mut buf).unwrap();
+    let deserialized = deserialize_object_properties(&mut buf).unwrap();
     assert_eq!(deserialized, exts);
   }
 }

--- a/libs/moqtail-rs/src/model/property/track_property.rs
+++ b/libs/moqtail-rs/src/model/property/track_property.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::constant::TrackExtensionType;
+use super::constant::TrackPropertyType;
 use crate::model::common::pair::{
   KeyValuePair, deserialize_kvp_list_until_empty, serialize_kvp_list,
 };
@@ -20,92 +20,89 @@ use crate::model::control::constant::GroupOrder;
 use crate::model::error::ParseError;
 use bytes::Bytes;
 
-/// Typed representation of a MOQT track-level Extension Header.
+/// Typed representation of a MOQT track-level Property.
 ///
-/// Unknown extension types are preserved as raw KeyValuePairs so that relays
+/// Unknown property types are preserved as raw KeyValuePairs so that relays
 /// can forward them unchanged per spec (relays MUST NOT modify or drop unknown
-/// extensions).
+/// properties).
 #[derive(Debug, Clone, PartialEq)]
-pub enum TrackExtension {
+pub enum TrackProperty {
   DeliveryTimeout { timeout_ms: u64 },
   MaxCacheDuration { duration_ms: u64 },
-  ImmutableExtensions { extensions: Vec<KeyValuePair> },
+  ImmutableProperties { properties: Vec<KeyValuePair> },
   DefaultPublisherPriority { priority: u8 },
   DefaultPublisherGroupOrder { order: GroupOrder },
   DynamicGroups { enabled: bool },
   Unknown { kvp: KeyValuePair },
 }
 
-impl TrackExtension {
-  /// Returns the raw wire type value for this extension.
+impl TrackProperty {
+  /// Returns the raw wire type value for this property.
   pub fn type_value(&self) -> u64 {
     match self {
-      Self::DeliveryTimeout { .. } => TrackExtensionType::DeliveryTimeout as u64,
-      Self::MaxCacheDuration { .. } => TrackExtensionType::MaxCacheDuration as u64,
-      Self::ImmutableExtensions { .. } => TrackExtensionType::ImmutableExtensions as u64,
-      Self::DefaultPublisherPriority { .. } => TrackExtensionType::DefaultPublisherPriority as u64,
+      Self::DeliveryTimeout { .. } => TrackPropertyType::DeliveryTimeout as u64,
+      Self::MaxCacheDuration { .. } => TrackPropertyType::MaxCacheDuration as u64,
+      Self::ImmutableProperties { .. } => TrackPropertyType::ImmutableProperties as u64,
+      Self::DefaultPublisherPriority { .. } => TrackPropertyType::DefaultPublisherPriority as u64,
       Self::DefaultPublisherGroupOrder { .. } => {
-        TrackExtensionType::DefaultPublisherGroupOrder as u64
+        TrackPropertyType::DefaultPublisherGroupOrder as u64
       }
-      Self::DynamicGroups { .. } => TrackExtensionType::DynamicGroups as u64,
+      Self::DynamicGroups { .. } => TrackPropertyType::DynamicGroups as u64,
       Self::Unknown { kvp } => kvp.get_type(),
     }
   }
 
-  /// Serializes this extension to its wire KVP bytes.
+  /// Serializes this property to its wire KVP bytes.
   pub fn serialize(&self) -> Result<Bytes, ParseError> {
     let kvp: KeyValuePair = self.clone().try_into()?;
     kvp.serialize()
   }
 
-  /// Deserializes a TrackExtension from a pre-parsed KeyValuePair.
+  /// Deserializes a TrackProperty from a pre-parsed KeyValuePair.
   /// Unknown type values are returned as `Unknown { kvp }` rather than an error.
   pub fn deserialize(kvp: KeyValuePair) -> Result<Self, ParseError> {
     let type_value = kvp.get_type();
-    let ext_type = match TrackExtensionType::try_from(type_value) {
+    let ext_type = match TrackPropertyType::try_from(type_value) {
       Ok(t) => t,
       Err(_) => return Ok(Self::Unknown { kvp }),
     };
 
     match ext_type {
-      TrackExtensionType::DeliveryTimeout => {
-        let value = kvp_varint_value(&kvp, "TrackExtension::deserialize(DeliveryTimeout)")?;
+      TrackPropertyType::DeliveryTimeout => {
+        let value = kvp_varint_value(&kvp, "TrackProperty::deserialize(DeliveryTimeout)")?;
         if value == 0 {
           return Err(ParseError::ProtocolViolation {
-            context: "TrackExtension::deserialize(DeliveryTimeout)",
+            context: "TrackProperty::deserialize(DeliveryTimeout)",
             details: "DELIVERY_TIMEOUT must be greater than 0".to_string(),
           });
         }
         Ok(Self::DeliveryTimeout { timeout_ms: value })
       }
-      TrackExtensionType::MaxCacheDuration => {
-        let value = kvp_varint_value(&kvp, "TrackExtension::deserialize(MaxCacheDuration)")?;
+      TrackPropertyType::MaxCacheDuration => {
+        let value = kvp_varint_value(&kvp, "TrackProperty::deserialize(MaxCacheDuration)")?;
         Ok(Self::MaxCacheDuration { duration_ms: value })
       }
-      TrackExtensionType::ImmutableExtensions => {
-        let bytes = kvp_bytes_value(&kvp, "TrackExtension::deserialize(ImmutableExtensions)")?;
+      TrackPropertyType::ImmutableProperties => {
+        let bytes = kvp_bytes_value(&kvp, "TrackProperty::deserialize(ImmutableProperties)")?;
         let mut buf = bytes;
-        let extensions = deserialize_kvp_list_until_empty(&mut buf)?;
-        if extensions
+        let properties = deserialize_kvp_list_until_empty(&mut buf)?;
+        if properties
           .iter()
-          .any(|inner| inner.get_type() == TrackExtensionType::ImmutableExtensions as u64)
+          .any(|inner| inner.get_type() == TrackPropertyType::ImmutableProperties as u64)
         {
           return Err(ParseError::ProtocolViolation {
-            context: "TrackExtension::deserialize(ImmutableExtensions)",
-            details: "ImmutableExtensions MUST NOT contain another ImmutableExtensions key"
+            context: "TrackProperty::deserialize(ImmutableProperties)",
+            details: "ImmutableProperties MUST NOT contain another ImmutableProperties key"
               .to_string(),
           });
         }
-        Ok(Self::ImmutableExtensions { extensions })
+        Ok(Self::ImmutableProperties { properties })
       }
-      TrackExtensionType::DefaultPublisherPriority => {
-        let value = kvp_varint_value(
-          &kvp,
-          "TrackExtension::deserialize(DefaultPublisherPriority)",
-        )?;
+      TrackPropertyType::DefaultPublisherPriority => {
+        let value = kvp_varint_value(&kvp, "TrackProperty::deserialize(DefaultPublisherPriority)")?;
         if value > 255 {
           return Err(ParseError::ProtocolViolation {
-            context: "TrackExtension::deserialize(DefaultPublisherPriority)",
+            context: "TrackProperty::deserialize(DefaultPublisherPriority)",
             details: format!("DEFAULT_PUBLISHER_PRIORITY must be 0-255, got {value}"),
           });
         }
@@ -113,17 +110,17 @@ impl TrackExtension {
           priority: value as u8,
         })
       }
-      TrackExtensionType::DefaultPublisherGroupOrder => {
+      TrackPropertyType::DefaultPublisherGroupOrder => {
         let value = kvp_varint_value(
           &kvp,
-          "TrackExtension::deserialize(DefaultPublisherGroupOrder)",
+          "TrackProperty::deserialize(DefaultPublisherGroupOrder)",
         )?;
         let order = match value {
           1 => GroupOrder::Ascending,
           2 => GroupOrder::Descending,
           _ => {
             return Err(ParseError::ProtocolViolation {
-              context: "TrackExtension::deserialize(DefaultPublisherGroupOrder)",
+              context: "TrackProperty::deserialize(DefaultPublisherGroupOrder)",
               details: format!(
                 "DEFAULT_PUBLISHER_GROUP_ORDER must be 1 (Ascending) or 2 (Descending), got {value}"
               ),
@@ -132,51 +129,51 @@ impl TrackExtension {
         };
         Ok(Self::DefaultPublisherGroupOrder { order })
       }
-      TrackExtensionType::DynamicGroups => {
-        let value = kvp_varint_value(&kvp, "TrackExtension::deserialize(DynamicGroups)")?;
+      TrackPropertyType::DynamicGroups => {
+        let value = kvp_varint_value(&kvp, "TrackProperty::deserialize(DynamicGroups)")?;
         let enabled = match value {
           0 => false,
           1 => true,
           _ => {
             return Err(ParseError::ProtocolViolation {
-              context: "TrackExtension::deserialize(DynamicGroups)",
+              context: "TrackProperty::deserialize(DynamicGroups)",
               details: format!("DYNAMIC_GROUPS must be 0 or 1, got {value}"),
             });
           }
         };
         Ok(Self::DynamicGroups { enabled })
       }
-      // Object-scope extensions; treated as unknown at track level
+      // Object-scope properties; treated as unknown at track level
       _ => Ok(Self::Unknown { kvp }),
     }
   }
 }
 
-impl TryInto<KeyValuePair> for TrackExtension {
+impl TryInto<KeyValuePair> for TrackProperty {
   type Error = ParseError;
 
   fn try_into(self) -> Result<KeyValuePair, Self::Error> {
     match self {
       Self::DeliveryTimeout { timeout_ms } => {
-        KeyValuePair::try_new_varint(TrackExtensionType::DeliveryTimeout as u64, timeout_ms)
+        KeyValuePair::try_new_varint(TrackPropertyType::DeliveryTimeout as u64, timeout_ms)
       }
       Self::MaxCacheDuration { duration_ms } => {
-        KeyValuePair::try_new_varint(TrackExtensionType::MaxCacheDuration as u64, duration_ms)
+        KeyValuePair::try_new_varint(TrackPropertyType::MaxCacheDuration as u64, duration_ms)
       }
-      Self::ImmutableExtensions { extensions } => KeyValuePair::try_new_bytes(
-        TrackExtensionType::ImmutableExtensions as u64,
-        serialize_kvp_list(&extensions)?,
+      Self::ImmutableProperties { properties } => KeyValuePair::try_new_bytes(
+        TrackPropertyType::ImmutableProperties as u64,
+        serialize_kvp_list(&properties)?,
       ),
       Self::DefaultPublisherPriority { priority } => KeyValuePair::try_new_varint(
-        TrackExtensionType::DefaultPublisherPriority as u64,
+        TrackPropertyType::DefaultPublisherPriority as u64,
         priority as u64,
       ),
       Self::DefaultPublisherGroupOrder { order } => KeyValuePair::try_new_varint(
-        TrackExtensionType::DefaultPublisherGroupOrder as u64,
+        TrackPropertyType::DefaultPublisherGroupOrder as u64,
         order as u64,
       ),
       Self::DynamicGroups { enabled } => KeyValuePair::try_new_varint(
-        TrackExtensionType::DynamicGroups as u64,
+        TrackPropertyType::DynamicGroups as u64,
         if enabled { 1 } else { 0 },
       ),
       Self::Unknown { kvp } => Ok(kvp),
@@ -184,9 +181,9 @@ impl TryInto<KeyValuePair> for TrackExtension {
   }
 }
 
-/// Serializes a slice of TrackExtensions to their concatenated wire KVP bytes.
+/// Serializes a slice of TrackProperties to their concatenated wire KVP bytes.
 /// Empty slice produces no bytes (zero wire overhead).
-pub fn serialize_track_extensions(exts: &[TrackExtension]) -> Result<Bytes, ParseError> {
+pub fn serialize_track_properties(exts: &[TrackProperty]) -> Result<Bytes, ParseError> {
   let kvps: Vec<KeyValuePair> = exts
     .iter()
     .map(|e| e.clone().try_into())
@@ -194,12 +191,12 @@ pub fn serialize_track_extensions(exts: &[TrackExtension]) -> Result<Bytes, Pars
   serialize_kvp_list(&kvps)
 }
 
-/// Deserializes TrackExtensions from remaining payload bytes.
+/// Deserializes TrackProperties from remaining payload bytes.
 /// Reads KVPs until the buffer is empty. Returns an empty Vec if no bytes remain.
-pub fn deserialize_track_extensions(bytes: &mut Bytes) -> Result<Vec<TrackExtension>, ParseError> {
+pub fn deserialize_track_properties(bytes: &mut Bytes) -> Result<Vec<TrackProperty>, ParseError> {
   deserialize_kvp_list_until_empty(bytes)?
     .into_iter()
-    .map(TrackExtension::deserialize)
+    .map(TrackProperty::deserialize)
     .collect()
 }
 
@@ -209,7 +206,7 @@ fn kvp_varint_value(kvp: &KeyValuePair, context: &'static str) -> Result<u64, Pa
     KeyValuePair::Bytes { type_value, .. } => Err(ParseError::ProtocolViolation {
       context,
       details: format!(
-        "Extension type 0x{type_value:02X} expects VarInt encoding but received Bytes"
+        "Property type 0x{type_value:02X} expects VarInt encoding but received Bytes"
       ),
     }),
   }
@@ -221,7 +218,7 @@ fn kvp_bytes_value(kvp: &KeyValuePair, context: &'static str) -> Result<Bytes, P
     KeyValuePair::VarInt { type_value, .. } => Err(ParseError::ProtocolViolation {
       context,
       details: format!(
-        "Extension type 0x{type_value:02X} expects Bytes encoding but received VarInt"
+        "Property type 0x{type_value:02X} expects Bytes encoding but received VarInt"
       ),
     }),
   }
@@ -232,50 +229,50 @@ mod tests {
   use super::*;
   use bytes::{Buf, Bytes};
 
-  fn roundtrip(ext: TrackExtension) -> TrackExtension {
+  fn roundtrip(ext: TrackProperty) -> TrackProperty {
     let serialized = ext.serialize().unwrap();
     let mut buf = serialized;
     let kvp = KeyValuePair::deserialize(&mut buf).unwrap();
     assert!(!buf.has_remaining());
-    TrackExtension::deserialize(kvp).unwrap()
+    TrackProperty::deserialize(kvp).unwrap()
   }
 
   #[test]
   fn test_roundtrip_delivery_timeout() {
-    let ext = TrackExtension::DeliveryTimeout { timeout_ms: 5000 };
+    let ext = TrackProperty::DeliveryTimeout { timeout_ms: 5000 };
     assert_eq!(roundtrip(ext.clone()), ext);
   }
 
   #[test]
   fn test_roundtrip_max_cache_duration() {
-    let ext = TrackExtension::MaxCacheDuration { duration_ms: 10000 };
+    let ext = TrackProperty::MaxCacheDuration { duration_ms: 10000 };
     assert_eq!(roundtrip(ext.clone()), ext);
   }
 
   #[test]
-  fn test_roundtrip_immutable_extensions() {
+  fn test_roundtrip_immutable_properties() {
     let inner = vec![
       KeyValuePair::try_new_varint(0x10, 42).unwrap(),
       KeyValuePair::try_new_bytes(0x11, Bytes::from_static(b"hello")).unwrap(),
     ];
-    let ext = TrackExtension::ImmutableExtensions {
-      extensions: inner.clone(),
+    let ext = TrackProperty::ImmutableProperties {
+      properties: inner.clone(),
     };
     assert_eq!(roundtrip(ext.clone()), ext);
   }
 
   #[test]
   fn test_roundtrip_default_publisher_priority() {
-    let ext = TrackExtension::DefaultPublisherPriority { priority: 128 };
+    let ext = TrackProperty::DefaultPublisherPriority { priority: 128 };
     assert_eq!(roundtrip(ext.clone()), ext);
-    let ext_max = TrackExtension::DefaultPublisherPriority { priority: 255 };
+    let ext_max = TrackProperty::DefaultPublisherPriority { priority: 255 };
     assert_eq!(roundtrip(ext_max.clone()), ext_max);
   }
 
   #[test]
   fn test_roundtrip_default_publisher_group_order() {
     for order in [GroupOrder::Ascending, GroupOrder::Descending] {
-      let ext = TrackExtension::DefaultPublisherGroupOrder { order };
+      let ext = TrackProperty::DefaultPublisherGroupOrder { order };
       assert_eq!(roundtrip(ext.clone()), ext);
     }
   }
@@ -283,7 +280,7 @@ mod tests {
   #[test]
   fn test_roundtrip_dynamic_groups() {
     for enabled in [true, false] {
-      let ext = TrackExtension::DynamicGroups { enabled };
+      let ext = TrackProperty::DynamicGroups { enabled };
       assert_eq!(roundtrip(ext.clone()), ext);
     }
   }
@@ -291,7 +288,7 @@ mod tests {
   #[test]
   fn test_roundtrip_unknown() {
     let kvp = KeyValuePair::try_new_varint(0xFE, 99).unwrap();
-    let ext = TrackExtension::Unknown { kvp };
+    let ext = TrackProperty::Unknown { kvp };
     assert_eq!(roundtrip(ext.clone()), ext);
   }
 
@@ -299,7 +296,7 @@ mod tests {
   fn test_delivery_timeout_zero_is_error() {
     let kvp = KeyValuePair::try_new_varint(0x02, 0).unwrap();
     assert!(matches!(
-      TrackExtension::deserialize(kvp).unwrap_err(),
+      TrackProperty::deserialize(kvp).unwrap_err(),
       ParseError::ProtocolViolation { .. }
     ));
   }
@@ -308,7 +305,7 @@ mod tests {
   fn test_default_publisher_priority_over_255_is_error() {
     let kvp = KeyValuePair::try_new_varint(0x0E, 256).unwrap();
     assert!(matches!(
-      TrackExtension::deserialize(kvp).unwrap_err(),
+      TrackProperty::deserialize(kvp).unwrap_err(),
       ParseError::ProtocolViolation { .. }
     ));
   }
@@ -317,7 +314,7 @@ mod tests {
   fn test_default_publisher_group_order_original_is_error() {
     let kvp = KeyValuePair::try_new_varint(0x22, 0).unwrap(); // 0 = Original, invalid
     assert!(matches!(
-      TrackExtension::deserialize(kvp).unwrap_err(),
+      TrackProperty::deserialize(kvp).unwrap_err(),
       ParseError::ProtocolViolation { .. }
     ));
   }
@@ -326,18 +323,18 @@ mod tests {
   fn test_dynamic_groups_over_1_is_error() {
     let kvp = KeyValuePair::try_new_varint(0x30, 2).unwrap();
     assert!(matches!(
-      TrackExtension::deserialize(kvp).unwrap_err(),
+      TrackProperty::deserialize(kvp).unwrap_err(),
       ParseError::ProtocolViolation { .. }
     ));
   }
 
   #[test]
-  fn test_immutable_extensions_nested_is_error() {
+  fn test_immutable_properties_nested_is_error() {
     let inner_immutable = KeyValuePair::try_new_bytes(0x0B, Bytes::from_static(b"")).unwrap();
     let inner_bytes = inner_immutable.serialize().unwrap();
     let outer = KeyValuePair::try_new_bytes(0x0B, inner_bytes).unwrap();
     assert!(matches!(
-      TrackExtension::deserialize(outer).unwrap_err(),
+      TrackProperty::deserialize(outer).unwrap_err(),
       ParseError::ProtocolViolation { .. }
     ));
   }
@@ -345,32 +342,32 @@ mod tests {
   #[test]
   fn test_serialize_deserialize_mixed() {
     let exts = vec![
-      TrackExtension::DeliveryTimeout { timeout_ms: 1000 },
-      TrackExtension::DefaultPublisherPriority { priority: 64 },
-      TrackExtension::DynamicGroups { enabled: true },
-      TrackExtension::Unknown {
+      TrackProperty::DeliveryTimeout { timeout_ms: 1000 },
+      TrackProperty::DefaultPublisherPriority { priority: 64 },
+      TrackProperty::DynamicGroups { enabled: true },
+      TrackProperty::Unknown {
         kvp: KeyValuePair::try_new_varint(0xFE, 7).unwrap(),
       },
     ];
-    let serialized = serialize_track_extensions(&exts).unwrap();
+    let serialized = serialize_track_properties(&exts).unwrap();
     let mut buf = serialized;
-    let deserialized = deserialize_track_extensions(&mut buf).unwrap();
+    let deserialized = deserialize_track_properties(&mut buf).unwrap();
     assert_eq!(deserialized, exts);
   }
 
   #[test]
   fn test_serialize_deserialize_empty() {
-    let serialized = serialize_track_extensions(&[]).unwrap();
+    let serialized = serialize_track_properties(&[]).unwrap();
     assert!(serialized.is_empty());
     let mut buf = serialized;
-    let deserialized = deserialize_track_extensions(&mut buf).unwrap();
+    let deserialized = deserialize_track_properties(&mut buf).unwrap();
     assert!(deserialized.is_empty());
   }
 
   #[test]
-  fn test_immutable_extensions_independent_of_outer_prev_type() {
-    // A low-type extension precedes ImmutableExtensions (0x0B) in the outer
-    // list, so the outer prev_type is nonzero by the time ImmutableExtensions
+  fn test_immutable_properties_independent_of_outer_prev_type() {
+    // A low-type property precedes ImmutableProperties (0x0B) in the outer
+    // list, so the outer prev_type is nonzero by the time ImmutableProperties
     // is reached. The inner KVP list must restart its own delta state from 0,
     // independent of the outer list's running prev_type.
     let inner = vec![
@@ -378,14 +375,14 @@ mod tests {
       KeyValuePair::try_new_bytes(0x03, Bytes::from_static(b"data")).unwrap(),
     ];
     let exts = vec![
-      TrackExtension::DeliveryTimeout { timeout_ms: 100 },
-      TrackExtension::ImmutableExtensions {
-        extensions: inner.clone(),
+      TrackProperty::DeliveryTimeout { timeout_ms: 100 },
+      TrackProperty::ImmutableProperties {
+        properties: inner.clone(),
       },
     ];
-    let serialized = serialize_track_extensions(&exts).unwrap();
+    let serialized = serialize_track_properties(&exts).unwrap();
     let mut buf = serialized;
-    let deserialized = deserialize_track_extensions(&mut buf).unwrap();
+    let deserialized = deserialize_track_properties(&mut buf).unwrap();
     assert_eq!(deserialized, exts);
   }
 }

--- a/libs/moqtail-rs/src/transport/control_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/control_stream_handler.rs
@@ -378,8 +378,8 @@ mod tests {
 
   fn create_test_subscribe_ok() -> SubscribeOk {
     use crate::model::control::constant::GroupOrder;
-    use crate::model::extension_header::track_extension::TrackExtension;
     use crate::model::parameter::message_parameter::MessageParameter;
+    use crate::model::property::track_property::TrackProperty;
     let mut subscribe_ok = SubscribeOk::new(
       145136,
       999,
@@ -392,7 +392,7 @@ mod tests {
         }),
         MessageParameter::new_expires(100),
       ],
-      vec![TrackExtension::DeliveryTimeout { timeout_ms: 5000 }],
+      vec![TrackProperty::DeliveryTimeout { timeout_ms: 5000 }],
     );
     // Wire encoding canonicalizes parameter order ascending by type (delta-encoding requirement).
     subscribe_ok

--- a/libs/moqtail-rs/src/transport/data_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/data_stream_handler.rs
@@ -214,9 +214,9 @@ impl SendDataStream {
         self.fetch_prev_ctx = fetch_obj.context();
       }
       HeaderInfo::Subgroup { header, .. } => {
-        let has_extensions = header.header_type.has_extensions();
+        let has_properties = header.header_type.has_properties();
         let subgroup_obj = object.try_into_subgroup()?;
-        buf.extend_from_slice(&subgroup_obj.serialize(previous_object_id, has_extensions)?);
+        buf.extend_from_slice(&subgroup_obj.serialize(previous_object_id, has_properties)?);
       }
     }
 
@@ -564,8 +564,8 @@ impl RecvDataStream {
           )
         }
         HeaderInfo::Subgroup { header, .. } => {
-          let has_extensions = header.header_type.has_extensions();
-          SubgroupObject::deserialize(&mut bytes_cursor, previous_object_id, has_extensions)
+          let has_properties = header.header_type.has_properties();
+          SubgroupObject::deserialize(&mut bytes_cursor, previous_object_id, has_properties)
             .and_then(|subgroup_obj| {
               let object_id = subgroup_obj.object_id;
               let object = Object::try_from_subgroup(
@@ -690,9 +690,9 @@ mod tests {
   use crate::model::control::fetch::JoiningFetchProps;
   use crate::model::control::{fetch::Fetch, subscribe::Subscribe};
   use crate::model::data::constant::SubgroupHeaderType;
-  use crate::model::extension_header::object_extension::ObjectExtension;
   use crate::model::parameter::authorization_token::AuthorizationToken;
   use crate::model::parameter::message_parameter::MessageParameter;
+  use crate::model::property::object_property::ObjectProperty;
   use bytes::Bytes;
   use std::error::Error;
   use std::sync::Arc;
@@ -731,11 +731,11 @@ mod tests {
       object_id: 10,
       publisher_priority: 255,
       forwarding_preference: ObjectForwardingPreference::Subgroup,
-      extension_headers: Some(vec![
-        ObjectExtension::Unknown {
+      properties: Some(vec![
+        ObjectProperty::Unknown {
           kvp: KeyValuePair::try_new_varint(0, 10).unwrap(),
         },
-        ObjectExtension::Unknown {
+        ObjectProperty::Unknown {
           kvp: KeyValuePair::try_new_bytes(1, Bytes::from_static(b"wololoo")).unwrap(),
         },
       ]),
@@ -790,11 +790,11 @@ mod tests {
   #[allow(dead_code)]
   fn make_subgroup_object() -> SubgroupObject {
     let object_id: u64 = 10;
-    let extension_headers = Some(vec![
-      ObjectExtension::Unknown {
+    let properties = Some(vec![
+      ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_varint(0, 10).unwrap(),
       },
-      ObjectExtension::Unknown {
+      ObjectProperty::Unknown {
         kvp: KeyValuePair::try_new_bytes(1, Bytes::from_static(b"wololoo")).unwrap(),
       },
     ]);
@@ -803,7 +803,7 @@ mod tests {
 
     SubgroupObject {
       object_id,
-      extension_headers,
+      properties,
       payload,
       object_status,
     }


### PR DESCRIPTION
Implements task `RS-8` from [`docs/draft16to18tasks.md`](docs/draft16to18tasks.md). Closes #226.

> 📎 **A.2 : 7427** — "Rename Extension Headers to Properties (#1504)"

## What this is

A pure rename, no wire-format or behaviour change. `model/extension_header/` → `model/property/`, with `track_extension`/`object_extension` → `track_property`/`object_property`.

Public API: `TrackExtension` → `TrackProperty`, `ObjectExtension` → `ObjectProperty`, `TrackExtensionType` → `TrackPropertyType`, `LOCHeaderExtension` → `LOCProperty`, `LOCHeaderExtensionId` → `LOCPropertyId`, and the `ImmutableExtensions` variant → `ImmutableProperties`.

## Beyond the literal list in the issue

Three things were renamed that the issue doesn't spell out, each following draft-18's own vocabulary:

- **The wire-flag names.** §11.4.2 renames the type bit to **PROPERTIES** (0x01) and the field to `Properties`, so `has_extensions()` → `has_properties()` and the `EXTENSIONS` / `FLAG_EXTENSIONS_PRESENT` constants → `PROPERTIES` / `FLAG_PROPERTIES_PRESENT`. Leaving these would have left the wire vocabulary contradicting the spec.
- **Struct fields**, since `extension_headers` is itself an `extension_header` identifier: `track_extensions` → `track_properties` on `Publish`/`SubscribeOk`/`FetchOk` (draft-18 spells the field "Track Properties"), `extension_headers` → `properties` on `Datagram`/`SubgroupObject`/`FetchObject`, and `Object::extensions` → `properties`.
- **`LOCHeaderExtension` → `LOCProperty`**, the symmetric partner of the specified `LOCHeaderExtensionId` → `LOCPropertyId`.

Three uses of "extension" are deliberately **kept** — they are a different sense of the word, and a blind find-and-replace would have corrupted them:

- `message_parameter.rs:312` — "Extension trait for `Vec<MessageParameter>`" (the Rust idiom)
- `track_manager.rs:509,515` — `new_is_extension_of_existing` / `existing_is_extension_of_new` (namespace-prefix extension)

## Acceptance criteria

- [x] `cargo build --workspace` green
- [x] Test count unchanged — **247** passed for `moqtail` (plus relay's 30), same as before
- [x] No `extension_header` identifiers remain

## How the "pure rename" claim was verified

Rather than reviewing ~900 diff lines by eye: for each changed file, the original content was taken from `HEAD`, the rename script plus `rustfmt` replayed over it, and the result diffed against the working tree. **21 of 22 `.rs` files reproduce byte-for-byte.** The only file that differs is `model.rs`, where the sole difference is restoring alphabetical order (`parameter` before `property`).

## Also included

One line in `docs/draft16to18tasks.md`: RS-9's `Files:` pointer referenced `model/extension_header/constant.rs:55-63`, a path this PR deletes. Since RS-8 unblocks RS-9 (#228), it now points at `model/property/constant.rs:55-63` (line numbers still hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)