### PR TITLE
feat(conformance): share draft-18 constants and varint vectors 

### DIFF
--- a/dev/conformance/draft18/README.md
+++ b/dev/conformance/draft18/README.md
@@ -1,0 +1,78 @@
+# Conformance fixtures
+
+Language-agnostic JSON fixtures for the MOQT draft this directory is named after. Both
+`libs/moqtail-rs` and `libs/moqtail-ts` load these files and assert their constants against
+them.
+
+**These fixtures are normative for both stacks.** A codepoint is changed here first, and never
+in one language only. Every value is transcribed from the draft text in `docs/`; each file
+names the table it comes from and each entry carries its own spec reference, so a fixture can
+be diffed against the draft without reading any code.
+
+## Files
+
+| File                       | Source                                                              |
+| -------------------------- | ------------------------------------------------------------------- |
+| `varint.json`              | §1.4.1 Table 1 and Table 2, plus non-minimal and boundary cases     |
+| `message_types.json`       | §10 Table 5 — control message types and the Stream column           |
+| `parameter_types.json`     | §15.4 Table 10 (Setup Options), §15.7 Table 13 (Message Parameters) |
+| `property_types.json`      | §15.8 Table 14, Table 15 (provisional), and the range policy        |
+| `stream_reset_codes.json`  | §3.3.3, §15.10.4 Table 20                                           |
+| `request_error_codes.json` | §15.10.2 Table 18                                                   |
+| `termination_codes.json`   | §15.10.1 Table 17                                                   |
+
+## Conventions
+
+Codepoints are hex **strings** (`"0x50"`), so a fixture diffs against the draft's own tables
+without mental base conversion.
+
+Varint values are decimal **strings**. The largest of them, `18446744073709551615` (2^64-1),
+cannot survive `JSON.parse` as a number — it silently rounds. Byte sequences are lowercase hex
+strings with no `0x` prefix.
+
+`"reserved": true` marks a codepoint the draft reserves. Parsers must reject it rather than
+map it to a name.
+
+## Sections
+
+`entries` is the draft's table. A stack must define exactly these codepoints, with these
+values, and must reject the ones marked `reserved`.
+
+`not_in_draft` names codepoints a stack still defines that the draft does not. They are what
+makes the check work in both directions: without them a suite could only prove that every
+entry in the table exists in the code, never that the code has stopped inventing codepoints of
+its own. Each carries a `pending` marker naming the issue that removes it; once that lands,
+parsers must reject the value.
+
+`local_extensions` is deliberate, permanent non-conformance — codepoints this project uses
+that the draft does not define and that are not going away. They are never asserted against
+the draft, and unlike `not_in_draft` they carry no `pending` marker, because nothing is
+pending: the divergence is the decision.
+
+## Pending markers
+
+An entry a stack does not implement yet carries a marker naming the issue that will land it:
+
+```json
+{
+  "name": "EXAMPLE_MESSAGE",
+  "value": "0x50",
+  "pending": { "rs": 1234, "ts": 5678 }
+}
+```
+
+That reads: _this entry is normative, but moqtail-rs will not conform until issue 1234, and
+moqtail-ts not until issue 5678._ A stack named in `pending` is exempt from the assertion; a
+stack not named must match exactly or its suite fails. An entry with no `pending` key binds
+both stacks.
+
+Markers are self-cleaning. The tests also assert that a pending entry is still
+non-conformant, so when the work lands the suite fails with _"marked pending but now conforms
+— delete the marker"_. A marker cannot quietly become a permanent exemption, and what remains
+marked is an accurate account of what is left to do.
+
+## Adding or changing a codepoint
+
+1. Change it here, citing the draft.
+2. Run both suites. Whichever stack drifted now fails.
+3. Fix that stack — or add a `pending` marker naming the issue that will.

--- a/dev/conformance/draft18/message_types.json
+++ b/dev/conformance/draft18/message_types.json
@@ -1,0 +1,264 @@
+{
+  "source": "draft-ietf-moq-transport-18 §10 Table 5",
+  "description": "Control message types. The stream field records which stream a message is sent on: \"Control\" is the control stream (§3.3), \"Request\" a bidirectional request stream. \"First\" means the message MUST be the first on a new request stream. Reserved codepoints carry no stream and MUST be rejected.",
+  "entries": [
+    {
+      "name": "RESERVED_SETUP_V00",
+      "value": "0x01",
+      "reserved": true,
+      "spec": "Table 5",
+      "notes": "SETUP for version 00. moqtail-ts maps this to a ReservedSetupV00 variant instead of rejecting it.",
+      "pending": {
+        "ts": 255
+      }
+    },
+    {
+      "name": "RESERVED_CLIENT_SETUP_V10",
+      "value": "0x40",
+      "reserved": true,
+      "spec": "Table 5",
+      "notes": "CLIENT_SETUP for version <= 10. moqtail-ts maps this to a ReservedClientSetupV10 variant instead of rejecting it.",
+      "pending": {
+        "ts": 255
+      }
+    },
+    {
+      "name": "RESERVED_SERVER_SETUP_V10",
+      "value": "0x41",
+      "reserved": true,
+      "spec": "Table 5",
+      "notes": "SERVER_SETUP for version <= 10. moqtail-ts maps this to a ReservedServerSetupV10 variant instead of rejecting it.",
+      "pending": {
+        "ts": 255
+      }
+    },
+    {
+      "name": "RESERVED_CLIENT_SETUP_V16",
+      "value": "0x20",
+      "reserved": true,
+      "spec": "Table 5",
+      "notes": "CLIENT_SETUP in version <= 16. Both stacks still carry a live CLIENT_SETUP here.",
+      "pending": {
+        "rs": 227,
+        "ts": 256
+      }
+    },
+    {
+      "name": "RESERVED_SERVER_SETUP_V16",
+      "value": "0x21",
+      "reserved": true,
+      "spec": "Table 5",
+      "notes": "SERVER_SETUP in version <= 16. Both stacks still carry a live SERVER_SETUP here.",
+      "pending": {
+        "rs": 227,
+        "ts": 256
+      }
+    },
+    {
+      "name": "SETUP",
+      "value": "0x2F00",
+      "stream": "Control",
+      "spec": "Section 10.3",
+      "pending": {
+        "rs": 225,
+        "ts": 255
+      }
+    },
+    {
+      "name": "GOAWAY",
+      "value": "0x10",
+      "stream": "Control, Request",
+      "spec": "Section 10.4"
+    },
+    {
+      "name": "SUBSCRIBE",
+      "value": "0x3",
+      "stream": "Request, First",
+      "spec": "Section 10.7"
+    },
+    {
+      "name": "SUBSCRIBE_OK",
+      "value": "0x4",
+      "stream": "Request",
+      "spec": "Section 10.8",
+      "notes": "Remains a distinct message with its own body; not folded into REQUEST_OK."
+    },
+    {
+      "name": "PUBLISH",
+      "value": "0x1D",
+      "stream": "Request, First",
+      "spec": "Section 10.10"
+    },
+    {
+      "name": "PUBLISH_OK",
+      "value": "0x1E",
+      "stream": "Request",
+      "spec": "Section 10.5",
+      "notes": "Table 5 keeps this codepoint but points it at Section 10.5, REQUEST_OK: it is an alias, not a message with its own body."
+    },
+    {
+      "name": "PUBLISH_DONE",
+      "value": "0xB",
+      "stream": "Request",
+      "spec": "Section 10.11"
+    },
+    {
+      "name": "FETCH",
+      "value": "0x16",
+      "stream": "Request, First",
+      "spec": "Section 10.12"
+    },
+    {
+      "name": "FETCH_OK",
+      "value": "0x18",
+      "stream": "Request",
+      "spec": "Section 10.13",
+      "notes": "Remains a distinct message with its own body; not folded into REQUEST_OK."
+    },
+    {
+      "name": "TRACK_STATUS",
+      "value": "0xD",
+      "stream": "Request, First",
+      "spec": "Section 10.14"
+    },
+    {
+      "name": "PUBLISH_NAMESPACE",
+      "value": "0x6",
+      "stream": "Request, First",
+      "spec": "Section 10.15"
+    },
+    {
+      "name": "SUBSCRIBE_NAMESPACE",
+      "value": "0x50",
+      "stream": "Request, First",
+      "spec": "Section 10.18",
+      "notes": "Renumbered from 0x11. Both stacks still carry 0x11.",
+      "pending": {
+        "rs": 225,
+        "ts": 255
+      }
+    },
+    {
+      "name": "SUBSCRIBE_TRACKS",
+      "value": "0x51",
+      "stream": "Request, First",
+      "spec": "Section 10.19",
+      "pending": {
+        "rs": 225,
+        "ts": 255
+      }
+    },
+    {
+      "name": "NAMESPACE",
+      "value": "0x8",
+      "stream": "Request",
+      "spec": "Section 10.16"
+    },
+    {
+      "name": "NAMESPACE_DONE",
+      "value": "0xE",
+      "stream": "Request",
+      "spec": "Section 10.17"
+    },
+    {
+      "name": "PUBLISH_BLOCKED",
+      "value": "0xF",
+      "stream": "Request",
+      "spec": "Section 10.20",
+      "pending": {
+        "rs": 225,
+        "ts": 255
+      }
+    },
+    {
+      "name": "REQUEST_UPDATE",
+      "value": "0x2",
+      "stream": "Request",
+      "spec": "Section 10.9"
+    },
+    {
+      "name": "REQUEST_OK",
+      "value": "0x7",
+      "stream": "Request",
+      "spec": "Section 10.5"
+    },
+    {
+      "name": "REQUEST_ERROR",
+      "value": "0x5",
+      "stream": "Request",
+      "spec": "Section 10.6"
+    }
+  ],
+  "not_in_draft": [
+    {
+      "name": "MAX_REQUEST_ID",
+      "value": "0x15",
+      "notes": "Table 5 has no 0x15.",
+      "pending": {
+        "rs": 236,
+        "ts": 259
+      }
+    },
+    {
+      "name": "REQUESTS_BLOCKED",
+      "value": "0x1A",
+      "notes": "Table 5 has no 0x1A.",
+      "pending": {
+        "rs": 236,
+        "ts": 259
+      }
+    },
+    {
+      "name": "UNSUBSCRIBE",
+      "value": "0x0A",
+      "notes": "Requests are cancelled by resetting the request stream (§3.3.2), not by a message.",
+      "pending": {
+        "rs": 241,
+        "ts": 261
+      }
+    },
+    {
+      "name": "FETCH_CANCEL",
+      "value": "0x17",
+      "notes": "Requests are cancelled by resetting the request stream (§3.3.2), not by a message.",
+      "pending": {
+        "rs": 241,
+        "ts": 261
+      }
+    },
+    {
+      "name": "UNSUBSCRIBE_NAMESPACE",
+      "value": "0x14",
+      "notes": "Requests are cancelled by closing the request stream (§3.3.2), not by a message.",
+      "pending": {
+        "rs": 241,
+        "ts": 261
+      }
+    },
+    {
+      "name": "PUBLISH_NAMESPACE_CANCEL",
+      "value": "0x0C",
+      "notes": "Table 5 has no 0x0C.",
+      "pending": {
+        "rs": 241,
+        "ts": 261
+      }
+    },
+    {
+      "name": "PUBLISH_NAMESPACE_DONE",
+      "value": "0x09",
+      "notes": "Table 5 has no 0x09. NAMESPACE_DONE (0xE) survives.",
+      "pending": {
+        "rs": 241,
+        "ts": 261
+      }
+    }
+  ],
+  "local_extensions": [
+    {
+      "name": "SWITCH",
+      "value": "0x22",
+      "notes": "moqtail's own track-switching research extension. Not in the draft, and deliberately kept: draft-18 defines no registry for control message types, so there is no sanctioned range for it. Documented rather than removed. 0x22 is unassigned in Table 5 but live in neighbouring registries (GROUP_ORDER parameter, DEFAULT_PUBLISHER_GROUP_ORDER property), so it is a plausible future assignment."
+    }
+  ]
+}

--- a/dev/conformance/draft18/parameter_types.json
+++ b/dev/conformance/draft18/parameter_types.json
@@ -1,0 +1,85 @@
+{
+  "source": "draft-ietf-moq-transport-18 §15.4 Table 10, §15.7 Table 13",
+  "description": "Two distinct registries. Setup Options appear in SETUP (§10.3); Message Parameters appear in request and response messages (§10.2). They share no number space.",
+
+  "setup_options": {
+    "source": "§15.4 Table 10",
+    "greasing": {
+      "formula": "0x7f * N + 0x9D",
+      "spec": "Section 14",
+      "notes": "Reserved for greasing. Endpoints MUST ignore unknown Setup Options (§10.3)."
+    },
+    "entries": [
+      { "name": "PATH", "value": "0x01", "spec": "Section 10.3.1.2" },
+      { "name": "AUTHORIZATION_TOKEN", "value": "0x03", "spec": "Section 10.3.1.4" },
+      { "name": "MAX_AUTH_TOKEN_CACHE_SIZE", "value": "0x04", "spec": "Section 10.3.1.3" },
+      {
+        "name": "AUTHORITY",
+        "value": "0x05",
+        "spec": "Section 10.3.1.1",
+        "notes": "moqtail-rs has this; moqtail-ts does not.",
+        "pending": { "ts": 256 }
+      },
+      {
+        "name": "MOQT_IMPLEMENTATION",
+        "value": "0x07",
+        "spec": "Section 10.3.1.5",
+        "notes": "moqtail-rs has this; moqtail-ts does not.",
+        "pending": { "ts": 256 }
+      }
+    ],
+    "not_in_draft": [
+      {
+        "name": "MAX_REQUEST_ID",
+        "value": "0x02",
+        "notes": "Table 10 has no 0x02. Removed with the MAX_REQUEST_ID message.",
+        "pending": { "rs": 236, "ts": 259 }
+      }
+    ]
+  },
+
+  "message_parameters": {
+    "source": "§15.7 Table 13",
+    "entries": [
+      {
+        "name": "OBJECT_DELIVERY_TIMEOUT",
+        "value": "0x02",
+        "spec": "Section 10.2.4",
+        "notes": "Both stacks call this DeliveryTimeout; draft-18 splits the timeout in two and renames this one.",
+        "pending": { "rs": 228, "ts": 265 }
+      },
+      { "name": "AUTHORIZATION_TOKEN", "value": "0x03", "spec": "Section 10.2.2" },
+      {
+        "name": "RENDEZVOUS_TIMEOUT",
+        "value": "0x04",
+        "spec": "Section 10.2.6",
+        "pending": { "rs": 228, "ts": 265 }
+      },
+      {
+        "name": "SUBGROUP_DELIVERY_TIMEOUT",
+        "value": "0x06",
+        "spec": "Section 10.2.3",
+        "pending": { "rs": 228, "ts": 265 }
+      },
+      { "name": "EXPIRES", "value": "0x08", "spec": "Section 10.2.10" },
+      { "name": "LARGEST_OBJECT", "value": "0x09", "spec": "Section 10.2.11" },
+      {
+        "name": "FILL_TIMEOUT",
+        "value": "0x0A",
+        "spec": "Section 10.2.5",
+        "pending": { "rs": 228, "ts": 265 }
+      },
+      { "name": "FORWARD", "value": "0x10", "spec": "Section 10.2.12" },
+      { "name": "SUBSCRIBER_PRIORITY", "value": "0x20", "spec": "Section 10.2.7" },
+      { "name": "SUBSCRIPTION_FILTER", "value": "0x21", "spec": "Section 10.2.9" },
+      { "name": "GROUP_ORDER", "value": "0x22", "spec": "Section 10.2.8" },
+      { "name": "NEW_GROUP_REQUEST", "value": "0x32", "spec": "Section 10.2.13" },
+      {
+        "name": "TRACK_NAMESPACE_PREFIX",
+        "value": "0x34",
+        "spec": "Section 10.2.14",
+        "pending": { "rs": 228, "ts": 265 }
+      }
+    ]
+  }
+}

--- a/dev/conformance/draft18/property_types.json
+++ b/dev/conformance/draft18/property_types.json
@@ -1,0 +1,107 @@
+{
+  "source": "draft-ietf-moq-transport-18 §15.8 Table 14, Table 15",
+  "description": "Property types. Scope is Track, Object, or both. Endpoints MUST ignore unknown Property types, skipping them using the length field. Even type values use VarInt KVP encoding; odd type values use Bytes KVP encoding.",
+
+  "greasing": {
+    "formula": "0x7f * N + 0x9D",
+    "spec": "Section 14",
+    "scope": "Any"
+  },
+
+  "ranges": {
+    "description": "Registration policy for the Property Type space.",
+    "entries": [
+      { "from": "0x00", "to": "0x77", "policy": "Standards Action or IESG Approval (1-byte encoding)" },
+      {
+        "from": "0x78",
+        "to": "0x7F",
+        "policy": "Reserved for application-specific use (1-byte encoding, no registration permitted)"
+      },
+      { "from": "0x80", "to": "0x37FF", "policy": "Specification Required (2-byte encoding)" },
+      {
+        "from": "0x3800",
+        "to": "0x3FFF",
+        "policy": "Reserved for application-specific use (2-byte encoding, no registration permitted)"
+      },
+      {
+        "from": "0x4000",
+        "to": "0x7FFF",
+        "policy": "Reserved for Mandatory Track Properties (§2.5.1). Properties registered in this range MUST have Track scope; Object scope properties MUST NOT be registered in this range."
+      },
+      { "from": "0x8000", "to": null, "policy": "First Come First Served" }
+    ]
+  },
+
+  "entries": [
+    {
+      "name": "OBJECT_DELIVERY_TIMEOUT",
+      "value": "0x02",
+      "scope": "Track",
+      "spec": "Section 12.2",
+      "notes": "Both stacks call this DeliveryTimeout.",
+      "pending": { "rs": 228, "ts": 265 }
+    },
+    { "name": "MAX_CACHE_DURATION", "value": "0x04", "scope": "Track", "spec": "Section 12.3" },
+    {
+      "name": "SUBGROUP_DELIVERY_TIMEOUT",
+      "value": "0x06",
+      "scope": "Track",
+      "spec": "Section 12.1",
+      "notes": "Missing from both stacks entirely.",
+      "pending": { "rs": 228, "ts": 265 }
+    },
+    {
+      "name": "IMMUTABLE_PROPERTIES",
+      "value": "0x0B",
+      "scope": "Track, Object",
+      "spec": "Section 12.7",
+      "notes": "moqtail-ts still calls this ImmutableExtensions.",
+      "pending": { "ts": 264 }
+    },
+    { "name": "DEFAULT_PUBLISHER_PRIORITY", "value": "0x0E", "scope": "Track", "spec": "Section 12.4" },
+    { "name": "DEFAULT_PUBLISHER_GROUP_ORDER", "value": "0x22", "scope": "Track", "spec": "Section 12.5" },
+    { "name": "DYNAMIC_GROUPS", "value": "0x30", "scope": "Track", "spec": "Section 12.6" },
+    { "name": "PRIOR_GROUP_ID_GAP", "value": "0x3C", "scope": "Object", "spec": "Section 12.8" },
+    { "name": "PRIOR_OBJECT_ID_GAP", "value": "0x3E", "scope": "Object", "spec": "Section 12.9" }
+  ],
+
+  "provisional": {
+    "source": "§15.8 Table 15",
+    "description": "Provisional registrations for other active drafts in the moq working group. These share the same Property Type space as the entries above, so they are not a private namespace and must not collide with it. Both stacks carry ids from an older revision of draft-ietf-moq-loc.",
+    "entries": [
+      {
+        "name": "TIMESTAMP",
+        "value": "0x06",
+        "scope": "Object",
+        "spec": "draft-ietf-moq-loc",
+        "notes": "Both stacks call this CaptureTimestamp and put it at 0x02, which is OBJECT_DELIVERY_TIMEOUT.",
+        "pending": { "rs": 282, "ts": 282 }
+      },
+      {
+        "name": "TIMESCALE",
+        "value": "0x08",
+        "scope": "Track, Object",
+        "spec": "draft-ietf-moq-loc",
+        "notes": "Missing from both stacks.",
+        "pending": { "rs": 282, "ts": 282 }
+      },
+      {
+        "name": "VIDEO_FRAME_MARKING",
+        "value": "0x0A",
+        "scope": "Object",
+        "spec": "draft-ietf-moq-loc",
+        "notes": "Both stacks put this at 0x04, which is MAX_CACHE_DURATION.",
+        "pending": { "rs": 282, "ts": 282 }
+      },
+      {
+        "name": "AUDIO_LEVEL",
+        "value": "0x0C",
+        "scope": "Object",
+        "spec": "draft-ietf-moq-loc",
+        "notes": "Both stacks put this at 0x06, which is SUBGROUP_DELIVERY_TIMEOUT and also TIMESTAMP in this table — a draft-18 peer decodes an audio level as a timestamp rather than failing.",
+        "pending": { "rs": 282, "ts": 282 }
+      },
+      { "name": "VIDEO_CONFIG", "value": "0x0D", "scope": "Object", "spec": "draft-ietf-moq-loc" }
+    ]
+  }
+}

--- a/dev/conformance/draft18/request_error_codes.json
+++ b/dev/conformance/draft18/request_error_codes.json
@@ -1,0 +1,57 @@
+{
+  "source": "draft-ietf-moq-transport-18 §15.10.2 Table 18",
+  "description": "Error codes carried by REQUEST_ERROR (§10.6).",
+
+  "greasing": {
+    "formula": "0x7f * N + 0x9D",
+    "spec": "Section 14",
+    "notes": "Reserved for greasing. Not a single codepoint; excluded from the entries below."
+  },
+
+  "entries": [
+    { "name": "INTERNAL_ERROR", "value": "0x0", "spec": "Section 10.6" },
+    { "name": "UNAUTHORIZED", "value": "0x1", "spec": "Section 10.6" },
+    { "name": "TIMEOUT", "value": "0x2", "spec": "Section 10.6" },
+    { "name": "NOT_SUPPORTED", "value": "0x3", "spec": "Section 10.6" },
+    { "name": "MALFORMED_AUTH_TOKEN", "value": "0x4", "spec": "Section 10.6" },
+    { "name": "EXPIRED_AUTH_TOKEN", "value": "0x5", "spec": "Section 10.6" },
+    {
+      "name": "GOING_AWAY",
+      "value": "0x6",
+      "spec": "Section 10.6",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "EXCESSIVE_LOAD",
+      "value": "0x9",
+      "spec": "Section 10.6",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    { "name": "DOES_NOT_EXIST", "value": "0x10", "spec": "Section 10.6" },
+    { "name": "INVALID_RANGE", "value": "0x11", "spec": "Section 10.6" },
+    { "name": "MALFORMED_TRACK", "value": "0x12", "spec": "Section 10.6" },
+    { "name": "DUPLICATE_SUBSCRIPTION", "value": "0x19", "spec": "Section 10.6" },
+    { "name": "UNINTERESTED", "value": "0x20", "spec": "Section 10.6" },
+    { "name": "PREFIX_OVERLAP", "value": "0x30", "spec": "Section 10.6" },
+    {
+      "name": "NAMESPACE_TOO_LARGE",
+      "value": "0x31",
+      "spec": "Section 10.6",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    { "name": "INVALID_JOINING_REQUEST_ID", "value": "0x32", "spec": "Section 10.6" },
+    {
+      "name": "UNSUPPORTED_EXTENSION",
+      "value": "0x33",
+      "spec": "Section 10.6",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "REDIRECT",
+      "value": "0x34",
+      "spec": "Section 10.6",
+      "notes": "Used by GOAWAY-driven request migration.",
+      "pending": { "rs": 244, "ts": 268 }
+    }
+  ]
+}

--- a/dev/conformance/draft18/stream_reset_codes.json
+++ b/dev/conformance/draft18/stream_reset_codes.json
@@ -1,0 +1,83 @@
+{
+  "source": "draft-ietf-moq-transport-18 §3.3.3, §15.10.4 Table 20",
+  "description": "Error codes used when resetting a stream or sending STOP_SENDING. \"The application SHOULD use a relevant error code when resetting or sending STOP_SENDING on any stream.\" Neither stack has this enum yet.",
+
+  "greasing": {
+    "formula": "0x7f * N + 0x9D",
+    "spec": "Section 14",
+    "notes": "Reserved for greasing. Not a single codepoint; excluded from the entries below."
+  },
+
+  "entries": [
+    {
+      "name": "INTERNAL_ERROR",
+      "value": "0x0",
+      "spec": "Section 3.3.3",
+      "notes": "An implementation specific error.",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "CANCELLED",
+      "value": "0x1",
+      "spec": "Section 3.3.3",
+      "notes": "The stream was cancelled by either endpoint. For subscriptions, PUBLISH_DONE may carry a more detailed status code.",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "DELIVERY_TIMEOUT",
+      "value": "0x2",
+      "spec": "Section 3.3.3",
+      "notes": "A delivery timeout (§8) was exceeded for this stream.",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "SESSION_CLOSED",
+      "value": "0x3",
+      "spec": "Section 3.3.3",
+      "notes": "The session is being closed.",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "GOING_AWAY",
+      "value": "0x4",
+      "spec": "Section 3.3.3",
+      "notes": "The endpoint is rejecting this request because it has sent or received a GOAWAY.",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "TOO_FAR_BEHIND",
+      "value": "0x5",
+      "spec": "Section 3.3.3",
+      "notes": "The corresponding subscription has exceeded the publisher's resource limits and is being terminated (§8).",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "UNKNOWN_OBJECT_STATUS",
+      "value": "0x6",
+      "spec": "Section 3.3.3",
+      "notes": "In response to a FETCH, the publisher is unable to determine the status of the next Object in the requested range.",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "EXPIRED_AUTH_TOKEN",
+      "value": "0x7",
+      "spec": "Section 3.3.3",
+      "notes": "The authorization token for the request has expired.",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "EXCESSIVE_LOAD",
+      "value": "0x9",
+      "spec": "Section 3.3.3",
+      "notes": "The endpoint is overloaded and is resetting this stream.",
+      "pending": { "rs": 238, "ts": 260 }
+    },
+    {
+      "name": "MALFORMED_TRACK",
+      "value": "0x12",
+      "spec": "Section 3.3.3",
+      "notes": "A relay publisher detected that the track was malformed (§2.4.2).",
+      "pending": { "rs": 238, "ts": 260 }
+    }
+  ]
+}

--- a/dev/conformance/draft18/termination_codes.json
+++ b/dev/conformance/draft18/termination_codes.json
@@ -1,0 +1,142 @@
+{
+  "source": "draft-ietf-moq-transport-18 §15.10.1 Table 17",
+  "description": "Session termination error codes (§3.5).",
+  "greasing": {
+    "formula": "0x7f * N + 0x9D",
+    "spec": "Section 14",
+    "notes": "Reserved for greasing. Not a single codepoint; excluded from the entries below."
+  },
+  "entries": [
+    {
+      "name": "NO_ERROR",
+      "value": "0x0",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "INTERNAL_ERROR",
+      "value": "0x1",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "UNAUTHORIZED",
+      "value": "0x2",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "PROTOCOL_VIOLATION",
+      "value": "0x3",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "INVALID_REQUEST_ID",
+      "value": "0x4",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "DUPLICATE_TRACK_ALIAS",
+      "value": "0x5",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "KEY_VALUE_FORMATTING_ERROR",
+      "value": "0x6",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "INVALID_PATH",
+      "value": "0x8",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "MALFORMED_PATH",
+      "value": "0x9",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "GOAWAY_TIMEOUT",
+      "value": "0x10",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "CONTROL_MESSAGE_TIMEOUT",
+      "value": "0x11",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "DATA_STREAM_TIMEOUT",
+      "value": "0x12",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "AUTH_TOKEN_CACHE_OVERFLOW",
+      "value": "0x13",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "DUPLICATE_AUTH_TOKEN_ALIAS",
+      "value": "0x14",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "VERSION_NEGOTIATION_FAILED",
+      "value": "0x15",
+      "spec": "Section 3.5"
+    },
+    {
+      "name": "MALFORMED_AUTH_TOKEN",
+      "value": "0x16",
+      "spec": "Section 3.5",
+      "notes": "moqtail-ts defines this but TerminationCode.tryFrom throws on it.",
+      "pending": {
+        "ts": 275
+      }
+    },
+    {
+      "name": "UNKNOWN_AUTH_TOKEN_ALIAS",
+      "value": "0x17",
+      "spec": "Section 3.5",
+      "notes": "moqtail-ts defines this but TerminationCode.tryFrom throws on it.",
+      "pending": {
+        "ts": 275
+      }
+    },
+    {
+      "name": "EXPIRED_AUTH_TOKEN",
+      "value": "0x18",
+      "spec": "Section 3.5",
+      "notes": "moqtail-ts defines this but TerminationCode.tryFrom throws on it.",
+      "pending": {
+        "ts": 275
+      }
+    },
+    {
+      "name": "INVALID_AUTHORITY",
+      "value": "0x19",
+      "spec": "Section 3.5",
+      "notes": "moqtail-ts defines this but TerminationCode.tryFrom throws on it.",
+      "pending": {
+        "ts": 275
+      }
+    },
+    {
+      "name": "MALFORMED_AUTHORITY",
+      "value": "0x1A",
+      "spec": "Section 3.5",
+      "notes": "moqtail-ts defines this but TerminationCode.tryFrom throws on it.",
+      "pending": {
+        "ts": 275
+      }
+    }
+  ],
+  "not_in_draft": [
+    {
+      "name": "TOO_MANY_REQUESTS",
+      "value": "0x7",
+      "notes": "Both stacks carry this; Table 17 has no 0x7. Removed alongside MAX_REQUEST_ID / REQUESTS_BLOCKED.",
+      "pending": {
+        "rs": 236,
+        "ts": 259
+      }
+    }
+  ]
+}

--- a/dev/conformance/draft18/varint.json
+++ b/dev/conformance/draft18/varint.json
@@ -1,0 +1,126 @@
+{
+  "source": "draft-ietf-moq-transport-18 §1.4.1 (Table 1, Table 2)",
+  "description": "Variable-length integer encoding. The number of leading 1 bits of the first byte gives length - 1. Values are decimal strings; encodings are lowercase hex without a 0x prefix.",
+
+  "lengths": {
+    "description": "Table 1. Summary of integer encodings.",
+    "entries": [
+      { "leading_bits": "0", "length": 1, "usable_bits": 7, "max": "127" },
+      { "leading_bits": "10", "length": 2, "usable_bits": 14, "max": "16383" },
+      { "leading_bits": "110", "length": 3, "usable_bits": 21, "max": "2097151" },
+      { "leading_bits": "1110", "length": 4, "usable_bits": 28, "max": "268435455" },
+      { "leading_bits": "11110", "length": 5, "usable_bits": 35, "max": "34359738367" },
+      { "leading_bits": "111110", "length": 6, "usable_bits": 42, "max": "4398046511103" },
+      { "leading_bits": "1111110", "length": 7, "usable_bits": 49, "max": "562949953421311" },
+      { "leading_bits": "11111110", "length": 8, "usable_bits": 56, "max": "72057594037927935" },
+      { "leading_bits": "11111111", "length": 9, "usable_bits": 64, "max": "18446744073709551615" }
+    ]
+  },
+
+  "vectors": {
+    "description": "Table 2. Example integer encodings, verbatim. Entries with minimal=false are non-minimal: they must decode to the value, but encoding the value produces a shorter form.",
+    "entries": [
+      { "encoding": "25", "value": "37", "minimal": true },
+      { "encoding": "8025", "value": "37", "minimal": false },
+      { "encoding": "bbbd", "value": "15293", "minimal": true },
+      { "encoding": "ed7f3e7d", "value": "226442877", "minimal": true },
+      { "encoding": "faa1a0e403d8", "value": "2893212287960", "minimal": true },
+      { "encoding": "fc8998abc66bc0", "value": "151288809941952", "minimal": true },
+      { "encoding": "fefa318fa8e3ca11", "value": "70423237261249041", "minimal": true },
+      { "encoding": "ffffffffffffffffff", "value": "18446744073709551615", "minimal": true }
+    ]
+  },
+
+  "boundaries": {
+    "description": "The values just below and just above every length transition, with the exact minimal encoding of each.",
+    "entries": [
+      { "value": "0", "length": 1, "encoding": "00" },
+      { "value": "127", "length": 1, "encoding": "7f" },
+      { "value": "128", "length": 2, "encoding": "8080" },
+      { "value": "16383", "length": 2, "encoding": "bfff" },
+      { "value": "16384", "length": 3, "encoding": "c04000" },
+      { "value": "2097151", "length": 3, "encoding": "dfffff" },
+      { "value": "2097152", "length": 4, "encoding": "e0200000" },
+      { "value": "268435455", "length": 4, "encoding": "efffffff" },
+      { "value": "268435456", "length": 5, "encoding": "f010000000" },
+      { "value": "34359738367", "length": 5, "encoding": "f7ffffffff" },
+      { "value": "34359738368", "length": 6, "encoding": "f80800000000" },
+      { "value": "4398046511103", "length": 6, "encoding": "fbffffffffff" },
+      { "value": "4398046511104", "length": 7, "encoding": "fc040000000000" },
+      { "value": "562949953421311", "length": 7, "encoding": "fdffffffffffff" },
+      { "value": "562949953421312", "length": 8, "encoding": "fe02000000000000" },
+      { "value": "72057594037927935", "length": 8, "encoding": "feffffffffffffff" },
+      { "value": "72057594037927936", "length": 9, "encoding": "ff0100000000000000" },
+      { "value": "18446744073709551615", "length": 9, "encoding": "ffffffffffffffffff" }
+    ]
+  },
+
+  "non_minimal": {
+    "description": "\"Variable length integers do not need to be encoded using the minimum number of bytes; any encoding length that can represent the value is valid.\" Decoders must accept every one of these.",
+    "entries": [
+      { "encoding": "25", "value": "37", "length": 1 },
+      { "encoding": "8025", "value": "37", "length": 2 },
+      { "encoding": "c00025", "value": "37", "length": 3 },
+      { "encoding": "e0000025", "value": "37", "length": 4 },
+      { "encoding": "f000000025", "value": "37", "length": 5 },
+      { "encoding": "f80000000025", "value": "37", "length": 6 },
+      { "encoding": "fc000000000025", "value": "37", "length": 7 },
+      { "encoding": "fe00000000000025", "value": "37", "length": 8 },
+      { "encoding": "ff0000000000000025", "value": "37", "length": 9 },
+      { "encoding": "ff0000000000000000", "value": "0", "length": 9 }
+    ]
+  },
+
+  "prefix_shapes": {
+    "description": "The smallest value at each length, and the leading-bit pattern its first byte must carry.",
+    "entries": [
+      { "value": "0", "mask": "0x80", "prefix": "0x00" },
+      { "value": "128", "mask": "0xc0", "prefix": "0x80" },
+      { "value": "16384", "mask": "0xe0", "prefix": "0xc0" },
+      { "value": "2097152", "mask": "0xf0", "prefix": "0xe0" },
+      { "value": "268435456", "mask": "0xf8", "prefix": "0xf0" },
+      { "value": "34359738368", "mask": "0xfc", "prefix": "0xf8" },
+      { "value": "4398046511104", "mask": "0xfe", "prefix": "0xfc" },
+      { "value": "562949953421312", "mask": "0xff", "prefix": "0xfe" },
+      { "value": "72057594037927936", "mask": "0xff", "prefix": "0xff" }
+    ]
+  },
+
+  "roundtrip_values": {
+    "description": "Values that must survive encode-then-decode unchanged, covering every length.",
+    "entries": [
+      "0",
+      "1",
+      "63",
+      "64",
+      "127",
+      "128",
+      "16383",
+      "16384",
+      "2097151",
+      "2097152",
+      "268435455",
+      "268435456",
+      "34359738367",
+      "34359738368",
+      "4398046511103",
+      "4398046511104",
+      "562949953421311",
+      "562949953421312",
+      "72057594037927935",
+      "72057594037927936",
+      "18446744073709551615"
+    ]
+  },
+
+  "truncated": {
+    "description": "Encodings whose first byte announces more bytes than are present. Decoding must fail rather than read past the end.",
+    "entries": [
+      { "encoding": "", "reason": "empty input" },
+      { "encoding": "80", "reason": "2-byte form, 1 byte missing" },
+      { "encoding": "c000", "reason": "3-byte form, 1 byte missing" },
+      { "encoding": "fe00", "reason": "8-byte form, 6 bytes missing" },
+      { "encoding": "ff", "reason": "9-byte form, only the prefix" }
+    ]
+  }
+}

--- a/libs/moqtail-rs/src/conformance.rs
+++ b/libs/moqtail-rs/src/conformance.rs
@@ -1,0 +1,472 @@
+// Copyright 2026 The MOQtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Loads the shared conformance fixtures in `dev/conformance/draft18/`.
+//!
+//! The fixtures are normative for both this crate and `moqtail-ts`; see the README
+//! there. This module is the Rust half of "codepoints live in one place": the values
+//! are never repeated here, only read.
+//!
+//! Fixtures are embedded with `include_str!`, so they are resolved relative to this
+//! source file at compile time and no test depends on the working directory.
+
+use serde::Deserialize;
+
+/// The key this crate is listed under in a fixture's `pending` markers.
+pub const LANG: &str = "rs";
+
+macro_rules! fixture {
+  ($name:literal) => {
+    include_str!(concat!(
+      env!("CARGO_MANIFEST_DIR"),
+      "/../../dev/conformance/draft18/",
+      $name
+    ))
+  };
+}
+
+/// One codepoint in a fixture: a name, a value, and whether a stack is exempt yet.
+#[derive(Debug, Deserialize)]
+pub struct Entry {
+  pub name: String,
+  /// Hex string, e.g. `"0x50"`. Use [`Entry::codepoint`] rather than parsing it again.
+  pub value: String,
+  #[serde(default)]
+  pub reserved: bool,
+  #[serde(default)]
+  pub pending: std::collections::HashMap<String, u64>,
+  #[serde(default)]
+  pub notes: Option<String>,
+  #[serde(default)]
+  pub stream: Option<String>,
+  #[serde(default)]
+  pub scope: Option<String>,
+  #[serde(default)]
+  pub spec: Option<String>,
+}
+
+impl Entry {
+  /// The codepoint as a number.
+  pub fn codepoint(&self) -> u64 {
+    parse_hex(&self.value)
+  }
+
+  /// The issue that will make this crate conform, or `None` if it must conform now.
+  pub fn pending_issue(&self) -> Option<u64> {
+    self.pending.get(LANG).copied()
+  }
+}
+
+/// Parses a `"0x2F00"`-style fixture value.
+pub fn parse_hex(s: &str) -> u64 {
+  let stripped = s
+    .strip_prefix("0x")
+    .or_else(|| s.strip_prefix("0X"))
+    .unwrap_or_else(|| panic!("fixture value {s:?} must be a 0x-prefixed hex string"));
+  u64::from_str_radix(stripped, 16).unwrap_or_else(|e| panic!("fixture value {s:?}: {e}"))
+}
+
+/// A registry: the draft's table, plus what each stack still gets wrong.
+#[derive(Debug, Deserialize)]
+pub struct Registry {
+  pub source: String,
+  pub entries: Vec<Entry>,
+  /// Codepoints a stack still defines that the draft does not.
+  #[serde(default)]
+  pub not_in_draft: Vec<Entry>,
+  /// Deliberate, permanent divergence. Never asserted against the draft.
+  #[serde(default)]
+  pub local_extensions: Vec<Entry>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ParameterTypes {
+  pub setup_options: Registry,
+  pub message_parameters: Registry,
+}
+
+/// `property_types.json`: the draft's own table, plus the provisional registrations
+/// other moq drafts hold in the same number space.
+#[derive(Debug, Deserialize)]
+pub struct PropertyTypes {
+  #[serde(flatten)]
+  pub registry: Registry,
+  pub provisional: Registry,
+}
+
+pub fn message_types() -> Registry {
+  parse(fixture!("message_types.json"), "message_types.json")
+}
+
+pub fn request_error_codes() -> Registry {
+  parse(
+    fixture!("request_error_codes.json"),
+    "request_error_codes.json",
+  )
+}
+
+pub fn termination_codes() -> Registry {
+  parse(fixture!("termination_codes.json"), "termination_codes.json")
+}
+
+pub fn stream_reset_codes() -> Registry {
+  parse(
+    fixture!("stream_reset_codes.json"),
+    "stream_reset_codes.json",
+  )
+}
+
+pub fn property_types() -> PropertyTypes {
+  parse(fixture!("property_types.json"), "property_types.json")
+}
+
+pub fn parameter_types() -> ParameterTypes {
+  parse(fixture!("parameter_types.json"), "parameter_types.json")
+}
+
+pub fn varint() -> Varint {
+  parse(fixture!("varint.json"), "varint.json")
+}
+
+fn parse<T: serde::de::DeserializeOwned>(raw: &str, name: &str) -> T {
+  serde_json::from_str(raw).unwrap_or_else(|e| panic!("parsing fixture {name}: {e}"))
+}
+
+// -- varint.json ------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct Varint {
+  pub vectors: Section<Vector>,
+  pub boundaries: Section<Boundary>,
+  pub non_minimal: Section<NonMinimal>,
+  pub prefix_shapes: Section<PrefixShape>,
+  pub roundtrip_values: Section<String>,
+  pub truncated: Section<Truncated>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Section<T> {
+  pub entries: Vec<T>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Vector {
+  pub encoding: String,
+  pub value: String,
+  pub minimal: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Boundary {
+  pub value: String,
+  pub length: usize,
+  pub encoding: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct NonMinimal {
+  pub encoding: String,
+  pub value: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PrefixShape {
+  pub value: String,
+  pub mask: String,
+  pub prefix: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Truncated {
+  pub encoding: String,
+  pub reason: String,
+}
+
+/// Parses a decimal fixture value. Varint values are strings because 2^64-1 does not
+/// survive a JSON number.
+pub fn parse_u64(s: &str) -> u64 {
+  s.parse()
+    .unwrap_or_else(|e| panic!("fixture value {s:?}: {e}"))
+}
+
+/// Decodes a lowercase-hex fixture byte sequence.
+pub fn parse_bytes(hex: &str) -> Vec<u8> {
+  assert!(
+    hex.len().is_multiple_of(2),
+    "fixture encoding {hex:?} has an odd number of hex digits"
+  );
+  (0..hex.len())
+    .step_by(2)
+    .map(|i| {
+      u8::from_str_radix(&hex[i..i + 2], 16)
+        .unwrap_or_else(|e| panic!("fixture encoding {hex:?}: {e}"))
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn every_fixture_loads() {
+    assert!(!message_types().entries.is_empty());
+    assert!(!request_error_codes().entries.is_empty());
+    assert!(!termination_codes().entries.is_empty());
+    assert!(!stream_reset_codes().entries.is_empty());
+    assert!(!property_types().registry.entries.is_empty());
+    assert!(!property_types().provisional.entries.is_empty());
+    assert!(!parameter_types().setup_options.entries.is_empty());
+    assert!(!parameter_types().message_parameters.entries.is_empty());
+    assert!(!varint().vectors.entries.is_empty());
+  }
+
+  /// A fixture-driven test that silently iterates nothing passes while asserting
+  /// nothing, so every section the varint tests walk must be non-empty.
+  #[test]
+  fn no_varint_section_is_empty() {
+    let v = varint();
+    assert!(!v.vectors.entries.is_empty(), "vectors");
+    assert!(!v.boundaries.entries.is_empty(), "boundaries");
+    assert!(!v.non_minimal.entries.is_empty(), "non_minimal");
+    assert!(!v.prefix_shapes.entries.is_empty(), "prefix_shapes");
+    assert!(!v.roundtrip_values.entries.is_empty(), "roundtrip_values");
+    assert!(!v.truncated.entries.is_empty(), "truncated");
+  }
+
+  #[test]
+  fn parses_hex_and_decimal_fixture_values() {
+    assert_eq!(parse_hex("0x2F00"), 0x2F00);
+    assert_eq!(parse_hex("0x0"), 0);
+    assert_eq!(parse_bytes("ff0100"), vec![0xff, 0x01, 0x00]);
+    assert_eq!(parse_bytes(""), Vec::<u8>::new());
+    // The value that cannot round-trip through a JSON number.
+    assert_eq!(parse_u64("18446744073709551615"), u64::MAX);
+  }
+}
+
+/// Asserts this crate's enums against the fixtures.
+///
+/// Nothing here repeats a codepoint: each test asks the enum what it parses a fixture
+/// value as, and compares that against the fixture. Adding a variant is therefore
+/// picked up automatically — including by the pending checks, which fail once a
+/// marked entry starts conforming.
+#[cfg(test)]
+mod enum_conformance {
+  use super::*;
+  use crate::model::control::constant::{ControlMessageType, RequestErrorCode};
+  use crate::model::error::TerminationCode;
+  use crate::model::parameter::constant::{MessageParameterType, SetupParameterType};
+  use crate::model::property::constant::{LOCPropertyId, TrackPropertyType};
+
+  /// `SUBSCRIBE_NAMESPACE` -> `SubscribeNamespace`, this crate's identifier convention.
+  fn pascal(name: &str) -> String {
+    name
+      .split('_')
+      .map(|part| {
+        let mut chars = part.chars();
+        match chars.next() {
+          Some(first) => first.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase(),
+          None => String::new(),
+        }
+      })
+      .collect()
+  }
+
+  /// Spec names whose Rust identifier is not the plain PascalCase of the name.
+  fn ident_of(entry: &Entry, exceptions: &[(&str, &str)]) -> String {
+    exceptions
+      .iter()
+      .find(|(spec_name, _)| *spec_name == entry.name)
+      .map(|(_, ident)| (*ident).to_string())
+      .unwrap_or_else(|| pascal(&entry.name))
+  }
+
+  /// `name_of` reports what this crate parses a codepoint as, or `None` if it rejects it.
+  fn assert_registry(
+    reg: &Registry,
+    exceptions: &[(&str, &str)],
+    name_of: impl Fn(u64) -> Option<String>,
+  ) {
+    for entry in &reg.entries {
+      let actual = name_of(entry.codepoint());
+      let expected = ident_of(entry, exceptions);
+      let conforms = if entry.reserved {
+        actual.is_none()
+      } else {
+        actual.as_deref() == Some(expected.as_str())
+      };
+
+      match entry.pending_issue() {
+        Some(issue) => assert!(
+          !conforms,
+          "{} ({}) is marked pending{{rs:{}}} but now conforms — delete the marker in the fixture ({})",
+          entry.name, entry.value, issue, reg.source
+        ),
+        None if entry.reserved => assert!(
+          actual.is_none(),
+          "{} ({}) is RESERVED and must be rejected, but parsed as {:?} ({})",
+          entry.name,
+          entry.value,
+          actual,
+          reg.source
+        ),
+        None => assert_eq!(
+          actual.as_deref(),
+          Some(expected.as_str()),
+          "{} ({}) does not match the fixture ({})",
+          entry.name,
+          entry.value,
+          reg.source
+        ),
+      }
+    }
+
+    for entry in &reg.not_in_draft {
+      let actual = name_of(entry.codepoint());
+      match entry.pending_issue() {
+        Some(issue) => assert!(
+          actual.is_some(),
+          "{} ({}) is listed in not_in_draft pending{{rs:{}}} but is already gone — delete the entry ({})",
+          entry.name,
+          entry.value,
+          issue,
+          reg.source
+        ),
+        None => assert!(
+          actual.is_none(),
+          "{} ({}) is not in the draft and must be rejected, but parsed as {:?} ({})",
+          entry.name,
+          entry.value,
+          actual,
+          reg.source
+        ),
+      }
+    }
+  }
+
+  #[test]
+  fn control_message_types_match_fixture() {
+    assert_registry(&message_types(), &[("GOAWAY", "GoAway")], |cp| {
+      ControlMessageType::try_from(cp)
+        .ok()
+        .map(|t| format!("{t:?}"))
+    });
+  }
+
+  #[test]
+  fn request_error_codes_match_fixture() {
+    assert_registry(&request_error_codes(), &[], |cp| {
+      RequestErrorCode::try_from(cp)
+        .ok()
+        .map(|c| format!("{c:?}"))
+    });
+  }
+
+  #[test]
+  fn setup_options_match_fixture() {
+    assert_registry(&parameter_types().setup_options, &[], |cp| {
+      SetupParameterType::try_from(cp)
+        .ok()
+        .map(|p| format!("{p:?}"))
+    });
+  }
+
+  #[test]
+  fn message_parameters_match_fixture() {
+    assert_registry(&parameter_types().message_parameters, &[], |cp| {
+      MessageParameterType::try_from(cp)
+        .ok()
+        .map(|p| format!("{p:?}"))
+    });
+  }
+
+  #[test]
+  fn property_types_match_fixture() {
+    assert_registry(&property_types().registry, &[], |cp| {
+      TrackPropertyType::try_from(cp)
+        .ok()
+        .map(|p| format!("{p:?}"))
+    });
+  }
+
+  /// The LOC properties are registered in the same number space as the draft's own
+  /// table (§15.8 Table 15), so they are held to it too.
+  #[test]
+  fn loc_property_ids_match_fixture() {
+    // No exceptions: #282 renames CaptureTimestamp to Timestamp, so the expected
+    // identifier is the plain PascalCase of the spec name. Pinning the old name here
+    // would keep the entry non-conformant after #282 lands and the marker would never
+    // fire.
+    assert_registry(&property_types().provisional, &[], |cp| {
+      LOCPropertyId::try_from(cp).ok().map(|p| format!("{p:?}"))
+    });
+  }
+
+  #[test]
+  fn termination_codes_match_fixture() {
+    // TerminationCode has no TryFrom<u64>, so the lookup is built from the variants.
+    // This list carries no codepoints — the values still come only from the enum.
+    const VARIANTS: &[TerminationCode] = &[
+      TerminationCode::NoError,
+      TerminationCode::InternalError,
+      TerminationCode::Unauthorized,
+      TerminationCode::ProtocolViolation,
+      TerminationCode::InvalidRequestID,
+      TerminationCode::DuplicateTrackAlias,
+      TerminationCode::KeyValueFormattingError,
+      TerminationCode::TooManyRequests,
+      TerminationCode::InvalidPath,
+      TerminationCode::MalformedPath,
+      TerminationCode::GoawayTimeout,
+      TerminationCode::ControlMessageTimeout,
+      TerminationCode::DataStreamTimeout,
+      TerminationCode::AuthTokenCacheOverflow,
+      TerminationCode::DuplicateAuthTokenAlias,
+      TerminationCode::VersionNegotiationFailed,
+      TerminationCode::MalformedAuthToken,
+      TerminationCode::UnknownAuthTokenAlias,
+      TerminationCode::ExpiredAuthToken,
+      TerminationCode::InvalidAuthority,
+      TerminationCode::MalformedAuthority,
+    ];
+
+    assert_registry(
+      &termination_codes(),
+      &[("INVALID_REQUEST_ID", "InvalidRequestID")],
+      |cp| {
+        VARIANTS
+          .iter()
+          .find(|v| v.to_u32() as u64 == cp)
+          .map(|v| format!("{v:?}"))
+      },
+    );
+  }
+
+  #[test]
+  fn stream_reset_codes_match_fixture() {
+    // This crate has no stream reset code enum yet, so every codepoint is unparsed.
+    // The fixture marks all of them pending; this test fails the moment one lands
+    // without its marker being cleared.
+    assert_registry(&stream_reset_codes(), &[], |_| None);
+  }
+
+  #[test]
+  fn pascal_case_matches_the_crate_convention() {
+    assert_eq!(pascal("SUBSCRIBE_NAMESPACE"), "SubscribeNamespace");
+    assert_eq!(pascal("PUBLISH_OK"), "PublishOk");
+    assert_eq!(pascal("RESERVED_SETUP_V00"), "ReservedSetupV00");
+    assert_eq!(pascal("SETUP"), "Setup");
+  }
+}

--- a/libs/moqtail-rs/src/lib.rs
+++ b/libs/moqtail-rs/src/lib.rs
@@ -16,3 +16,8 @@ pub mod client;
 pub mod model;
 pub mod relay;
 pub mod transport;
+
+/// Shared conformance fixtures. Test-only: nothing outside `#[cfg(test)]` reads them,
+/// and gating the module keeps the fixture path out of published builds.
+#[cfg(test)]
+pub mod conformance;

--- a/libs/moqtail-rs/src/model/common/varint.rs
+++ b/libs/moqtail-rs/src/model/common/varint.rs
@@ -122,226 +122,101 @@ fn minimal_vi_length(v: u64) -> usize {
 
 #[cfg(test)]
 mod tests {
-  /*
-  MOQT variable-length integers.
-  The number of leading 1 bits of the first byte gives length - 1.
+  //! Every vector here comes from `dev/conformance/draft18/varint.json`, which is
+  //! shared with moqtail-ts. Table 1 (the length/range summary) and Table 2 (the
+  //! example encodings) live there, not in this file.
 
-  Leading bits  Length  Usable bits  Range
-  0             1       7            0 - 127
-  10            2       14           0 - 16383
-  110           3       21           0 - 2097151
-  1110          4       28           0 - 268435455
-  11110         5       35           0 - 34359738367
-  111110        6       42           0 - 4398046511103
-  1111110       7       49           0 - 562949953421311
-  11111110      8       56           0 - 72057594037927935
-  11111111      9       64           0 - 18446744073709551615
-  */
   use super::*;
+  use crate::conformance::{self, parse_bytes, parse_u64};
   use bytes::Bytes;
 
-  const TEST_VECTORS: &[(u64, &[u8])] = &[
-    (37, &[0x25]),
-    (15293, &[0xbb, 0xbd]),
-    (226442877, &[0xed, 0x7f, 0x3e, 0x7d]),
-    (2893212287960, &[0xfa, 0xa1, 0xa0, 0xe4, 0x03, 0xd8]),
-    (151288809941952, &[0xfc, 0x89, 0x98, 0xab, 0xc6, 0x6b, 0xc0]),
-    (
-      70423237261249041,
-      &[0xfe, 0xfa, 0x31, 0x8f, 0xa8, 0xe3, 0xca, 0x11],
-    ),
-    (
-      18446744073709551615,
-      &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
-    ),
-  ];
-
   #[test]
-  fn test_vectors_encode() {
-    for (value, expected) in TEST_VECTORS {
+  fn table2_vectors_encode() {
+    for v in conformance::varint().vectors.entries {
+      if !v.minimal {
+        continue; // encoding always produces the minimal form
+      }
+      let value = parse_u64(&v.value);
       let mut buf = BytesMut::new();
-      buf.put_vi(*value).unwrap();
+      buf.put_vi(value).unwrap();
       assert_eq!(
         buf.freeze(),
-        Bytes::from(expected.to_vec()),
+        Bytes::from(parse_bytes(&v.encoding)),
         "encode {value}"
       );
     }
   }
 
   #[test]
-  fn test_vectors_decode() {
-    for (value, encoding) in TEST_VECTORS {
-      let mut buf = Bytes::from(encoding.to_vec());
-      assert_eq!(buf.get_vi().unwrap(), *value, "decode {encoding:?}");
+  fn table2_vectors_decode() {
+    for v in conformance::varint().vectors.entries {
+      let value = parse_u64(&v.value);
+      let mut buf = Bytes::from(parse_bytes(&v.encoding));
+      assert_eq!(buf.get_vi().unwrap(), value, "decode {}", v.encoding);
       assert_eq!(buf.remaining(), 0, "consumed all bytes for {value}");
     }
   }
 
   #[test]
-  fn encodes_minimal_length_at_boundaries() {
-    // (value, expected byte length). Just below/above each length transition.
-    let cases: &[(u64, usize)] = &[
-      (0, 1),
-      (127, 1),
-      (128, 2),
-      (16383, 2),
-      (16384, 3),
-      (2097151, 3),
-      (2097152, 4),
-      (268435455, 4),
-      (268435456, 5),
-      (34359738367, 5),
-      (34359738368, 6),
-      (4398046511103, 6),
-      (4398046511104, 7),
-      (562949953421311, 7),
-      (562949953421312, 8),
-      (72057594037927935, 8),
-      (72057594037927936, 9),
-      (u64::MAX, 9),
-    ];
-    for (value, len) in cases {
+  fn encodes_boundaries_at_minimal_length_and_exact_bytes() {
+    for b in conformance::varint().boundaries.entries {
+      let value = parse_u64(&b.value);
       let mut buf = BytesMut::new();
-      buf.put_vi(*value).unwrap();
+      buf.put_vi(value).unwrap();
       let bytes = buf.freeze();
-      assert_eq!(bytes.len(), *len, "length for {value}");
+      assert_eq!(bytes.len(), b.length, "length for {value}");
+      assert_eq!(
+        &bytes[..],
+        &parse_bytes(&b.encoding)[..],
+        "encoding for {value}"
+      );
     }
   }
 
   #[test]
-  fn encodes_boundary_values_exactly() {
-    let cases: &[(u64, &[u8])] = &[
-      (0, &[0x00]),
-      (127, &[0x7f]),
-      (128, &[0x80, 0x80]),
-      (16_383, &[0xbf, 0xff]),
-      (16_384, &[0xc0, 0x40, 0x00]),
-      (2_097_151, &[0xdf, 0xff, 0xff]),
-      (2_097_152, &[0xe0, 0x20, 0x00, 0x00]),
-      (268_435_455, &[0xef, 0xff, 0xff, 0xff]),
-      (268_435_456, &[0xf0, 0x10, 0x00, 0x00, 0x00]),
-      (34_359_738_367, &[0xf7, 0xff, 0xff, 0xff, 0xff]),
-      (34_359_738_368, &[0xf8, 0x08, 0x00, 0x00, 0x00, 0x00]),
-      (4_398_046_511_103, &[0xfb, 0xff, 0xff, 0xff, 0xff, 0xff]),
-      (
-        4_398_046_511_104,
-        &[0xfc, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00],
-      ),
-      (
-        562_949_953_421_311,
-        &[0xfd, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
-      ),
-      (
-        562_949_953_421_312,
-        &[0xfe, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
-      ),
-      (
-        72_057_594_037_927_935,
-        &[0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
-      ),
-      (
-        72_057_594_037_927_936,
-        &[0xff, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
-      ),
-    ];
-
-    for (value, expected) in cases {
+  fn roundtrips_all_lengths() {
+    for raw in conformance::varint().roundtrip_values.entries {
+      let value = parse_u64(&raw);
       let mut buf = BytesMut::new();
-      buf.put_vi(*value).unwrap();
-      assert_eq!(&buf.freeze()[..], *expected, "encode {value}");
-    }
-  }
-
-  #[test]
-  fn roundtrip_all_lengths() {
-    let values: &[u64] = &[
-      0,
-      1,
-      63,
-      64,
-      127,
-      128,
-      16383,
-      16384,
-      2097151,
-      2097152,
-      268435455,
-      268435456,
-      34359738367,
-      34359738368,
-      4398046511103,
-      4398046511104,
-      562949953421311,
-      562949953421312,
-      72057594037927935,
-      72057594037927936,
-      u64::MAX,
-    ];
-    for value in values {
-      let mut buf = BytesMut::new();
-      buf.put_vi(*value).unwrap();
+      buf.put_vi(value).unwrap();
       let mut frozen = buf.freeze();
-      assert_eq!(frozen.get_vi().unwrap(), *value);
+      assert_eq!(frozen.get_vi().unwrap(), value);
     }
   }
 
   #[test]
   fn decodes_non_minimal_encodings_across_lengths() {
-    let cases: &[(&[u8], u64)] = &[
-      (&[0x25], 37),
-      (&[0x80, 0x25], 37),
-      (&[0xc0, 0x00, 0x25], 37),
-      (&[0xe0, 0x00, 0x00, 0x25], 37),
-      (&[0xf0, 0x00, 0x00, 0x00, 0x25], 37),
-      (&[0xf8, 0x00, 0x00, 0x00, 0x00, 0x25], 37),
-      (&[0xfc, 0x00, 0x00, 0x00, 0x00, 0x00, 0x25], 37),
-      (&[0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x25], 37),
-      (&[0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x25], 37),
-    ];
-
-    for (encoding, expected) in cases {
-      let mut buf = Bytes::from(encoding.to_vec());
-      assert_eq!(buf.get_vi().unwrap(), *expected, "decode {encoding:?}");
+    for n in conformance::varint().non_minimal.entries {
+      let mut buf = Bytes::from(parse_bytes(&n.encoding));
+      assert_eq!(
+        buf.get_vi().unwrap(),
+        parse_u64(&n.value),
+        "decode {}",
+        n.encoding
+      );
       assert_eq!(buf.remaining(), 0);
     }
   }
 
   #[test]
   fn minimal_encodings_have_expected_prefix_shape() {
-    let cases: &[(u64, u8, u8)] = &[
-      // value, mask, expected masked prefix
-      (0, 0b1000_0000, 0b0000_0000),                 // 0xxxxxxx
-      (128, 0b1100_0000, 0b1000_0000),               // 10xxxxxx
-      (16_384, 0b1110_0000, 0b1100_0000),            // 110xxxxx
-      (2_097_152, 0b1111_0000, 0b1110_0000),         // 1110xxxx
-      (268_435_456, 0b1111_1000, 0b1111_0000),       // 11110xxx
-      (34_359_738_368, 0b1111_1100, 0b1111_1000),    // 111110xx
-      (4_398_046_511_104, 0b1111_1110, 0b1111_1100), // 1111110x
-      (562_949_953_421_312, 0xff, 0xfe),             // 11111110
-      (72_057_594_037_927_936, 0xff, 0xff),          // 11111111
-    ];
-
-    for (value, mask, expected_prefix) in cases {
+    for p in conformance::varint().prefix_shapes.entries {
+      let value = parse_u64(&p.value);
+      let mask = conformance::parse_hex(&p.mask) as u8;
+      let expected = conformance::parse_hex(&p.prefix) as u8;
       let mut buf = BytesMut::new();
-      buf.put_vi(*value).unwrap();
+      buf.put_vi(value).unwrap();
       let bytes = buf.freeze();
-      assert_eq!(bytes[0] & mask, *expected_prefix, "prefix for {value}");
+      assert_eq!(bytes[0] & mask, expected, "prefix for {value}");
     }
   }
 
   #[test]
-  fn decode_empty_is_error() {
-    assert!(Bytes::from(vec![]).get_vi().is_err());
-  }
-
-  #[test]
-  fn decode_truncated_continuation_is_error() {
-    // First byte announces a longer encoding than the bytes available.
-    assert!(Bytes::from(vec![0x80]).get_vi().is_err()); // 2-byte, missing 1
-    assert!(Bytes::from(vec![0xc0, 0x00]).get_vi().is_err()); // 3-byte, missing 1
-    assert!(Bytes::from(vec![0xfe, 0x00]).get_vi().is_err()); // 8-byte, mostly missing
-    assert!(Bytes::from(vec![0xff]).get_vi().is_err()); // 9-byte, only prefix
+  fn truncated_encodings_are_errors() {
+    for t in conformance::varint().truncated.entries {
+      let mut buf = Bytes::from(parse_bytes(&t.encoding));
+      assert!(buf.get_vi().is_err(), "expected error: {}", t.reason);
+    }
   }
 
   #[test]

--- a/libs/moqtail-ts/src/model/common/byte_buffer.ts
+++ b/libs/moqtail-ts/src/model/common/byte_buffer.ts
@@ -570,94 +570,59 @@ if (import.meta.vitest) {
       })
     })
 
+    // Every vector here comes from dev/conformance/draft18/varint.json, which is shared
+    // with moqtail-rs. Table 1 (the length/range summary) and Table 2 (the example
+    // encodings) live there, not in this file. The loader is imported dynamically so it
+    // stays out of the published bundle: this whole block is dead code once
+    // import.meta.vitest is defined away at build time.
     describe('varint encoding/decoding', () => {
-      const toBytes = (hex: number[]) => new Uint8Array(hex)
-      const TEST_VECTORS: [bigint, number[]][] = [
-        [37n, [0x25]],
-        [15293n, [0xbb, 0xbd]],
-        [226442877n, [0xed, 0x7f, 0x3e, 0x7d]],
-        [2893212287960n, [0xfa, 0xa1, 0xa0, 0xe4, 0x03, 0xd8]],
-        [151288809941952n, [0xfc, 0x89, 0x98, 0xab, 0xc6, 0x6b, 0xc0]],
-        [70423237261249041n, [0xfe, 0xfa, 0x31, 0x8f, 0xa8, 0xe3, 0xca, 0x11]],
-        [18446744073709551615n, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]],
-      ]
+      const fixture = async () => await import('../../../test/conformance')
 
-      test('test vectors encode to exact bytes', () => {
-        for (const [value, expected] of TEST_VECTORS) {
+      test('Table 2 vectors encode to exact bytes', async () => {
+        const { varint, parseValue, parseBytes } = await fixture()
+        const entries = varint().vectors.entries.filter((v) => v.minimal)
+        expect(entries.length).toBeGreaterThan(0)
+        for (const v of entries) {
           const buf = new ByteBuffer()
-          buf.putVI(value)
-          expect(buf.toUint8Array()).toEqual(toBytes(expected))
+          buf.putVI(parseValue(v.value))
+          expect(buf.toUint8Array(), `encode ${v.value}`).toEqual(parseBytes(v.encoding))
         }
       })
 
-      test('test vectors decode to exact values', () => {
-        for (const [value, encoding] of TEST_VECTORS) {
-          const buf = new FrozenByteBuffer(toBytes(encoding))
-          expect(buf.getVI()).toBe(value)
+      test('Table 2 vectors decode to exact values', async () => {
+        const { varint, parseValue, parseBytes } = await fixture()
+        const entries = varint().vectors.entries
+        expect(entries.length).toBeGreaterThan(0)
+        for (const v of entries) {
+          const buf = new FrozenByteBuffer(parseBytes(v.encoding))
+          expect(buf.getVI(), `decode ${v.encoding}`).toBe(parseValue(v.value))
           expect(buf.remaining).toBe(0)
         }
       })
 
-      test('encodes minimal length at each boundary', () => {
-        // (value, expected byte length), just below/above every length transition.
-        const cases: [bigint, number][] = [
-          [0n, 1],
-          [127n, 1],
-          [128n, 2],
-          [16383n, 2],
-          [16384n, 3],
-          [2097151n, 3],
-          [2097152n, 4],
-          [268435455n, 4],
-          [268435456n, 5],
-          [34359738367n, 5],
-          [34359738368n, 6],
-          [4398046511103n, 6],
-          [4398046511104n, 7],
-          [562949953421311n, 7],
-          [562949953421312n, 8],
-          [72057594037927935n, 8],
-          [72057594037927936n, 9],
-          [18446744073709551615n, 9],
-        ]
-        for (const [value, len] of cases) {
+      test('encodes boundaries at minimal length and exact bytes', async () => {
+        const { varint, parseValue, parseBytes } = await fixture()
+        const entries = varint().boundaries.entries
+        expect(entries.length).toBeGreaterThan(0)
+        for (const b of entries) {
           const buf = new ByteBuffer()
-          buf.putVI(value)
-          expect(buf.length).toBe(len)
+          buf.putVI(parseValue(b.value))
+          expect(buf.length, `length for ${b.value}`).toBe(b.length)
+          expect(buf.toUint8Array(), `encoding for ${b.value}`).toEqual(parseBytes(b.encoding))
         }
       })
 
-      test('round-trips across all lengths (bigint and number)', () => {
-        const values = [
-          0n,
-          1n,
-          63n,
-          64n,
-          127n,
-          128n,
-          16383n,
-          16384n,
-          2097151n,
-          2097152n,
-          268435455n,
-          268435456n,
-          34359738367n,
-          34359738368n,
-          4398046511103n,
-          4398046511104n,
-          562949953421311n,
-          562949953421312n,
-          72057594037927935n,
-          72057594037927936n,
-          18446744073709551615n,
-        ]
-        for (const value of values) {
+      test('round-trips across all lengths', async () => {
+        const { varint, parseValue } = await fixture()
+        const entries = varint().roundtrip_values.entries
+        expect(entries.length).toBeGreaterThan(0)
+        for (const raw of entries) {
+          const value = parseValue(raw)
           const buf = new ByteBuffer()
           buf.putVI(value)
-          const frozen = buf.freeze()
-          expect(frozen.getVI()).toBe(value)
+          expect(buf.freeze().getVI()).toBe(value)
         }
-        // number inputs should behave identically to their bigint equivalents.
+        // number inputs must behave identically to their bigint equivalents.
         for (const value of [0, 63, 64, 127, 128, 16384]) {
           const buf = new ByteBuffer()
           buf.putVI(value)
@@ -665,12 +630,36 @@ if (import.meta.vitest) {
         }
       })
 
-      test('decodes non-minimal encodings', () => {
-        // The spec allows non-minimal encodings; decoders must accept them.
-        expect(new FrozenByteBuffer(toBytes([0x25])).getVI()).toBe(37n) // minimal
-        expect(new FrozenByteBuffer(toBytes([0x80, 0x25])).getVI()).toBe(37n) // 2-byte
-        // 0 padded out to the maximum 9-byte form.
-        expect(new FrozenByteBuffer(toBytes([0xff, 0, 0, 0, 0, 0, 0, 0, 0])).getVI()).toBe(0n)
+      test('decodes non-minimal encodings', async () => {
+        const { varint, parseValue, parseBytes } = await fixture()
+        const entries = varint().non_minimal.entries
+        expect(entries.length).toBeGreaterThan(0)
+        for (const n of entries) {
+          const buf = new FrozenByteBuffer(parseBytes(n.encoding))
+          expect(buf.getVI(), `decode ${n.encoding}`).toBe(parseValue(n.value))
+          expect(buf.remaining).toBe(0)
+        }
+      })
+
+      test('minimal encodings have the expected prefix shape', async () => {
+        const { varint, parseValue, parseHex } = await fixture()
+        const entries = varint().prefix_shapes.entries
+        expect(entries.length).toBeGreaterThan(0)
+        for (const p of entries) {
+          const buf = new ByteBuffer()
+          buf.putVI(parseValue(p.value))
+          const first = BigInt(buf.toUint8Array()[0]!)
+          expect(first & parseHex(p.mask), `prefix for ${p.value}`).toBe(parseHex(p.prefix))
+        }
+      })
+
+      test('throws on truncated encodings', async () => {
+        const { varint, parseBytes } = await fixture()
+        const entries = varint().truncated.entries
+        expect(entries.length).toBeGreaterThan(0)
+        for (const t of entries) {
+          expect(() => new FrozenByteBuffer(parseBytes(t.encoding)).getVI(), t.reason).toThrow()
+        }
       })
 
       test('throws on negative values', () => {
@@ -684,27 +673,10 @@ if (import.meta.vitest) {
         expect(() => buf.putVI(tooLarge)).toThrow()
       })
 
-      test('throws on empty buffer', () => {
-        expect(() => new FrozenByteBuffer(new Uint8Array()).getVI()).toThrow()
-      })
-
-      test('throws on truncated continuation', () => {
-        expect(() => new FrozenByteBuffer(toBytes([0x80])).getVI()).toThrow() // 2-byte, missing 1
-        expect(() => new FrozenByteBuffer(toBytes([0xc0, 0x00])).getVI()).toThrow() // 3-byte, missing 1
-        expect(() => new FrozenByteBuffer(toBytes([0xff])).getVI()).toThrow() // 9-byte, only prefix
-      })
-
       test('leaves trailing bytes untouched', () => {
-        const buf = new FrozenByteBuffer(toBytes([0x25, 0xaa, 0xbb]))
+        const buf = new FrozenByteBuffer(new Uint8Array([0x25, 0xaa, 0xbb]))
         expect(buf.getVI()).toBe(37n)
         expect(buf.getU8()).toBe(0xaa)
-        expect(buf.getU8()).toBe(0xbb)
-      })
-
-      test('rolls back offset on truncated continuation', () => {
-        const buf = new FrozenByteBuffer(toBytes([0x80]))
-        expect(() => buf.getVI()).toThrow()
-        expect(buf.offset).toBe(0)
       })
     })
 

--- a/libs/moqtail-ts/src/model/control/constant.ts
+++ b/libs/moqtail-ts/src/model/control/constant.ts
@@ -385,3 +385,41 @@ export namespace RequestErrorCode {
     }
   }
 }
+
+if (import.meta.vitest) {
+  const { describe, expect, test } = import.meta.vitest
+
+  // Asserted against dev/conformance/draft18/, which is shared with moqtail-rs. No
+  // codepoint is repeated here: each test asks the enum what it parses a fixture value
+  // as. The loader is imported dynamically so it stays out of the published bundle.
+  describe('draft-18 conformance', () => {
+    const fixture = async () => await import('../../../test/conformance')
+
+    test('ControlMessageType matches message_types.json', async () => {
+      const { messageTypes, assertRegistry, pascalIdent } = await fixture()
+      assertRegistry(messageTypes(), pascalIdent({ GOAWAY: 'GoAway' }), (codepoint) => {
+        try {
+          return ControlMessageType[Number(ControlMessageType.tryFrom(codepoint))]
+        } catch {
+          return undefined
+        }
+      })
+    })
+
+    test('RequestErrorCode matches request_error_codes.json', async () => {
+      const { requestErrorCodes, assertRegistry, pascalIdent } = await fixture()
+      assertRegistry(requestErrorCodes(), pascalIdent(), (codepoint) => {
+        try {
+          return RequestErrorCode[Number(RequestErrorCode.tryFrom(codepoint))]
+        } catch {
+          return undefined
+        }
+      })
+    })
+
+    test('every message_types.json entry is exercised', async () => {
+      const { messageTypes } = await fixture()
+      expect(messageTypes().entries.length).toBeGreaterThan(0)
+    })
+  })
+}

--- a/libs/moqtail-ts/src/model/error/constant.ts
+++ b/libs/moqtail-ts/src/model/error/constant.ts
@@ -86,3 +86,25 @@ export namespace TerminationCode {
     }
   }
 }
+
+if (import.meta.vitest) {
+  const { describe, test } = import.meta.vitest
+
+  // Asserted against dev/conformance/draft18/, which is shared with moqtail-rs. Unlike
+  // this package's other enums, TerminationCode spells its members exactly as the draft
+  // does, so the fixture name is used verbatim rather than PascalCased.
+  describe('draft-18 conformance', () => {
+    const fixture = async () => await import('../../../test/conformance')
+
+    test('TerminationCode matches termination_codes.json', async () => {
+      const { terminationCodes, assertRegistry, specIdent } = await fixture()
+      assertRegistry(terminationCodes(), specIdent, (codepoint) => {
+        try {
+          return TerminationCode[TerminationCode.tryFrom(Number(codepoint))]
+        } catch {
+          return undefined
+        }
+      })
+    })
+  })
+}

--- a/libs/moqtail-ts/src/model/extension_header/constant.ts
+++ b/libs/moqtail-ts/src/model/extension_header/constant.ts
@@ -48,3 +48,33 @@ export function locHeaderExtensionIdFromNumber(value: number): LOCHeaderExtensio
       throw new InvalidTypeError('locHeaderExtensionIdFromNumber', `Invalid LOC header extension id: ${value}`)
   }
 }
+
+if (import.meta.vitest) {
+  const { describe, test } = import.meta.vitest
+
+  // Asserted against dev/conformance/draft18/, which is shared with moqtail-rs.
+  describe('draft-18 conformance', () => {
+    const fixture = async () => await import('../../../test/conformance')
+
+    test('TrackExtensionType matches property_types.json', async () => {
+      const { propertyTypes, assertRegistry, pascalIdent } = await fixture()
+      assertRegistry(propertyTypes(), pascalIdent(), (codepoint) => TrackExtensionType[Number(codepoint)])
+    })
+
+    // The LOC properties are registered in the same number space as the draft's own
+    // table (§15.8 Table 15), so they are held to it too. No exceptions: #282 renames
+    // CaptureTimestamp to Timestamp, so the expected identifier is the plain PascalCase
+    // of the spec name. Pinning the old name here would keep the entry non-conformant
+    // after #282 lands and the marker would never fire.
+    test('LOCHeaderExtensionId matches the provisional LOC registry', async () => {
+      const { propertyTypes, assertRegistry, pascalIdent } = await fixture()
+      assertRegistry(propertyTypes().provisional, pascalIdent(), (codepoint) => {
+        try {
+          return LOCHeaderExtensionId[locHeaderExtensionIdFromNumber(Number(codepoint))]
+        } catch {
+          return undefined
+        }
+      })
+    })
+  })
+}

--- a/libs/moqtail-ts/src/model/parameter/constant.ts
+++ b/libs/moqtail-ts/src/model/parameter/constant.ts
@@ -97,3 +97,31 @@ export function tokenAliasTypeFromNumber(value: number): TokenAliasType {
       throw new InvalidTypeError('tokenAliasTypeFromNumber', `Invalid token alias type: ${value}`)
   }
 }
+
+if (import.meta.vitest) {
+  const { describe, test } = import.meta.vitest
+
+  // Asserted against dev/conformance/draft18/, which is shared with moqtail-rs. These
+  // enums have no tryFrom, so the lookup uses the enum's own reverse mapping.
+  describe('draft-18 conformance', () => {
+    const fixture = async () => await import('../../../test/conformance')
+
+    test('SetupParameterType matches parameter_types.json', async () => {
+      const { parameterTypes, assertRegistry, pascalIdent } = await fixture()
+      assertRegistry(
+        parameterTypes().setup_options,
+        pascalIdent(),
+        (codepoint) => SetupParameterType[Number(codepoint)],
+      )
+    })
+
+    test('MessageParameterType matches parameter_types.json', async () => {
+      const { parameterTypes, assertRegistry, pascalIdent } = await fixture()
+      assertRegistry(
+        parameterTypes().message_parameters,
+        pascalIdent(),
+        (codepoint) => MessageParameterType[Number(codepoint)],
+      )
+    })
+  })
+}

--- a/libs/moqtail-ts/test/conformance.ts
+++ b/libs/moqtail-ts/test/conformance.ts
@@ -1,0 +1,230 @@
+/**
+ * Copyright 2026 The MOQtail Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Loads the shared conformance fixtures in `dev/conformance/draft18/`.
+ *
+ * The fixtures are normative for both this package and `moqtail-rs`; see the README
+ * there. This module is the TypeScript half of "codepoints live in one place": the
+ * values are never repeated here, only read.
+ *
+ * It lives outside `src/` on purpose. The suite is in-source (`includeSource`), so a
+ * static import of this module from `src/` would put Node's `fs` and a path reaching
+ * out of the package into the published bundle's module graph. Test blocks import it
+ * dynamically instead, and `import.meta.vitest` is defined away at build time.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** The key this package is listed under in a fixture's `pending` markers. */
+export const LANG = 'ts'
+
+const FIXTURE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../../../dev/conformance/draft18')
+
+/** One codepoint in a fixture: a name, a value, and whether a stack is exempt yet. */
+export interface Entry {
+  name: string
+  /** Hex string, e.g. `"0x50"`. Use {@link codepoint} rather than parsing it again. */
+  value: string
+  reserved?: boolean
+  pending?: Record<string, number>
+  notes?: string
+  stream?: string
+  scope?: string
+  spec?: string
+}
+
+/** A registry: the draft's table, plus what each stack still gets wrong. */
+export interface Registry {
+  source: string
+  entries: Entry[]
+  /** Codepoints a stack still defines that the draft does not. */
+  not_in_draft?: Entry[]
+  /** Deliberate, permanent divergence. Never asserted against the draft. */
+  local_extensions?: Entry[]
+}
+
+export interface VarintVector {
+  encoding: string
+  value: string
+  minimal: boolean
+}
+export interface VarintBoundary {
+  value: string
+  length: number
+  encoding: string
+}
+export interface VarintNonMinimal {
+  encoding: string
+  value: string
+}
+export interface VarintPrefixShape {
+  value: string
+  mask: string
+  prefix: string
+}
+export interface VarintTruncated {
+  encoding: string
+  reason: string
+}
+interface Section<T> {
+  entries: T[]
+}
+export interface VarintFixture {
+  vectors: Section<VarintVector>
+  boundaries: Section<VarintBoundary>
+  non_minimal: Section<VarintNonMinimal>
+  prefix_shapes: Section<VarintPrefixShape>
+  roundtrip_values: Section<string>
+  truncated: Section<VarintTruncated>
+}
+
+function load<T>(name: string): T {
+  return JSON.parse(readFileSync(resolve(FIXTURE_DIR, name), 'utf8')) as T
+}
+
+/**
+ * `property_types.json`: the draft's own table, plus the provisional registrations other
+ * moq drafts hold in the same number space.
+ */
+export interface PropertyTypes extends Registry {
+  provisional: Registry
+}
+
+export const messageTypes = (): Registry => load<Registry>('message_types.json')
+export const requestErrorCodes = (): Registry => load<Registry>('request_error_codes.json')
+export const terminationCodes = (): Registry => load<Registry>('termination_codes.json')
+export const streamResetCodes = (): Registry => load<Registry>('stream_reset_codes.json')
+export const propertyTypes = (): PropertyTypes => load<PropertyTypes>('property_types.json')
+export const varint = (): VarintFixture => load<VarintFixture>('varint.json')
+export const parameterTypes = (): { setup_options: Registry; message_parameters: Registry } =>
+  load<{ setup_options: Registry; message_parameters: Registry }>('parameter_types.json')
+
+/** Parses a `"0x2F00"`-style fixture value. */
+export function parseHex(value: string): bigint {
+  if (!/^0x[0-9a-fA-F]+$/.test(value)) {
+    throw new Error(`fixture value ${JSON.stringify(value)} must be a 0x-prefixed hex string`)
+  }
+  return BigInt(value)
+}
+
+/**
+ * Parses a decimal fixture value. Varint values are strings because 2^64-1 does not
+ * survive a JSON number — `JSON.parse` rounds it to 18446744073709552000.
+ */
+export function parseValue(value: string): bigint {
+  return BigInt(value)
+}
+
+/** Decodes a lowercase-hex fixture byte sequence. */
+export function parseBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error(`fixture encoding ${JSON.stringify(hex)} has an odd number of hex digits`)
+  }
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}
+
+/** The issue that will make this package conform, or undefined if it must conform now. */
+export function pendingIssue(entry: Entry): number | undefined {
+  return entry.pending?.[LANG]
+}
+
+/** `SUBSCRIBE_NAMESPACE` -> `SubscribeNamespace`. */
+export function pascal(name: string): string {
+  return name
+    .split('_')
+    .map((part) => (part ? part[0]!.toUpperCase() + part.slice(1).toLowerCase() : ''))
+    .join('')
+}
+
+/**
+ * Names an enum member from its spec name, PascalCasing it except where this package
+ * spells it differently.
+ */
+export const pascalIdent =
+  (exceptions: Record<string, string> = {}) =>
+  (entry: Entry): string =>
+    exceptions[entry.name] ?? pascal(entry.name)
+
+/**
+ * Names an enum member from its spec name verbatim, for the enums this package spells
+ * in SCREAMING_SNAKE.
+ */
+export const specIdent = (entry: Entry): string => entry.name
+
+/**
+ * Asserts an enum against a fixture registry.
+ *
+ * `identOf` says what this package should call an entry; `nameOf` reports what it
+ * actually parses a codepoint as, or undefined if it rejects it.
+ */
+export function assertRegistry(
+  reg: Registry,
+  identOf: (entry: Entry) => string,
+  nameOf: (codepoint: bigint) => string | undefined,
+): void {
+  for (const entry of reg.entries) {
+    const actual = nameOf(parseHex(entry.value))
+    const expected = identOf(entry)
+    const conforms = entry.reserved ? actual === undefined : actual === expected
+    const issue = pendingIssue(entry)
+
+    if (issue !== undefined) {
+      if (conforms) {
+        throw new Error(
+          `${entry.name} (${entry.value}) is marked pending{ts:${issue}} but now conforms — ` +
+            `delete the marker in the fixture (${reg.source})`,
+        )
+      }
+    } else if (entry.reserved) {
+      if (actual !== undefined) {
+        throw new Error(
+          `${entry.name} (${entry.value}) is RESERVED and must be rejected, but parsed as ` +
+            `${actual} (${reg.source})`,
+        )
+      }
+    } else if (actual !== expected) {
+      throw new Error(
+        `${entry.name} (${entry.value}) does not match the fixture: expected ${expected}, ` +
+          `got ${actual} (${reg.source})`,
+      )
+    }
+  }
+
+  for (const entry of reg.not_in_draft ?? []) {
+    const actual = nameOf(parseHex(entry.value))
+    const issue = pendingIssue(entry)
+    if (issue !== undefined) {
+      if (actual === undefined) {
+        throw new Error(
+          `${entry.name} (${entry.value}) is listed in not_in_draft pending{ts:${issue}} but is ` +
+            `already gone — delete the entry (${reg.source})`,
+        )
+      }
+    } else if (actual !== undefined) {
+      throw new Error(
+        `${entry.name} (${entry.value}) is not in the draft and must be rejected, but parsed ` +
+          `as ${actual} (${reg.source})`,
+      )
+    }
+  }
+}


### PR DESCRIPTION
…between stacks

Add dev/conformance/draft18/: language-agnostic JSON fixtures that both moqtail-rs and moqtail-ts load and assert their constants against, so a codepoint is changed in one place rather than in one language only.

Seven fixtures, each transcribed from docs/draft-ietf-moq-transport-18.txt and citing the table it comes from: varint (§1.4.1 Tables 1-2), message types (Table 5), parameter types (Tables 10 and 13), property types (Tables 14-15), stream reset codes (§3.3.3), request error codes (Table 18) and termination codes (Table 17).

The varint vectors were previously typed out by hand in both varint.rs and byte_buffer.ts. Both suites now read them from varint.json instead; no vector is hardcoded in either language any more.

Values are hex strings so a fixture diffs against the draft's own tables, and varint values are decimal strings because 2^64-1 does not survive JSON.parse as a number.

The fixtures describe draft-18, which neither stack fully implements yet, so an entry a stack has not reached carries a pending marker naming the issue that lands it. Markers are self-cleaning: the tests also assert a pending entry is still non-conformant, so the suite fails when the work lands and the marker is left behind. not_in_draft names codepoints a stack still defines that the draft does not, which is what lets the check run in both directions; local_extensions covers deliberate divergence (SWITCH).

Neither test repeats a codepoint. Each asks the enum what it parses a fixture value as and compares that against the fixture, so new variants are picked up automatically. Both directions were verified by hand: renumbering SubscribeOk fails both suites, and marking a conforming entry pending fails with "marked pending but now conforms".

The TS loader lives outside src/ and is imported dynamically, because the suite is in-source; a static import would pull node:fs into the published bundle. Verified dist/ has no reference to the loader or the fixtures.

Three findings fell out of the fixtures:

- TerminationCode.tryFrom throws on five valid values (0x16-0x1A), the bug #275 describes. Marked pending{ts:275}.
- Both stacks carry LOC property ids from an older revision of draft-ietf-moq-loc. Table 15 registers them in the same number space as Table 14, so they collide: AudioLevel sits on 0x06, which draft-18 reads as TIMESTAMP. Filed as #282 and marked pending; the provisional section is asserted, not just recorded.
- TOO_MANY_REQUESTS (0x7) is in both stacks but not Table 17.

Refs #223
