### PR TITLE
fix: renumber LOC property ids

### DIFF
--- a/apps/client-js/src/lib/publisher.ts
+++ b/apps/client-js/src/lib/publisher.ts
@@ -352,7 +352,7 @@ export class Publisher {
       );
     }
     const headers = new ExtensionHeaders()
-      .addCaptureTimestamp(Date.now())
+      .addTimestamp(Date.now())
       .addVideoFrameMarking(isKey ? 1 : 0)
       .build();
 

--- a/apps/meet/src/composables/useVideoPipeline.ts
+++ b/apps/meet/src/composables/useVideoPipeline.ts
@@ -129,7 +129,7 @@ export async function startAudioEncoder({
         chunk.copyTo(payload);
 
         const captureTime = Math.round(Date.now());
-        const locHeaders = new ExtensionHeaders().addCaptureTimestamp(captureTime);
+        const locHeaders = new ExtensionHeaders().addTimestamp(captureTime);
 
         // console.warn('Audio Group ID is:', currentAudioGroupId)
         const moqt = MoqtObject.newWithPayload(
@@ -244,7 +244,7 @@ export function initializeVideoEncoder({
         }
 
         const locHeaders = new ExtensionHeaders()
-          .addCaptureTimestamp(captureTime)
+          .addTimestamp(captureTime)
           .addVideoFrameMarking(chunk.type === 'key' ? 1 : 0);
 
         const desc = meta?.decoderConfig?.description;
@@ -432,7 +432,7 @@ export async function startVideoEncoder({
         }
 
         const locHeaders = new ExtensionHeaders()
-          .addCaptureTimestamp(captureTime)
+          .addTimestamp(captureTime)
           .addVideoFrameMarking(chunk.type === 'key' ? 1 : 0);
 
         const desc = meta?.decoderConfig?.description;

--- a/apps/meet/src/lib/playout_buffer.ts
+++ b/apps/meet/src/lib/playout_buffer.ts
@@ -108,7 +108,7 @@ export class PlayoutBuffer {
     if (object.extensionHeaders) {
       const headers = ExtensionHeaders.fromKeyValuePairs(object.extensionHeaders);
       for (const header of headers) {
-        if (ExtensionHeader.isCaptureTimestamp(header)) {
+        if (ExtensionHeader.isTimestamp(header)) {
           return Number(header.timestamp);
         }
       }

--- a/apps/meet/src/workers/decoderWorker.ts
+++ b/apps/meet/src/workers/decoderWorker.ts
@@ -148,9 +148,7 @@ self.onmessage = async e => {
     //console.debug('[WORKER]Received the payload:', moqtObj)
     //console.debug('[WORKER]Received the extension headers:', extensionHeaders)
     const headers = ExtensionHeaders.fromKeyValuePairs(extensionHeaders ?? []);
-    const timestamp = Number(
-      headers.find(h => ExtensionHeader.isCaptureTimestamp(h))?.timestamp ?? 0n,
-    );
+    const timestamp = Number(headers.find(h => ExtensionHeader.isTimestamp(h))?.timestamp ?? 0n);
     const configHeader = headers.find(h => ExtensionHeader.isVideoConfig(h));
     const isKey = headers.some(h => ExtensionHeader.isVideoFrameMarking(h) && h.value === 1n);
 
@@ -237,9 +235,7 @@ self.onmessage = async e => {
     const extensionHeaders = extensions;
 
     const headers = ExtensionHeaders.fromKeyValuePairs(extensionHeaders ?? []);
-    const timestamp = Number(
-      headers.find(h => ExtensionHeader.isCaptureTimestamp(h))?.timestamp ?? 0n,
-    );
+    const timestamp = Number(headers.find(h => ExtensionHeader.isTimestamp(h))?.timestamp ?? 0n);
 
     if (!audioDecoder) {
       // console.debug('[DECODER] Creating new audio decoder at', new Date().toISOString())

--- a/dev/conformance/draft18/property_types.json
+++ b/dev/conformance/draft18/property_types.json
@@ -1,23 +1,29 @@
 {
   "source": "draft-ietf-moq-transport-18 §15.8 Table 14, Table 15",
   "description": "Property types. Scope is Track, Object, or both. Endpoints MUST ignore unknown Property types, skipping them using the length field. Even type values use VarInt KVP encoding; odd type values use Bytes KVP encoding.",
-
   "greasing": {
     "formula": "0x7f * N + 0x9D",
     "spec": "Section 14",
     "scope": "Any"
   },
-
   "ranges": {
     "description": "Registration policy for the Property Type space.",
     "entries": [
-      { "from": "0x00", "to": "0x77", "policy": "Standards Action or IESG Approval (1-byte encoding)" },
+      {
+        "from": "0x00",
+        "to": "0x77",
+        "policy": "Standards Action or IESG Approval (1-byte encoding)"
+      },
       {
         "from": "0x78",
         "to": "0x7F",
         "policy": "Reserved for application-specific use (1-byte encoding, no registration permitted)"
       },
-      { "from": "0x80", "to": "0x37FF", "policy": "Specification Required (2-byte encoding)" },
+      {
+        "from": "0x80",
+        "to": "0x37FF",
+        "policy": "Specification Required (2-byte encoding)"
+      },
       {
         "from": "0x3800",
         "to": "0x3FFF",
@@ -28,10 +34,13 @@
         "to": "0x7FFF",
         "policy": "Reserved for Mandatory Track Properties (§2.5.1). Properties registered in this range MUST have Track scope; Object scope properties MUST NOT be registered in this range."
       },
-      { "from": "0x8000", "to": null, "policy": "First Come First Served" }
+      {
+        "from": "0x8000",
+        "to": null,
+        "policy": "First Come First Served"
+      }
     ]
   },
-
   "entries": [
     {
       "name": "OBJECT_DELIVERY_TIMEOUT",
@@ -39,16 +48,27 @@
       "scope": "Track",
       "spec": "Section 12.2",
       "notes": "Both stacks call this DeliveryTimeout.",
-      "pending": { "rs": 228, "ts": 265 }
+      "pending": {
+        "rs": 228,
+        "ts": 265
+      }
     },
-    { "name": "MAX_CACHE_DURATION", "value": "0x04", "scope": "Track", "spec": "Section 12.3" },
+    {
+      "name": "MAX_CACHE_DURATION",
+      "value": "0x04",
+      "scope": "Track",
+      "spec": "Section 12.3"
+    },
     {
       "name": "SUBGROUP_DELIVERY_TIMEOUT",
       "value": "0x06",
       "scope": "Track",
       "spec": "Section 12.1",
       "notes": "Missing from both stacks entirely.",
-      "pending": { "rs": 228, "ts": 265 }
+      "pending": {
+        "rs": 228,
+        "ts": 265
+      }
     },
     {
       "name": "IMMUTABLE_PROPERTIES",
@@ -56,15 +76,41 @@
       "scope": "Track, Object",
       "spec": "Section 12.7",
       "notes": "moqtail-ts still calls this ImmutableExtensions.",
-      "pending": { "ts": 264 }
+      "pending": {
+        "ts": 264
+      }
     },
-    { "name": "DEFAULT_PUBLISHER_PRIORITY", "value": "0x0E", "scope": "Track", "spec": "Section 12.4" },
-    { "name": "DEFAULT_PUBLISHER_GROUP_ORDER", "value": "0x22", "scope": "Track", "spec": "Section 12.5" },
-    { "name": "DYNAMIC_GROUPS", "value": "0x30", "scope": "Track", "spec": "Section 12.6" },
-    { "name": "PRIOR_GROUP_ID_GAP", "value": "0x3C", "scope": "Object", "spec": "Section 12.8" },
-    { "name": "PRIOR_OBJECT_ID_GAP", "value": "0x3E", "scope": "Object", "spec": "Section 12.9" }
+    {
+      "name": "DEFAULT_PUBLISHER_PRIORITY",
+      "value": "0x0E",
+      "scope": "Track",
+      "spec": "Section 12.4"
+    },
+    {
+      "name": "DEFAULT_PUBLISHER_GROUP_ORDER",
+      "value": "0x22",
+      "scope": "Track",
+      "spec": "Section 12.5"
+    },
+    {
+      "name": "DYNAMIC_GROUPS",
+      "value": "0x30",
+      "scope": "Track",
+      "spec": "Section 12.6"
+    },
+    {
+      "name": "PRIOR_GROUP_ID_GAP",
+      "value": "0x3C",
+      "scope": "Object",
+      "spec": "Section 12.8"
+    },
+    {
+      "name": "PRIOR_OBJECT_ID_GAP",
+      "value": "0x3E",
+      "scope": "Object",
+      "spec": "Section 12.9"
+    }
   ],
-
   "provisional": {
     "source": "§15.8 Table 15",
     "description": "Provisional registrations for other active drafts in the moq working group. These share the same Property Type space as the entries above, so they are not a private namespace and must not collide with it. Both stacks carry ids from an older revision of draft-ietf-moq-loc.",
@@ -73,35 +119,32 @@
         "name": "TIMESTAMP",
         "value": "0x06",
         "scope": "Object",
-        "spec": "draft-ietf-moq-loc",
-        "notes": "Both stacks call this CaptureTimestamp and put it at 0x02, which is OBJECT_DELIVERY_TIMEOUT.",
-        "pending": { "rs": 282, "ts": 282 }
+        "spec": "draft-ietf-moq-loc"
       },
       {
         "name": "TIMESCALE",
         "value": "0x08",
         "scope": "Track, Object",
-        "spec": "draft-ietf-moq-loc",
-        "notes": "Missing from both stacks.",
-        "pending": { "rs": 282, "ts": 282 }
+        "spec": "draft-ietf-moq-loc"
       },
       {
         "name": "VIDEO_FRAME_MARKING",
         "value": "0x0A",
         "scope": "Object",
-        "spec": "draft-ietf-moq-loc",
-        "notes": "Both stacks put this at 0x04, which is MAX_CACHE_DURATION.",
-        "pending": { "rs": 282, "ts": 282 }
+        "spec": "draft-ietf-moq-loc"
       },
       {
         "name": "AUDIO_LEVEL",
         "value": "0x0C",
         "scope": "Object",
-        "spec": "draft-ietf-moq-loc",
-        "notes": "Both stacks put this at 0x06, which is SUBGROUP_DELIVERY_TIMEOUT and also TIMESTAMP in this table — a draft-18 peer decodes an audio level as a timestamp rather than failing.",
-        "pending": { "rs": 282, "ts": 282 }
+        "spec": "draft-ietf-moq-loc"
       },
-      { "name": "VIDEO_CONFIG", "value": "0x0D", "scope": "Object", "spec": "draft-ietf-moq-loc" }
+      {
+        "name": "VIDEO_CONFIG",
+        "value": "0x0D",
+        "scope": "Object",
+        "spec": "draft-ietf-moq-loc"
+      }
     ]
   }
 }

--- a/libs/moqtail-rs/src/conformance.rs
+++ b/libs/moqtail-rs/src/conformance.rs
@@ -405,10 +405,6 @@ mod enum_conformance {
   /// table (§15.8 Table 15), so they are held to it too.
   #[test]
   fn loc_property_ids_match_fixture() {
-    // No exceptions: #282 renames CaptureTimestamp to Timestamp, so the expected
-    // identifier is the plain PascalCase of the spec name. Pinning the old name here
-    // would keep the entry non-conformant after #282 lands and the marker would never
-    // fire.
     assert_registry(&property_types().provisional, &[], |cp| {
       LOCPropertyId::try_from(cp).ok().map(|p| format!("{p:?}"))
     });

--- a/libs/moqtail-rs/src/model/property/constant.rs
+++ b/libs/moqtail-rs/src/model/property/constant.rs
@@ -19,10 +19,11 @@ use crate::model::error::ParseError;
 #[repr(u64)]
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum LOCPropertyId {
-  CaptureTimestamp = 2,  // Section 2.3.1.1 - Common Header
-  VideoFrameMarking = 4, // Section 2.3.2.2 - Video Header
-  AudioLevel = 6,        // Section 2.3.3.1 - Audio Header
-  VideoConfig = 13,      // Section 2.3.2.1 - Video Header
+  Timestamp = 0x06,
+  Timescale = 0x08,
+  VideoFrameMarking = 0x0A,
+  AudioLevel = 0x0C,
+  VideoConfig = 0x0D,
 }
 
 impl TryFrom<u64> for LOCPropertyId {
@@ -30,10 +31,11 @@ impl TryFrom<u64> for LOCPropertyId {
 
   fn try_from(value: u64) -> Result<Self, Self::Error> {
     match value {
-      2 => Ok(LOCPropertyId::CaptureTimestamp),
-      4 => Ok(LOCPropertyId::VideoFrameMarking),
-      6 => Ok(LOCPropertyId::AudioLevel),
-      13 => Ok(LOCPropertyId::VideoConfig),
+      0x06 => Ok(LOCPropertyId::Timestamp),
+      0x08 => Ok(LOCPropertyId::Timescale),
+      0x0A => Ok(LOCPropertyId::VideoFrameMarking),
+      0x0C => Ok(LOCPropertyId::AudioLevel),
+      0x0D => Ok(LOCPropertyId::VideoConfig),
       _ => Err(ParseError::InvalidType {
         context: "LOCPropertyId::try_from(u64)",
         details: format!("Invalid type, got {value}"),

--- a/libs/moqtail-rs/src/model/property/loc.rs
+++ b/libs/moqtail-rs/src/model/property/loc.rs
@@ -21,7 +21,8 @@ use super::constant::LOCPropertyId;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum LOCProperty {
-  CaptureTimestamp { value: u64 },
+  Timestamp { value: u64 },
+  Timescale { value: u64 },
   VideoFrameMarking { value: u64 },
   AudioLevel { value: u64 },
   VideoConfig { value: Bytes },
@@ -31,8 +32,12 @@ impl LOCProperty {
   pub fn serialize(&self) -> Result<Bytes, ParseError> {
     let mut buf = BytesMut::new();
     match self {
-      LOCProperty::CaptureTimestamp { value } => {
-        buf.put_vi(LOCPropertyId::CaptureTimestamp)?;
+      LOCProperty::Timestamp { value } => {
+        buf.put_vi(LOCPropertyId::Timestamp)?;
+        buf.put_vi(*value)?;
+      }
+      LOCProperty::Timescale { value } => {
+        buf.put_vi(LOCPropertyId::Timescale)?;
         buf.put_vi(*value)?;
       }
       LOCProperty::VideoFrameMarking { value } => {
@@ -74,9 +79,13 @@ impl LOCProperty {
         let value = payload.get_vi()?;
         Ok(LOCProperty::AudioLevel { value })
       }
-      LOCPropertyId::CaptureTimestamp => {
+      LOCPropertyId::Timestamp => {
         let value = payload.get_vi()?;
-        Ok(LOCProperty::CaptureTimestamp { value })
+        Ok(LOCProperty::Timestamp { value })
+      }
+      LOCPropertyId::Timescale => {
+        let value = payload.get_vi()?;
+        Ok(LOCProperty::Timescale { value })
       }
       LOCPropertyId::VideoFrameMarking => {
         let value = payload.get_vi()?;
@@ -94,7 +103,8 @@ impl TryFrom<KeyValuePair> for LOCProperty {
         let id = LOCPropertyId::try_from(type_value)?;
         match id {
           LOCPropertyId::AudioLevel => Ok(LOCProperty::AudioLevel { value }),
-          LOCPropertyId::CaptureTimestamp => Ok(LOCProperty::CaptureTimestamp { value }),
+          LOCPropertyId::Timestamp => Ok(LOCProperty::Timestamp { value }),
+          LOCPropertyId::Timescale => Ok(LOCProperty::Timescale { value }),
           LOCPropertyId::VideoFrameMarking => Ok(LOCProperty::VideoFrameMarking { value }),
           _ => Err(ParseError::InvalidType {
             context: "LOCProperty::try_from(KeyValuePair::VarInt)",

--- a/libs/moqtail-ts/src/model/data/object.ts
+++ b/libs/moqtail-ts/src/model/data/object.ts
@@ -313,7 +313,7 @@ if (import.meta.vitest) {
   describe('MoqtObject', () => {
     test('create object with payload', () => {
       const payload = new TextEncoder().encode('test payload')
-      const extensionHeaders = new ExtensionHeaders().addAudioLevel(100).addCaptureTimestamp(0).build()
+      const extensionHeaders = new ExtensionHeaders().addAudioLevel(100).addTimestamp(0).build()
       const fullTrackName = FullTrackName.tryNew('test/demo', 'track1')
       const location = new Location(100n, 10n)
       const obj = MoqtObject.newWithPayload(

--- a/libs/moqtail-ts/src/model/extension_header/constant.ts
+++ b/libs/moqtail-ts/src/model/extension_header/constant.ts
@@ -17,10 +17,11 @@
 import { InvalidTypeError } from '../error'
 
 export enum LOCHeaderExtensionId {
-  CaptureTimestamp = 2,
-  VideoFrameMarking = 4,
-  AudioLevel = 6,
-  VideoConfig = 13,
+  Timestamp = 0x06,
+  Timescale = 0x08,
+  VideoFrameMarking = 0x0a,
+  AudioLevel = 0x0c,
+  VideoConfig = 0x0d,
 }
 
 export enum TrackExtensionType {
@@ -36,13 +37,15 @@ export enum TrackExtensionType {
 
 export function locHeaderExtensionIdFromNumber(value: number): LOCHeaderExtensionId {
   switch (value) {
-    case 2:
-      return LOCHeaderExtensionId.CaptureTimestamp
-    case 4:
+    case 0x06:
+      return LOCHeaderExtensionId.Timestamp
+    case 0x08:
+      return LOCHeaderExtensionId.Timescale
+    case 0x0a:
       return LOCHeaderExtensionId.VideoFrameMarking
-    case 6:
+    case 0x0c:
       return LOCHeaderExtensionId.AudioLevel
-    case 13:
+    case 0x0d:
       return LOCHeaderExtensionId.VideoConfig
     default:
       throw new InvalidTypeError('locHeaderExtensionIdFromNumber', `Invalid LOC header extension id: ${value}`)
@@ -62,10 +65,7 @@ if (import.meta.vitest) {
     })
 
     // The LOC properties are registered in the same number space as the draft's own
-    // table (§15.8 Table 15), so they are held to it too. No exceptions: #282 renames
-    // CaptureTimestamp to Timestamp, so the expected identifier is the plain PascalCase
-    // of the spec name. Pinning the old name here would keep the entry non-conformant
-    // after #282 lands and the marker would never fire.
+    // table (§15.8 Table 15), so they are held to it too.
     test('LOCHeaderExtensionId matches the provisional LOC registry', async () => {
       const { propertyTypes, assertRegistry, pascalIdent } = await fixture()
       assertRegistry(propertyTypes().provisional, pascalIdent(), (codepoint) => {

--- a/libs/moqtail-ts/src/model/extension_header/extension_header.ts
+++ b/libs/moqtail-ts/src/model/extension_header/extension_header.ts
@@ -15,17 +15,19 @@
  */
 
 import { KeyValuePair } from '../common/pair'
-import { CaptureTimestamp } from './capture_time_stamp'
+import { Timestamp } from './timestamp'
+import { Timescale } from './timescale'
 import { VideoFrameMarking } from './video_frame_marking'
 import { AudioLevel } from './audio_level'
 import { VideoConfig } from './video_config'
 
-export type ExtensionHeader = CaptureTimestamp | VideoFrameMarking | AudioLevel | VideoConfig
+export type ExtensionHeader = Timestamp | Timescale | VideoFrameMarking | AudioLevel | VideoConfig
 
 export namespace ExtensionHeader {
   export function fromKeyValuePair(pair: KeyValuePair): ExtensionHeader | undefined {
     return (
-      CaptureTimestamp.fromKeyValuePair(pair) ||
+      Timestamp.fromKeyValuePair(pair) ||
+      Timescale.fromKeyValuePair(pair) ||
       VideoFrameMarking.fromKeyValuePair(pair) ||
       AudioLevel.fromKeyValuePair(pair) ||
       VideoConfig.fromKeyValuePair(pair)
@@ -36,8 +38,11 @@ export namespace ExtensionHeader {
     return header.toKeyValuePair()
   }
 
-  export function isCaptureTimestamp(header: ExtensionHeader): header is CaptureTimestamp {
-    return header instanceof CaptureTimestamp
+  export function isTimestamp(header: ExtensionHeader): header is Timestamp {
+    return header instanceof Timestamp
+  }
+  export function isTimescale(header: ExtensionHeader): header is Timescale {
+    return header instanceof Timescale
   }
   export function isVideoFrameMarking(header: ExtensionHeader): header is VideoFrameMarking {
     return header instanceof VideoFrameMarking
@@ -53,8 +58,12 @@ export namespace ExtensionHeader {
 export class ExtensionHeaders {
   private kvps: KeyValuePair[] = []
 
-  addCaptureTimestamp(timestamp: bigint | number): this {
-    this.kvps.push(new CaptureTimestamp(BigInt(timestamp)).toKeyValuePair())
+  addTimestamp(timestamp: bigint | number): this {
+    this.kvps.push(new Timestamp(BigInt(timestamp)).toKeyValuePair())
+    return this
+  }
+  addTimescale(timescale: bigint | number): this {
+    this.kvps.push(new Timescale(BigInt(timescale)).toKeyValuePair())
     return this
   }
   addVideoFrameMarking(marking: bigint | number): this {
@@ -95,14 +104,14 @@ if (import.meta.vitest) {
       const audioLevel = 99n
       const videoConfig = new Uint8Array([3, 1, 2, 4, 5, 6, 2, 5, 3])
       const kvps = new ExtensionHeaders()
-        .addCaptureTimestamp(timestamp)
+        .addTimestamp(timestamp)
         .addVideoFrameMarking(marking)
         .addAudioLevel(audioLevel)
         .addVideoConfig(videoConfig)
         .build()
       const parsed = ExtensionHeaders.fromKeyValuePairs(kvps)
       expect(parsed.length).toBe(4)
-      expect(parsed[0] && ExtensionHeader.isCaptureTimestamp(parsed[0]) && parsed[0].timestamp === timestamp).toBe(true)
+      expect(parsed[0] && ExtensionHeader.isTimestamp(parsed[0]) && parsed[0].timestamp === timestamp).toBe(true)
       expect(parsed[1] && ExtensionHeader.isVideoFrameMarking(parsed[1]) && parsed[1].value === marking).toBe(true)
       expect(parsed[2] && ExtensionHeader.isAudioLevel(parsed[2]) && parsed[2].audioLevel === audioLevel).toBe(true)
       expect(parsed[3] && ExtensionHeader.isVideoConfig(parsed[3]) && parsed[3].config === videoConfig).toBe(true)
@@ -114,14 +123,14 @@ if (import.meta.vitest) {
       const marking = 15938n
       const audioLevel = 99n
       const kvps = new ExtensionHeaders()
-        .addCaptureTimestamp(timestamp)
+        .addTimestamp(timestamp)
         .addRaw(unknown)
         .addVideoFrameMarking(marking)
         .addAudioLevel(audioLevel)
         .build()
       const parsed = ExtensionHeaders.fromKeyValuePairs(kvps)
       expect(parsed.length).toBe(3)
-      expect(parsed[0] && ExtensionHeader.isCaptureTimestamp(parsed[0]) && parsed[0].timestamp === timestamp).toBe(true)
+      expect(parsed[0] && ExtensionHeader.isTimestamp(parsed[0]) && parsed[0].timestamp === timestamp).toBe(true)
       expect(parsed[1] && ExtensionHeader.isVideoFrameMarking(parsed[1]) && parsed[1].value === marking).toBe(true)
       expect(parsed[2] && ExtensionHeader.isAudioLevel(parsed[2]) && parsed[2].audioLevel === audioLevel).toBe(true)
     })

--- a/libs/moqtail-ts/src/model/extension_header/index.ts
+++ b/libs/moqtail-ts/src/model/extension_header/index.ts
@@ -15,7 +15,8 @@
  */
 
 export * from './constant'
-export * from './capture_time_stamp'
+export * from './timestamp'
+export * from './timescale'
 export * from './video_frame_marking'
 export * from './audio_level'
 export * from './video_config'

--- a/libs/moqtail-ts/src/model/extension_header/timescale.ts
+++ b/libs/moqtail-ts/src/model/extension_header/timescale.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2026 The MOQtail Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KeyValuePair } from '../common/pair'
+import { LOCHeaderExtensionId } from './constant'
+
+export class Timescale {
+  static readonly TYPE = LOCHeaderExtensionId.Timescale
+
+  constructor(public readonly timescale: bigint) {}
+
+  toKeyValuePair(): KeyValuePair {
+    return KeyValuePair.tryNewVarInt(Timescale.TYPE, this.timescale)
+  }
+
+  static fromKeyValuePair(pair: KeyValuePair): Timescale | undefined {
+    const type = Number(pair.typeValue)
+    if (type === Timescale.TYPE && typeof pair.value === 'bigint') {
+      return new Timescale(pair.value)
+    }
+    return undefined
+  }
+}
+
+if (import.meta.vitest) {
+  const { describe, test, expect } = import.meta.vitest
+  describe('TimescaleExtensionHeader', () => {
+    test('should roundtrip Timescale', () => {
+      const value = 90000n
+      const pair = new Timescale(value).toKeyValuePair()
+      const parsed = Timescale.fromKeyValuePair(pair)
+      expect(parsed).toBeInstanceOf(Timescale)
+      expect(parsed?.timescale).toBe(value)
+    })
+
+    test('should return undefined for a different type', () => {
+      const pair = KeyValuePair.tryNewVarInt(LOCHeaderExtensionId.AudioLevel, 1n)
+      expect(Timescale.fromKeyValuePair(pair)).toBeUndefined()
+    })
+  })
+}

--- a/libs/moqtail-ts/src/model/extension_header/timestamp.ts
+++ b/libs/moqtail-ts/src/model/extension_header/timestamp.ts
@@ -17,18 +17,18 @@
 import { KeyValuePair } from '../common/pair'
 import { LOCHeaderExtensionId } from './constant'
 
-export class CaptureTimestamp {
-  static readonly TYPE = LOCHeaderExtensionId.CaptureTimestamp
+export class Timestamp {
+  static readonly TYPE = LOCHeaderExtensionId.Timestamp
   constructor(public readonly timestamp: bigint) {}
 
   toKeyValuePair(): KeyValuePair {
-    return KeyValuePair.tryNewVarInt(CaptureTimestamp.TYPE, this.timestamp)
+    return KeyValuePair.tryNewVarInt(Timestamp.TYPE, this.timestamp)
   }
 
-  static fromKeyValuePair(pair: KeyValuePair): CaptureTimestamp | undefined {
+  static fromKeyValuePair(pair: KeyValuePair): Timestamp | undefined {
     const type = Number(pair.typeValue)
-    if (type === CaptureTimestamp.TYPE && typeof pair.value === 'bigint') {
-      return new CaptureTimestamp(pair.value)
+    if (type === Timestamp.TYPE && typeof pair.value === 'bigint') {
+      return new Timestamp(pair.value)
     }
     return undefined
   }
@@ -36,12 +36,12 @@ export class CaptureTimestamp {
 
 if (import.meta.vitest) {
   const { describe, test, expect } = import.meta.vitest
-  describe('CaptureTimestampExtensionHeader', () => {
-    test('should roundtrip CaptureTimestamp', () => {
+  describe('TimestampExtensionHeader', () => {
+    test('should roundtrip Timestamp', () => {
       const value = 1234567890123456789n
-      const pair = new CaptureTimestamp(value).toKeyValuePair()
-      const header = CaptureTimestamp.fromKeyValuePair(pair)
-      expect(header).toBeInstanceOf(CaptureTimestamp)
+      const pair = new Timestamp(value).toKeyValuePair()
+      const header = Timestamp.fromKeyValuePair(pair)
+      expect(header).toBeInstanceOf(Timestamp)
       expect(header?.timestamp).toBe(value)
     })
   })


### PR DESCRIPTION
Both stacks carried LOC ids from an older revision of draft-ietf-moq-loc. Draft-18 §15.8 Table 15 registers them provisionally in the same Property Type space as Table 14 (A.1:7316, "Add provisional registry for LOC properties").

  CaptureTimestamp  2    -> Timestamp          0x06
  VideoFrameMarking 4    -> VideoFrameMarking  0x0A
  AudioLevel        6    -> AudioLevel         0x0C
  VideoConfig       13   -> VideoConfig        0x0D  (already correct)
                         -> Timescale          0x08  (was missing)

The one that bites is AudioLevel. Object Properties travel in their own list, so a codepoint only clashes with another at the same scope — and old AudioLevel 6 is exactly new TIMESTAMP 0x06, both Object scope. A draft-18 peer reads an audio level as a timestamp: a plausible wrong value rather than a parse error. The other two were wrong numbers rather than clashes; their old values sit at Track-scope codepoints, so a peer skips them as unknown Object properties (§15.8).

Note 0x06 appears in both tables — TIMESTAMP (Object) and SUBGROUP_DELIVERY_TIMEOUT (Track). That is the draft's own doing and is unambiguous, because Track Properties ride in PUBLISH / SUBSCRIBE_OK / FETCH_OK and Object Properties in the object header. So "no collision" only means anything per scope; #282's last acceptance criterion is corrected in a comment there.

Every new value keeps the §15.8 parity rule (even types are VarInt, odd are Bytes), so no encoding changed: VideoConfig stays the only odd id and the only Bytes-encoded one.

CaptureTimestamp is renamed to Timestamp to match the registry, which breaks the moqtail-ts API: addCaptureTimestamp/isCaptureTimestamp become addTimestamp/isTimestamp, and client-js and meet are updated in the same commit to keep the workspace building. Timescale gains a typed variant in Rust (the LOCPropertyId match is exhaustive) and a matching class in TS, so both stacks support the same set.

Retires the eight 282 markers in property_types.json. The conformance tests demanded it: leaving them fails with "marked pending but now conforms".

Closes #282
