### PR TITLE
feat(moqtail-rs): split delivery timeouts, add rendezvous/fill, align parameter numbers

### DIFF
--- a/dev/conformance/draft18/parameter_types.json
+++ b/dev/conformance/draft18/parameter_types.json
@@ -1,7 +1,6 @@
 {
   "source": "draft-ietf-moq-transport-18 §15.4 Table 10, §15.7 Table 13",
   "description": "Two distinct registries. Setup Options appear in SETUP (§10.3); Message Parameters appear in request and response messages (§10.2). They share no number space.",
-
   "setup_options": {
     "source": "§15.4 Table 10",
     "greasing": {
@@ -10,22 +9,38 @@
       "notes": "Reserved for greasing. Endpoints MUST ignore unknown Setup Options (§10.3)."
     },
     "entries": [
-      { "name": "PATH", "value": "0x01", "spec": "Section 10.3.1.2" },
-      { "name": "AUTHORIZATION_TOKEN", "value": "0x03", "spec": "Section 10.3.1.4" },
-      { "name": "MAX_AUTH_TOKEN_CACHE_SIZE", "value": "0x04", "spec": "Section 10.3.1.3" },
+      {
+        "name": "PATH",
+        "value": "0x01",
+        "spec": "Section 10.3.1.2"
+      },
+      {
+        "name": "AUTHORIZATION_TOKEN",
+        "value": "0x03",
+        "spec": "Section 10.3.1.4"
+      },
+      {
+        "name": "MAX_AUTH_TOKEN_CACHE_SIZE",
+        "value": "0x04",
+        "spec": "Section 10.3.1.3"
+      },
       {
         "name": "AUTHORITY",
         "value": "0x05",
         "spec": "Section 10.3.1.1",
         "notes": "moqtail-rs has this; moqtail-ts does not.",
-        "pending": { "ts": 256 }
+        "pending": {
+          "ts": 256
+        }
       },
       {
         "name": "MOQT_IMPLEMENTATION",
         "value": "0x07",
         "spec": "Section 10.3.1.5",
         "notes": "moqtail-rs has this; moqtail-ts does not.",
-        "pending": { "ts": 256 }
+        "pending": {
+          "ts": 256
+        }
       }
     ],
     "not_in_draft": [
@@ -33,11 +48,13 @@
         "name": "MAX_REQUEST_ID",
         "value": "0x02",
         "notes": "Table 10 has no 0x02. Removed with the MAX_REQUEST_ID message.",
-        "pending": { "rs": 236, "ts": 259 }
+        "pending": {
+          "rs": 236,
+          "ts": 259
+        }
       }
     ]
   },
-
   "message_parameters": {
     "source": "§15.7 Table 13",
     "entries": [
@@ -45,40 +62,81 @@
         "name": "OBJECT_DELIVERY_TIMEOUT",
         "value": "0x02",
         "spec": "Section 10.2.4",
-        "notes": "Both stacks call this DeliveryTimeout; draft-18 splits the timeout in two and renames this one.",
-        "pending": { "rs": 228, "ts": 265 }
+        "pending": {
+          "ts": 265
+        }
       },
-      { "name": "AUTHORIZATION_TOKEN", "value": "0x03", "spec": "Section 10.2.2" },
+      {
+        "name": "AUTHORIZATION_TOKEN",
+        "value": "0x03",
+        "spec": "Section 10.2.2"
+      },
       {
         "name": "RENDEZVOUS_TIMEOUT",
         "value": "0x04",
         "spec": "Section 10.2.6",
-        "pending": { "rs": 228, "ts": 265 }
+        "pending": {
+          "ts": 265
+        }
       },
       {
         "name": "SUBGROUP_DELIVERY_TIMEOUT",
         "value": "0x06",
         "spec": "Section 10.2.3",
-        "pending": { "rs": 228, "ts": 265 }
+        "pending": {
+          "ts": 265
+        }
       },
-      { "name": "EXPIRES", "value": "0x08", "spec": "Section 10.2.10" },
-      { "name": "LARGEST_OBJECT", "value": "0x09", "spec": "Section 10.2.11" },
+      {
+        "name": "EXPIRES",
+        "value": "0x08",
+        "spec": "Section 10.2.10"
+      },
+      {
+        "name": "LARGEST_OBJECT",
+        "value": "0x09",
+        "spec": "Section 10.2.11"
+      },
       {
         "name": "FILL_TIMEOUT",
         "value": "0x0A",
         "spec": "Section 10.2.5",
-        "pending": { "rs": 228, "ts": 265 }
+        "pending": {
+          "ts": 265
+        }
       },
-      { "name": "FORWARD", "value": "0x10", "spec": "Section 10.2.12" },
-      { "name": "SUBSCRIBER_PRIORITY", "value": "0x20", "spec": "Section 10.2.7" },
-      { "name": "SUBSCRIPTION_FILTER", "value": "0x21", "spec": "Section 10.2.9" },
-      { "name": "GROUP_ORDER", "value": "0x22", "spec": "Section 10.2.8" },
-      { "name": "NEW_GROUP_REQUEST", "value": "0x32", "spec": "Section 10.2.13" },
+      {
+        "name": "FORWARD",
+        "value": "0x10",
+        "spec": "Section 10.2.12"
+      },
+      {
+        "name": "SUBSCRIBER_PRIORITY",
+        "value": "0x20",
+        "spec": "Section 10.2.7"
+      },
+      {
+        "name": "SUBSCRIPTION_FILTER",
+        "value": "0x21",
+        "spec": "Section 10.2.9"
+      },
+      {
+        "name": "GROUP_ORDER",
+        "value": "0x22",
+        "spec": "Section 10.2.8"
+      },
+      {
+        "name": "NEW_GROUP_REQUEST",
+        "value": "0x32",
+        "spec": "Section 10.2.13"
+      },
       {
         "name": "TRACK_NAMESPACE_PREFIX",
         "value": "0x34",
         "spec": "Section 10.2.14",
-        "pending": { "rs": 228, "ts": 265 }
+        "pending": {
+          "ts": 265
+        }
       }
     ]
   }

--- a/dev/conformance/draft18/property_types.json
+++ b/dev/conformance/draft18/property_types.json
@@ -47,9 +47,7 @@
       "value": "0x02",
       "scope": "Track",
       "spec": "Section 12.2",
-      "notes": "Both stacks call this DeliveryTimeout.",
       "pending": {
-        "rs": 228,
         "ts": 265
       }
     },
@@ -64,9 +62,7 @@
       "value": "0x06",
       "scope": "Track",
       "spec": "Section 12.1",
-      "notes": "Missing from both stacks entirely.",
       "pending": {
-        "rs": 228,
         "ts": 265
       }
     },

--- a/docs/draft16to18tasks.md
+++ b/docs/draft16to18tasks.md
@@ -959,53 +959,53 @@ Read this the other way round to confirm nothing is dropped. Line numbers index
 
 ### A.1 — Since draft-ietf-moq-transport-17 (line 7202)
 
-| Line | Bullet                                                                          | Task                                       |
-| ---- | ------------------------------------------------------------------------------- | ------------------------------------------ |
-| 7206 | Unified moqt:// URI scheme for QUIC and WebTransport (#1486)                    | CL-1, JS-2, MT-2                           |
-| 7208 | Add fragment identifier support for moqt URIs (#1571)                           | CL-1, JS-2                                 |
-| 7210 | Split SUBSCRIBE_NAMESPACE into SUBSCRIBE_NAMESPACE and SUBSCRIBE_TRACKS (#1542) | RS-11, TS-11, RL-2                         |
-| 7213 | Remove Required Request ID (#1615)                                              | **RS-7b**, TS-7b                           |
-| 7215 | Add REDIRECT for request errors and established subscriptions (#1534)           | RS-13, TS-13                               |
-| 7218 | Allow GOAWAY on request streams to migrate individual requests (#1617)          | RS-13, RL-5                                |
-| 7229 | Add Request ID to GOAWAY (#1559)                                                | RS-13, TS-13                               |
-| 7231 | Remove PUBLISH_OK message type, make it a REQUEST_OK alias (#1611)              | RS-2, RS-7                                 |
-| 7233 | Generalize stream reset codes to all request streams… (#1606)                   | RS-10, RL-5                                |
-| 7236 | Add Track Properties to REQUEST_OK (#1576)                                      | RS-7                                       |
-| 7238 | Add support for mandatory-to-understand track extensions (#1509)                | RL-1, RS-10 (`UNSUPPORTED_EXTENSION 0x33`) |
-| 7240 | Exclude your own tracks from SUBSCRIBE_NAMESPACE (#1596)                        | RL-3                                       |
-| 7242 | Add Session-Level Tracks reserved namespace (#1562)                             | RS-17                                      |
-| 7244 | Allow coalescing REQUEST_UPDATE processing (#1540)                              | **RL-6**                                   |
-| 7246 | SUBSCRIBE takes precedence over SUBSCRIBE_NAMESPACE at relay (#1533)            | RL-3                                       |
-| 7249 | Don't close the Session for unknown errors (#1561)                              | RL-4                                       |
-| 7251 | Clarify REQUEST_UPDATE failure behavior for all request types (#1539)           | RS-19                                      |
-| 7254 | Clarify SUBSCRIBE_NAMESPACE stream closure semantics (#1541)                    | RS-11                                      |
-| 7256 | FETCH to a track with no objects returns INVALID_RANGE (#1537)                  | **RL-7**                                   |
-| 7258 | Clarify FETCH_OK End Location semantics (#1536)                                 | **RL-7**                                   |
-| 7260 | Clarify definition of scope (#1629)                                             | — editorial, no action                     |
-| 7262 | Clarify Joining Fetch behavior:                                                 | **RL-7**                                   |
-| 7264 | ↳ Joining FETCH is unaffected by forward changing to 0 (#1620)                  | **RL-7**                                   |
-| 7266 | ↳ Joining Fetch forward state mismatch is a request error (#1609)               | **RL-7**                                   |
-| 7268 | ↳ Clarify Joining Fetch ordering with Forward State transitions (#1577)         | **RL-7**                                   |
-| 7273 | Make Object ID and Group ID delta encoded in Fetch responses (#1586)            | RS-15, TS-15                               |
-| 7276 | Add FIRST_OBJECT bit to SUBGROUP_HEADER type (#1618)                            | RS-14, TS-14                               |
-| 7285 | Split DELIVERY_TIMEOUT into two types of timeout (#1605)                        | RS-9, TS-9                                 |
-| 7287 | FILL_TIMEOUT parameter (#1490)                                                  | RS-9, TS-9                                 |
-| 7289 | Forbid relays from lying about LARGEST_OBJECT (#1621)                           | RL-4                                       |
-| 7291 | Allow publisher to reopen subgroup after REQUEST_UPDATE forward 0->1 (#1583)    | RS-17                                      |
-| 7294 | Allow 7-byte varint and non-minimal encodings (#1595)                           | ✅ **RS-1 + TS-1 DONE**                    |
-| 7296 | Padding streams and datagrams (#1475)                                           | RS-17                                      |
-| 7298 | Close session when delta encoding wraps (#1560)                                 | RS-15                                      |
-| 7302 | Clarify Object existence and cross-source contradictions (#1566)                | RL-4                                       |
-| 7304 | Clarify immutable track properties (#1535)                                      | RL-1                                       |
-| 7306 | Improve Startup Latency and 0-RTT guidance (#1544)                              | — editorial                                |
-| 7308 | Improve Security Considerations section (#1625)                                 | — editorial                                |
-| 7310 | Rewrite abstract and introduction (#1556)                                       | — editorial                                |
-| 7312 | Define textual aliases for REQUEST_OK by request type (#1610)                   | RS-7                                       |
-| 7314 | Add IANA registry for Setup Options (#1564)                                     | RS-3                                       |
-| 7316 | Add provisional registry for LOC properties (#1624)                             | RS-8 (`LOCHeaderExtensionId`)              |
-| 7318 | Update MOQ Properties registration policies (#1525)                             | — editorial                                |
-| 7320 | Add stream type column to message type table (#1555)                            | RS-2                                       |
-| 7322 | Fix grease examples to match 0x7f multiplier (#1569)                            | RS-18                                      |
+| Line | Bullet                                                                          | Task                                                                                                                                                |
+| ---- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 7206 | Unified moqt:// URI scheme for QUIC and WebTransport (#1486)                    | CL-1, JS-2, MT-2                                                                                                                                    |
+| 7208 | Add fragment identifier support for moqt URIs (#1571)                           | CL-1, JS-2                                                                                                                                          |
+| 7210 | Split SUBSCRIBE_NAMESPACE into SUBSCRIBE_NAMESPACE and SUBSCRIBE_TRACKS (#1542) | RS-11, TS-11, RL-2                                                                                                                                  |
+| 7213 | Remove Required Request ID (#1615)                                              | **RS-7b**, TS-7b                                                                                                                                    |
+| 7215 | Add REDIRECT for request errors and established subscriptions (#1534)           | RS-13, TS-13                                                                                                                                        |
+| 7218 | Allow GOAWAY on request streams to migrate individual requests (#1617)          | RS-13, RL-5                                                                                                                                         |
+| 7229 | Add Request ID to GOAWAY (#1559)                                                | RS-13, TS-13                                                                                                                                        |
+| 7231 | Remove PUBLISH_OK message type, make it a REQUEST_OK alias (#1611)              | RS-2, RS-7                                                                                                                                          |
+| 7233 | Generalize stream reset codes to all request streams… (#1606)                   | RS-10, RL-5                                                                                                                                         |
+| 7236 | Add Track Properties to REQUEST_OK (#1576)                                      | RS-7                                                                                                                                                |
+| 7238 | Add support for mandatory-to-understand track extensions (#1509)                | RL-1, RS-10 (`UNSUPPORTED_EXTENSION 0x33`)                                                                                                          |
+| 7240 | Exclude your own tracks from SUBSCRIBE_NAMESPACE (#1596)                        | RL-3                                                                                                                                                |
+| 7242 | Add Session-Level Tracks reserved namespace (#1562)                             | RS-17                                                                                                                                               |
+| 7244 | Allow coalescing REQUEST_UPDATE processing (#1540)                              | **RL-6**                                                                                                                                            |
+| 7246 | SUBSCRIBE takes precedence over SUBSCRIBE_NAMESPACE at relay (#1533)            | RL-3                                                                                                                                                |
+| 7249 | Don't close the Session for unknown errors (#1561)                              | RL-4                                                                                                                                                |
+| 7251 | Clarify REQUEST_UPDATE failure behavior for all request types (#1539)           | RS-19                                                                                                                                               |
+| 7254 | Clarify SUBSCRIBE_NAMESPACE stream closure semantics (#1541)                    | RS-11                                                                                                                                               |
+| 7256 | FETCH to a track with no objects returns INVALID_RANGE (#1537)                  | **RL-7**                                                                                                                                            |
+| 7258 | Clarify FETCH_OK End Location semantics (#1536)                                 | **RL-7**                                                                                                                                            |
+| 7260 | Clarify definition of scope (#1629)                                             | RS-9 — a parameter in the wrong message type flips from "ignore" (draft-16) to session-closing PROTOCOL_VIOLATION (draft-18 §10.2.1); not editorial |
+| 7262 | Clarify Joining Fetch behavior:                                                 | **RL-7**                                                                                                                                            |
+| 7264 | ↳ Joining FETCH is unaffected by forward changing to 0 (#1620)                  | **RL-7**                                                                                                                                            |
+| 7266 | ↳ Joining Fetch forward state mismatch is a request error (#1609)               | **RL-7**                                                                                                                                            |
+| 7268 | ↳ Clarify Joining Fetch ordering with Forward State transitions (#1577)         | **RL-7**                                                                                                                                            |
+| 7273 | Make Object ID and Group ID delta encoded in Fetch responses (#1586)            | RS-15, TS-15                                                                                                                                        |
+| 7276 | Add FIRST_OBJECT bit to SUBGROUP_HEADER type (#1618)                            | RS-14, TS-14                                                                                                                                        |
+| 7285 | Split DELIVERY_TIMEOUT into two types of timeout (#1605)                        | RS-9, TS-9                                                                                                                                          |
+| 7287 | FILL_TIMEOUT parameter (#1490)                                                  | RS-9, TS-9                                                                                                                                          |
+| 7289 | Forbid relays from lying about LARGEST_OBJECT (#1621)                           | RL-4                                                                                                                                                |
+| 7291 | Allow publisher to reopen subgroup after REQUEST_UPDATE forward 0->1 (#1583)    | RS-17                                                                                                                                               |
+| 7294 | Allow 7-byte varint and non-minimal encodings (#1595)                           | ✅ **RS-1 + TS-1 DONE**                                                                                                                             |
+| 7296 | Padding streams and datagrams (#1475)                                           | RS-17                                                                                                                                               |
+| 7298 | Close session when delta encoding wraps (#1560)                                 | RS-15                                                                                                                                               |
+| 7302 | Clarify Object existence and cross-source contradictions (#1566)                | RL-4                                                                                                                                                |
+| 7304 | Clarify immutable track properties (#1535)                                      | RL-1                                                                                                                                                |
+| 7306 | Improve Startup Latency and 0-RTT guidance (#1544)                              | — editorial                                                                                                                                         |
+| 7308 | Improve Security Considerations section (#1625)                                 | — editorial                                                                                                                                         |
+| 7310 | Rewrite abstract and introduction (#1556)                                       | — editorial                                                                                                                                         |
+| 7312 | Define textual aliases for REQUEST_OK by request type (#1610)                   | RS-7                                                                                                                                                |
+| 7314 | Add IANA registry for Setup Options (#1564)                                     | RS-3                                                                                                                                                |
+| 7316 | Add provisional registry for LOC properties (#1624)                             | RS-8 (`LOCHeaderExtensionId`)                                                                                                                       |
+| 7318 | Update MOQ Properties registration policies (#1525)                             | — editorial                                                                                                                                         |
+| 7320 | Add stream type column to message type table (#1555)                            | RS-2                                                                                                                                                |
+| 7322 | Fix grease examples to match 0x7f multiplier (#1569)                            | RS-18                                                                                                                                               |
 
 ### A.2 — Since draft-ietf-moq-transport-16 (line 7324)
 

--- a/libs/moqtail-rs/src/model/control/publish.rs
+++ b/libs/moqtail-rs/src/model/control/publish.rs
@@ -198,7 +198,7 @@ mod tests {
       7,
       vec![],
       vec![
-        TrackProperty::DeliveryTimeout { timeout_ms: 3000 },
+        TrackProperty::ObjectDeliveryTimeout { timeout_ms: 3000 },
         TrackProperty::DefaultPublisherPriority { priority: 100 },
       ],
     );

--- a/libs/moqtail-rs/src/model/control/publish_ok.rs
+++ b/libs/moqtail-rs/src/model/control/publish_ok.rs
@@ -135,7 +135,7 @@ mod tests {
           Some(Location::new(5, 10)),
           Some(100),
         ),
-        MessageParameter::new_delivery_timeout(5000),
+        MessageParameter::new_object_delivery_timeout(5000),
       ],
     );
     // Wire encoding canonicalizes parameter order ascending by type (delta-encoding requirement).

--- a/libs/moqtail-rs/src/model/control/subscribe_ok.rs
+++ b/libs/moqtail-rs/src/model/control/subscribe_ok.rs
@@ -152,7 +152,7 @@ mod tests {
         MessageParameter::new_group_order(GroupOrder::Descending),
       ],
       track_properties: vec![
-        TrackProperty::DeliveryTimeout { timeout_ms: 500 },
+        TrackProperty::ObjectDeliveryTimeout { timeout_ms: 500 },
         TrackProperty::DynamicGroups { enabled: true },
       ],
     };

--- a/libs/moqtail-rs/src/model/parameter/constant.rs
+++ b/libs/moqtail-rs/src/model/parameter/constant.rs
@@ -53,15 +53,19 @@ impl From<SetupOptionType> for u64 {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u64)]
 pub enum MessageParameterType {
-  DeliveryTimeout = 0x02,
+  ObjectDeliveryTimeout = 0x02,
   AuthorizationToken = 0x03,
+  RendezvousTimeout = 0x04,
+  SubgroupDeliveryTimeout = 0x06,
   Expires = 0x08,
   LargestObject = 0x09,
+  FillTimeout = 0x0A,
   Forward = 0x10,
   SubscriberPriority = 0x20,
   SubscriptionFilter = 0x21,
   GroupOrder = 0x22,
   NewGroupRequest = 0x32,
+  TrackNamespacePrefix = 0x34,
 }
 
 impl TryFrom<u64> for MessageParameterType {
@@ -69,15 +73,19 @@ impl TryFrom<u64> for MessageParameterType {
 
   fn try_from(value: u64) -> Result<Self, Self::Error> {
     match value {
-      0x02 => Ok(MessageParameterType::DeliveryTimeout),
+      0x02 => Ok(MessageParameterType::ObjectDeliveryTimeout),
       0x03 => Ok(MessageParameterType::AuthorizationToken),
+      0x04 => Ok(MessageParameterType::RendezvousTimeout),
+      0x06 => Ok(MessageParameterType::SubgroupDeliveryTimeout),
       0x08 => Ok(MessageParameterType::Expires),
       0x09 => Ok(MessageParameterType::LargestObject),
+      0x0A => Ok(MessageParameterType::FillTimeout),
       0x10 => Ok(MessageParameterType::Forward),
       0x20 => Ok(MessageParameterType::SubscriberPriority),
       0x21 => Ok(MessageParameterType::SubscriptionFilter),
       0x22 => Ok(MessageParameterType::GroupOrder),
       0x32 => Ok(MessageParameterType::NewGroupRequest),
+      0x34 => Ok(MessageParameterType::TrackNamespacePrefix),
       _ => Err(ParseError::InvalidType {
         context: "MessageParameterType::try_from(u64)",
         details: format!("Unknown parameter type, got {value}"),

--- a/libs/moqtail-rs/src/model/parameter/message_parameter.rs
+++ b/libs/moqtail-rs/src/model/parameter/message_parameter.rs
@@ -23,7 +23,16 @@ use bytes::{Bytes, BytesMut};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MessageParameter {
-  DeliveryTimeout {
+  ObjectDeliveryTimeout {
+    timeout: u64,
+  },
+  SubgroupDeliveryTimeout {
+    timeout: u64,
+  },
+  RendezvousTimeout {
+    timeout: u64,
+  },
+  FillTimeout {
     timeout: u64,
   },
   AuthorizationToken {
@@ -55,8 +64,20 @@ pub enum MessageParameter {
 }
 
 impl MessageParameter {
-  pub fn new_delivery_timeout(timeout: u64) -> Self {
-    Self::DeliveryTimeout { timeout }
+  pub fn new_object_delivery_timeout(timeout: u64) -> Self {
+    Self::ObjectDeliveryTimeout { timeout }
+  }
+
+  pub fn new_subgroup_delivery_timeout(timeout: u64) -> Self {
+    Self::SubgroupDeliveryTimeout { timeout }
+  }
+
+  pub fn new_rendezvous_timeout(timeout: u64) -> Self {
+    Self::RendezvousTimeout { timeout }
+  }
+
+  pub fn new_fill_timeout(timeout: u64) -> Self {
+    Self::FillTimeout { timeout }
   }
 
   pub fn new_authorization_token(token: AuthorizationToken) -> Self {
@@ -102,7 +123,10 @@ impl MessageParameter {
   /// Returns the raw wire type value for this parameter.
   pub fn type_value(&self) -> u64 {
     match self {
-      Self::DeliveryTimeout { .. } => MessageParameterType::DeliveryTimeout as u64,
+      Self::ObjectDeliveryTimeout { .. } => MessageParameterType::ObjectDeliveryTimeout as u64,
+      Self::SubgroupDeliveryTimeout { .. } => MessageParameterType::SubgroupDeliveryTimeout as u64,
+      Self::RendezvousTimeout { .. } => MessageParameterType::RendezvousTimeout as u64,
+      Self::FillTimeout { .. } => MessageParameterType::FillTimeout as u64,
       Self::AuthorizationToken { .. } => MessageParameterType::AuthorizationToken as u64,
       Self::Expires { .. } => MessageParameterType::Expires as u64,
       Self::LargestObject { .. } => MessageParameterType::LargestObject as u64,
@@ -115,8 +139,8 @@ impl MessageParameter {
   }
 
   /// Returns true if this parameter is permitted in the given control message type.
-  /// Per spec: if a known parameter appears in a message where it is not defined,
-  /// it MUST be ignored by the receiver.
+  /// §10.2.1: a parameter appearing in a message type it is not defined for is a
+  /// PROTOCOL_VIOLATION (draft-16 ignored it; draft-18 rejects it).
   pub fn is_valid_for(&self, msg_type: ControlMessageType) -> bool {
     match self {
       Self::AuthorizationToken { .. } => matches!(
@@ -129,12 +153,17 @@ impl MessageParameter {
           | ControlMessageType::TrackStatus
           | ControlMessageType::Fetch
       ),
-      Self::DeliveryTimeout { .. } => matches!(
+      // §10.2.4 / §10.2.3: PUBLISH_OK, SUBSCRIBE, or REQUEST_UPDATE.
+      Self::ObjectDeliveryTimeout { .. } | Self::SubgroupDeliveryTimeout { .. } => matches!(
         msg_type,
         ControlMessageType::PublishOk
           | ControlMessageType::Subscribe
           | ControlMessageType::RequestUpdate
       ),
+      // §10.2.6: SUBSCRIBE only.
+      Self::RendezvousTimeout { .. } => matches!(msg_type, ControlMessageType::Subscribe),
+      // §10.2.5: FETCH only.
+      Self::FillTimeout { .. } => matches!(msg_type, ControlMessageType::Fetch),
       Self::SubscriberPriority { .. } => matches!(
         msg_type,
         ControlMessageType::Subscribe
@@ -206,15 +235,17 @@ impl MessageParameter {
           }
         })?;
         match param_type {
-          MessageParameterType::DeliveryTimeout => {
-            if *value == 0 {
-              return Err(ParseError::ProtocolViolation {
-                context: "MessageParameter::deserialize",
-                details: "DELIVERY_TIMEOUT must be greater than 0".to_string(),
-              });
-            }
-            Ok(Self::DeliveryTimeout { timeout: *value })
+          // §8: a value of 0 means no timeout is set. It is valid, not a violation.
+          MessageParameterType::ObjectDeliveryTimeout => {
+            Ok(Self::ObjectDeliveryTimeout { timeout: *value })
           }
+          MessageParameterType::SubgroupDeliveryTimeout => {
+            Ok(Self::SubgroupDeliveryTimeout { timeout: *value })
+          }
+          MessageParameterType::RendezvousTimeout => {
+            Ok(Self::RendezvousTimeout { timeout: *value })
+          }
+          MessageParameterType::FillTimeout => Ok(Self::FillTimeout { timeout: *value }),
           MessageParameterType::Expires => Ok(Self::Expires { expires: *value }),
           MessageParameterType::Forward => match *value {
             0 => Ok(Self::Forward { forward: false }),
@@ -351,8 +382,18 @@ impl TryInto<KeyValuePair> for MessageParameter {
 
   fn try_into(self) -> Result<KeyValuePair, Self::Error> {
     match self {
-      Self::DeliveryTimeout { timeout } => {
-        KeyValuePair::try_new_varint(MessageParameterType::DeliveryTimeout as u64, timeout)
+      Self::ObjectDeliveryTimeout { timeout } => {
+        KeyValuePair::try_new_varint(MessageParameterType::ObjectDeliveryTimeout as u64, timeout)
+      }
+      Self::SubgroupDeliveryTimeout { timeout } => KeyValuePair::try_new_varint(
+        MessageParameterType::SubgroupDeliveryTimeout as u64,
+        timeout,
+      ),
+      Self::RendezvousTimeout { timeout } => {
+        KeyValuePair::try_new_varint(MessageParameterType::RendezvousTimeout as u64, timeout)
+      }
+      Self::FillTimeout { timeout } => {
+        KeyValuePair::try_new_varint(MessageParameterType::FillTimeout as u64, timeout)
       }
       Self::Expires { expires } => {
         KeyValuePair::try_new_varint(MessageParameterType::Expires as u64, expires)
@@ -412,7 +453,10 @@ impl TryInto<KeyValuePair> for MessageParameter {
 
 /// Deserializes `count` MessageParameters from a raw byte buffer for the given message type.
 /// - Unknown parameter types → ProtocolViolation error
-/// - Known parameters not valid for `msg_type` → silently ignored per spec
+/// - Known parameters not valid for `msg_type` → ProtocolViolation error
+///
+/// §10.2.1: a parameter appearing in a message type it is not defined for MUST close the
+/// session with PROTOCOL_VIOLATION. (Draft-16 ignored it; draft-18 rejects it.)
 pub fn deserialize_message_parameters(
   bytes: &mut Bytes,
   count: u64,
@@ -422,10 +466,16 @@ pub fn deserialize_message_parameters(
   let mut params = Vec::with_capacity(kvps.len());
   for kvp in &kvps {
     let param = MessageParameter::deserialize(kvp)?;
-    if param.is_valid_for(msg_type) {
-      params.push(param);
+    if !param.is_valid_for(msg_type) {
+      return Err(ParseError::ProtocolViolation {
+        context: "deserialize_message_parameters",
+        details: format!(
+          "parameter type 0x{:02X} is not allowed in {msg_type:?}",
+          param.type_value()
+        ),
+      });
     }
-    // else: silently ignore per spec
+    params.push(param);
   }
   Ok(params)
 }
@@ -475,7 +525,7 @@ mod tests {
 
   #[test]
   fn test_roundtrip_delivery_timeout() {
-    let orig = MessageParameter::new_delivery_timeout(0xABCD);
+    let orig = MessageParameter::new_object_delivery_timeout(0xABCD);
     assert_eq!(roundtrip(orig.clone()), orig);
   }
 
@@ -565,19 +615,42 @@ mod tests {
   }
 
   #[test]
-  fn test_bulk_deserialize_ignores_wrong_message_params() {
-    // DeliveryTimeout is not valid in Fetch messages — should be silently dropped
+  fn test_bulk_deserialize_rejects_wrong_message_params() {
+    // §10.2.1: a parameter in a message type it is not defined for MUST close the
+    // session with PROTOCOL_VIOLATION. ObjectDeliveryTimeout is not valid in FETCH.
     let params = vec![
-      MessageParameter::new_delivery_timeout(100),
+      MessageParameter::new_object_delivery_timeout(100),
       MessageParameter::new_subscriber_priority(50),
     ];
     let param_count = params.len() as u64;
     let mut bytes = serialize_message_parameters(&params).unwrap();
-    // DeliveryTimeout is invalid for Fetch; SubscriberPriority is valid
-    let result =
-      deserialize_message_parameters(&mut bytes, param_count, ControlMessageType::Fetch).unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0], MessageParameter::new_subscriber_priority(50));
+    let err = deserialize_message_parameters(&mut bytes, param_count, ControlMessageType::Fetch)
+      .unwrap_err();
+    assert!(matches!(err, ParseError::ProtocolViolation { .. }));
+  }
+
+  #[test]
+  fn test_fill_timeout_rejected_outside_fetch() {
+    // FILL_TIMEOUT is FETCH-only (§10.2.5); in a SUBSCRIBE it must be rejected.
+    let params = vec![MessageParameter::new_fill_timeout(3000)];
+    let mut bytes = serialize_message_parameters(&params).unwrap();
+    let err =
+      deserialize_message_parameters(&mut bytes, 1, ControlMessageType::Subscribe).unwrap_err();
+    assert!(matches!(err, ParseError::ProtocolViolation { .. }));
+
+    // And accepted in a FETCH.
+    let mut bytes = serialize_message_parameters(&params).unwrap();
+    let ok = deserialize_message_parameters(&mut bytes, 1, ControlMessageType::Fetch).unwrap();
+    assert_eq!(ok, vec![MessageParameter::new_fill_timeout(3000)]);
+  }
+
+  #[test]
+  fn test_delivery_timeout_zero_means_no_timeout() {
+    // §8: a value of 0 is valid and means no timeout.
+    let params = vec![MessageParameter::new_object_delivery_timeout(0)];
+    let mut bytes = serialize_message_parameters(&params).unwrap();
+    let ok = deserialize_message_parameters(&mut bytes, 1, ControlMessageType::Subscribe).unwrap();
+    assert_eq!(ok, vec![MessageParameter::new_object_delivery_timeout(0)]);
   }
 
   #[test]
@@ -599,18 +672,18 @@ mod tests {
     ];
     let updates = vec![
       MessageParameter::new_subscriber_priority(50),
-      MessageParameter::new_delivery_timeout(500),
+      MessageParameter::new_object_delivery_timeout(500),
     ];
     apply_message_parameter_update(&mut current, updates);
     assert_eq!(current.len(), 3);
     assert!(current.contains(&MessageParameter::new_subscriber_priority(50)));
     assert!(current.contains(&MessageParameter::new_forward(true)));
-    assert!(current.contains(&MessageParameter::new_delivery_timeout(500)));
+    assert!(current.contains(&MessageParameter::new_object_delivery_timeout(500)));
   }
 
   #[test]
   fn test_is_valid_for() {
-    let timeout = MessageParameter::new_delivery_timeout(100);
+    let timeout = MessageParameter::new_object_delivery_timeout(100);
     assert!(timeout.is_valid_for(ControlMessageType::Subscribe));
     assert!(timeout.is_valid_for(ControlMessageType::PublishOk));
     assert!(!timeout.is_valid_for(ControlMessageType::Fetch));
@@ -619,8 +692,8 @@ mod tests {
   #[test]
   fn test_type_value() {
     assert_eq!(
-      MessageParameter::new_delivery_timeout(0).type_value(),
-      MessageParameterType::DeliveryTimeout as u64
+      MessageParameter::new_object_delivery_timeout(0).type_value(),
+      MessageParameterType::ObjectDeliveryTimeout as u64
     );
     assert_eq!(
       MessageParameter::new_forward(true).type_value(),

--- a/libs/moqtail-rs/src/model/property/constant.rs
+++ b/libs/moqtail-rs/src/model/property/constant.rs
@@ -55,14 +55,15 @@ impl From<LOCPropertyId> for u64 {
 #[repr(u64)]
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum TrackPropertyType {
-  DeliveryTimeout = 0x02,            // Track scope, VarInt (ms, must be > 0)
-  MaxCacheDuration = 0x04,           // Track scope, VarInt (ms)
-  ImmutableProperties = 0x0B,        // Track+Object scope, Bytes (nested KVPs)
-  DefaultPublisherPriority = 0x0E,   // Track scope, VarInt (0-255)
+  ObjectDeliveryTimeout = 0x02, // Track scope, VarInt (ms, 0 = no timeout)
+  MaxCacheDuration = 0x04,      // Track scope, VarInt (ms)
+  SubgroupDeliveryTimeout = 0x06, // Track scope, VarInt (ms, 0 = no timeout)
+  ImmutableProperties = 0x0B,   // Track+Object scope, Bytes (nested KVPs)
+  DefaultPublisherPriority = 0x0E, // Track scope, VarInt (0-255)
   DefaultPublisherGroupOrder = 0x22, // Track scope, VarInt (1=Ascending, 2=Descending)
-  DynamicGroups = 0x30,              // Track scope, VarInt (0 or 1)
-  PriorGroupIdGap = 0x3C,            // Object scope, VarInt
-  PriorObjectIdGap = 0x3E,           // Object scope, VarInt
+  DynamicGroups = 0x30,         // Track scope, VarInt (0 or 1)
+  PriorGroupIdGap = 0x3C,       // Object scope, VarInt
+  PriorObjectIdGap = 0x3E,      // Object scope, VarInt
 }
 
 impl TryFrom<u64> for TrackPropertyType {
@@ -70,8 +71,9 @@ impl TryFrom<u64> for TrackPropertyType {
 
   fn try_from(value: u64) -> Result<Self, Self::Error> {
     match value {
-      0x02 => Ok(TrackPropertyType::DeliveryTimeout),
+      0x02 => Ok(TrackPropertyType::ObjectDeliveryTimeout),
       0x04 => Ok(TrackPropertyType::MaxCacheDuration),
+      0x06 => Ok(TrackPropertyType::SubgroupDeliveryTimeout),
       0x0B => Ok(TrackPropertyType::ImmutableProperties),
       0x0E => Ok(TrackPropertyType::DefaultPublisherPriority),
       0x22 => Ok(TrackPropertyType::DefaultPublisherGroupOrder),
@@ -99,8 +101,9 @@ mod tests {
   #[test]
   fn test_track_property_type_roundtrip() {
     let known = [
-      (0x02u64, TrackPropertyType::DeliveryTimeout),
+      (0x02u64, TrackPropertyType::ObjectDeliveryTimeout),
       (0x04, TrackPropertyType::MaxCacheDuration),
+      (0x06, TrackPropertyType::SubgroupDeliveryTimeout),
       (0x0B, TrackPropertyType::ImmutableProperties),
       (0x0E, TrackPropertyType::DefaultPublisherPriority),
       (0x22, TrackPropertyType::DefaultPublisherGroupOrder),

--- a/libs/moqtail-rs/src/model/property/track_property.rs
+++ b/libs/moqtail-rs/src/model/property/track_property.rs
@@ -27,7 +27,8 @@ use bytes::Bytes;
 /// properties).
 #[derive(Debug, Clone, PartialEq)]
 pub enum TrackProperty {
-  DeliveryTimeout { timeout_ms: u64 },
+  ObjectDeliveryTimeout { timeout_ms: u64 },
+  SubgroupDeliveryTimeout { timeout_ms: u64 },
   MaxCacheDuration { duration_ms: u64 },
   ImmutableProperties { properties: Vec<KeyValuePair> },
   DefaultPublisherPriority { priority: u8 },
@@ -40,7 +41,8 @@ impl TrackProperty {
   /// Returns the raw wire type value for this property.
   pub fn type_value(&self) -> u64 {
     match self {
-      Self::DeliveryTimeout { .. } => TrackPropertyType::DeliveryTimeout as u64,
+      Self::ObjectDeliveryTimeout { .. } => TrackPropertyType::ObjectDeliveryTimeout as u64,
+      Self::SubgroupDeliveryTimeout { .. } => TrackPropertyType::SubgroupDeliveryTimeout as u64,
       Self::MaxCacheDuration { .. } => TrackPropertyType::MaxCacheDuration as u64,
       Self::ImmutableProperties { .. } => TrackPropertyType::ImmutableProperties as u64,
       Self::DefaultPublisherPriority { .. } => TrackPropertyType::DefaultPublisherPriority as u64,
@@ -68,15 +70,14 @@ impl TrackProperty {
     };
 
     match ext_type {
-      TrackPropertyType::DeliveryTimeout => {
-        let value = kvp_varint_value(&kvp, "TrackProperty::deserialize(DeliveryTimeout)")?;
-        if value == 0 {
-          return Err(ParseError::ProtocolViolation {
-            context: "TrackProperty::deserialize(DeliveryTimeout)",
-            details: "DELIVERY_TIMEOUT must be greater than 0".to_string(),
-          });
-        }
-        Ok(Self::DeliveryTimeout { timeout_ms: value })
+      TrackPropertyType::ObjectDeliveryTimeout => {
+        // §8: a value of 0 means no timeout is set. It is valid, not a violation.
+        let value = kvp_varint_value(&kvp, "TrackProperty::deserialize(ObjectDeliveryTimeout)")?;
+        Ok(Self::ObjectDeliveryTimeout { timeout_ms: value })
+      }
+      TrackPropertyType::SubgroupDeliveryTimeout => {
+        let value = kvp_varint_value(&kvp, "TrackProperty::deserialize(SubgroupDeliveryTimeout)")?;
+        Ok(Self::SubgroupDeliveryTimeout { timeout_ms: value })
       }
       TrackPropertyType::MaxCacheDuration => {
         let value = kvp_varint_value(&kvp, "TrackProperty::deserialize(MaxCacheDuration)")?;
@@ -154,9 +155,13 @@ impl TryInto<KeyValuePair> for TrackProperty {
 
   fn try_into(self) -> Result<KeyValuePair, Self::Error> {
     match self {
-      Self::DeliveryTimeout { timeout_ms } => {
-        KeyValuePair::try_new_varint(TrackPropertyType::DeliveryTimeout as u64, timeout_ms)
+      Self::ObjectDeliveryTimeout { timeout_ms } => {
+        KeyValuePair::try_new_varint(TrackPropertyType::ObjectDeliveryTimeout as u64, timeout_ms)
       }
+      Self::SubgroupDeliveryTimeout { timeout_ms } => KeyValuePair::try_new_varint(
+        TrackPropertyType::SubgroupDeliveryTimeout as u64,
+        timeout_ms,
+      ),
       Self::MaxCacheDuration { duration_ms } => {
         KeyValuePair::try_new_varint(TrackPropertyType::MaxCacheDuration as u64, duration_ms)
       }
@@ -239,7 +244,7 @@ mod tests {
 
   #[test]
   fn test_roundtrip_delivery_timeout() {
-    let ext = TrackProperty::DeliveryTimeout { timeout_ms: 5000 };
+    let ext = TrackProperty::ObjectDeliveryTimeout { timeout_ms: 5000 };
     assert_eq!(roundtrip(ext.clone()), ext);
   }
 
@@ -293,12 +298,19 @@ mod tests {
   }
 
   #[test]
-  fn test_delivery_timeout_zero_is_error() {
+  fn test_delivery_timeout_zero_means_no_timeout() {
+    // §8: a value of 0 means no timeout is set. It is valid, not a violation.
     let kvp = KeyValuePair::try_new_varint(0x02, 0).unwrap();
-    assert!(matches!(
-      TrackProperty::deserialize(kvp).unwrap_err(),
-      ParseError::ProtocolViolation { .. }
-    ));
+    assert_eq!(
+      TrackProperty::deserialize(kvp).unwrap(),
+      TrackProperty::ObjectDeliveryTimeout { timeout_ms: 0 }
+    );
+
+    let kvp = KeyValuePair::try_new_varint(0x06, 0).unwrap();
+    assert_eq!(
+      TrackProperty::deserialize(kvp).unwrap(),
+      TrackProperty::SubgroupDeliveryTimeout { timeout_ms: 0 }
+    );
   }
 
   #[test]
@@ -342,7 +354,7 @@ mod tests {
   #[test]
   fn test_serialize_deserialize_mixed() {
     let exts = vec![
-      TrackProperty::DeliveryTimeout { timeout_ms: 1000 },
+      TrackProperty::ObjectDeliveryTimeout { timeout_ms: 1000 },
       TrackProperty::DefaultPublisherPriority { priority: 64 },
       TrackProperty::DynamicGroups { enabled: true },
       TrackProperty::Unknown {
@@ -375,7 +387,7 @@ mod tests {
       KeyValuePair::try_new_bytes(0x03, Bytes::from_static(b"data")).unwrap(),
     ];
     let exts = vec![
-      TrackProperty::DeliveryTimeout { timeout_ms: 100 },
+      TrackProperty::ObjectDeliveryTimeout { timeout_ms: 100 },
       TrackProperty::ImmutableProperties {
         properties: inner.clone(),
       },

--- a/libs/moqtail-rs/src/transport/control_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/control_stream_handler.rs
@@ -391,7 +391,7 @@ mod tests {
         }),
         MessageParameter::new_expires(100),
       ],
-      vec![TrackProperty::DeliveryTimeout { timeout_ms: 5000 }],
+      vec![TrackProperty::ObjectDeliveryTimeout { timeout_ms: 5000 }],
     );
     // Wire encoding canonicalizes parameter order ascending by type (delta-encoding requirement).
     subscribe_ok


### PR DESCRIPTION
split delivery timeouts, add rendezvous/fill, align parameter numbers

Bring the Message Parameter and Property registries in line with draft-18 §15.7 and §15.8 (A.1:7285 split DELIVERY_TIMEOUT; A.1:7287 FILL_TIMEOUT; A.2:7353 RENDEZVOUS_TIMEOUT; A.2:7377 DELIVERY_TIMEOUT of 0; A.2:7401 copy the min requirement from parameter to property).

Message Parameters: rename DeliveryTimeout to OBJECT_DELIVERY_TIMEOUT and add SUBGROUP_DELIVERY_TIMEOUT 0x06, RENDEZVOUS_TIMEOUT 0x04, FILL_TIMEOUT 0x0A, and TRACK_NAMESPACE_PREFIX 0x34 — the enum had 9 of 13. Properties: rename DeliveryTimeout to ObjectDeliveryTimeout and add SubgroupDeliveryTimeout 0x06.

Per-message validity, from §10.2.3-6: the two delivery timeouts in PUBLISH_OK/SUBSCRIBE/REQUEST_UPDATE, RENDEZVOUS_TIMEOUT in SUBSCRIBE only, FILL_TIMEOUT in FETCH only.

Two behaviours changed with the draft, both of which the old code had from draft-16:

- A value of 0 is now valid and means "no timeout" (§8), on both the parameter and property sides. Both previously rejected 0 with "DELIVERY_TIMEOUT must be greater than 0". Removing that on both sides is what "the property-side minimum matches the parameter-side minimum" means: neither has a minimum above zero.

- A parameter appearing in a message type it is not defined for now closes the session with PROTOCOL_VIOLATION (§10.2.1) instead of being silently ignored. deserialize_message_parameters returned the surviving params and dropped the rest; it now errors. This is the substance of changelog bullet 7260 ("Clarify definition of scope"), which the plan had filed as "editorial, no action" — corrected in the reverse map. FILL_TIMEOUT in a non-FETCH request is the acceptance test for it.

TRACK_NAMESPACE_PREFIX is added to the codepoint registry but has no typed MessageParameter variant yet: its consumer is REQUEST_UPDATE for SUBSCRIBE_TRACKS (RS-11), and its 0x34 (even, single-varint) codepoint sits awkwardly against its Track Namespace tuple value — worth resolving with the message that uses it, not here.

Retires the seven rs:228 markers across parameter_types.json and property_types.json.

Closes #228
