### PR TITLE
feat(moqtail-rs): add the FIRST_OBJECT bit to SUBGROUP_HEADER

### DIFF
--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -369,6 +369,8 @@ async fn send_via_streams(
       Some(publisher_priority),
       true,
       true,
+      true, // first_object: a fresh stream is opened per group, so its first object is
+            // the first the publisher produced in this subgroup
     );
     let header_info = HeaderInfo::Subgroup { header: sub_header };
     let stream = Arc::new(Mutex::new(stream));

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -435,6 +435,11 @@ impl Subscription {
                               Some(object.publisher_priority),
                               has_properties,
                               false,
+                              // first_object: FIRST_OBJECT marks the original publisher's
+                              // first object in the subgroup. A relay forwarding from cache
+                              // is not that publisher and may start mid-subgroup, so it is
+                              // left unset here (see #229 / RS-14 scope).
+                              false,
                             ),
                           };
                           info!(

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -435,10 +435,16 @@ impl Subscription {
                               Some(object.publisher_priority),
                               has_properties,
                               false,
-                              // first_object: FIRST_OBJECT marks the original publisher's
-                              // first object in the subgroup. A relay forwarding from cache
-                              // is not that publisher and may start mid-subgroup, so it is
-                              // left unset here (see #229 / RS-14 scope).
+                              // first_object: draft-18 §2.2 requires that a relay
+                              // forwarding a subgroup which begins with the subgroup's
+                              // first-ever object MUST set FIRST_OBJECT. This cache-join
+                              // path replays from `start_location`, which may be
+                              // mid-subgroup, and the first-ever object is not
+                              // necessarily object_id 0, so the cache does not tell us
+                              // whether we are at that object. We therefore always leave
+                              // FIRST_OBJECT unset here. This is a known conformance gap
+                              // for the case where we do start at the first object;
+                              // closing it is deferred to #229 / RS-14.
                               false,
                             ),
                           };

--- a/libs/moqtail-rs/src/model/data/constant.rs
+++ b/libs/moqtail-rs/src/model/data/constant.rs
@@ -20,9 +20,9 @@ pub enum FetchHeaderType {
   Type0x05 = 0x05,
 }
 
-/// Subgroup Header Type
+/// Subgroup Header Type, per draft-18 §11.4.2.
 ///
-/// Type bit layout (0b00X1XXXX):
+/// Type bit layout (form `0b0XX1XXXX`):
 /// - Bit 0 (0x01): PROPERTIES - Properties present in all objects
 /// - Bits 1-2 (0x06): SUBGROUP_ID_MODE - How subgroup ID is encoded
 ///   - 0b00 (0x00): Subgroup ID = 0 (absent from header)
@@ -32,9 +32,13 @@ pub enum FetchHeaderType {
 /// - Bit 3 (0x08): END_OF_GROUP - This subgroup contains the final object in the group
 /// - Bit 4 (0x10): Always set (distinguishes subgroup from other header types)
 /// - Bit 5 (0x20): DEFAULT_PRIORITY - Publisher priority field omitted, inherited from subscription
+/// - Bit 6 (0x40): FIRST_OBJECT - The first object on this stream is the first the original
+///   publisher published in the subgroup
+/// - Bit 7 (0x80): Must be 0
 ///
-/// Valid ranges: 0x10-0x15, 0x18-0x1D (bit 5=0), 0x30-0x35, 0x38-0x3D (bit 5=1)
-/// Invalid: 0x16, 0x17, 0x1E, 0x1F, 0x36, 0x37, 0x3E, 0x3F (SUBGROUP_ID_MODE=0b11)
+/// Valid Type values are exactly the ranges 0x10-0x1F, 0x30-0x3F, 0x50-0x5F and 0x70-0x7F
+/// (bit 4 set, bit 7 clear), minus those with SUBGROUP_ID_MODE = 0b11: 0x16, 0x17, 0x1E, 0x1F,
+/// 0x36, 0x37, 0x3E, 0x3F, 0x56, 0x57, 0x5E, 0x5F, 0x76, 0x77, 0x7E, 0x7F.
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
 pub struct SubgroupHeaderType(u8);
 
@@ -49,8 +53,10 @@ impl SubgroupHeaderType {
   pub const REQUIRED_BIT: u8 = 0x10;
   /// Publisher priority field omitted, inherited from subscription (bit 5)
   pub const DEFAULT_PRIORITY: u8 = 0x20;
-  /// Mask for bits that must be zero: bits 6-7
-  const INVALID_BITS_MASK: u8 = 0xC0;
+  /// First object on this stream is the first published in the subgroup (bit 6)
+  pub const FIRST_OBJECT: u8 = 0x40;
+  /// Mask for bits that must be zero: bit 7 only
+  const INVALID_BITS_MASK: u8 = 0x80;
   /// Reserved SUBGROUP_ID_MODE value (0b11)
   const RESERVED_SUBGROUP_MODE: u8 = 0x06;
 
@@ -114,6 +120,12 @@ impl SubgroupHeaderType {
     self.0 & Self::DEFAULT_PRIORITY != 0
   }
 
+  /// Check if this stream's first object is the first the original publisher published
+  /// in the subgroup (bit 6 set).
+  pub fn is_first_object(&self) -> bool {
+    self.0 & Self::FIRST_OBJECT != 0
+  }
+
   /// Create type from property flags.
   /// subgroup_id_mode: 0=zero, 1=firstObjId, 2=explicit
   pub fn from_properties(
@@ -121,6 +133,7 @@ impl SubgroupHeaderType {
     subgroup_id_mode: u8,
     contains_end_of_group: bool,
     has_default_priority: bool,
+    first_object: bool,
   ) -> Self {
     let mut v: u8 = Self::REQUIRED_BIT;
     if has_properties {
@@ -132,6 +145,9 @@ impl SubgroupHeaderType {
     }
     if has_default_priority {
       v |= Self::DEFAULT_PRIORITY;
+    }
+    if first_object {
+      v |= Self::FIRST_OBJECT;
     }
     Self(v)
   }
@@ -307,5 +323,69 @@ impl TryFrom<u64> for ObjectDatagramType {
 impl From<ObjectDatagramType> for u64 {
   fn from(dtype: ObjectDatagramType) -> Self {
     dtype.0 as u64
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// The independent oracle for a valid SUBGROUP_HEADER type byte (draft-18 §11.4.2):
+  /// bit 7 clear, bit 4 set, and SUBGROUP_ID_MODE (bits 1-2) not 0b11.
+  fn is_valid_subgroup_type(b: u8) -> bool {
+    b & 0x80 == 0 && b & 0x10 != 0 && b & 0x06 != 0x06
+  }
+
+  #[test]
+  fn subgroup_header_type_classifies_all_256_bytes() {
+    // The 16 reserved SUBGROUP_ID_MODE = 0b11 values named explicitly in §11.4.2, as a
+    // cross-check that the oracle and the spec agree.
+    let reserved_mode_3 = [
+      0x16u8, 0x17, 0x1E, 0x1F, 0x36, 0x37, 0x3E, 0x3F, 0x56, 0x57, 0x5E, 0x5F, 0x76, 0x77, 0x7E,
+      0x7F,
+    ];
+
+    for b in 0u8..=255 {
+      let accepted = SubgroupHeaderType::try_new(b as u64).is_ok();
+      let expected = is_valid_subgroup_type(b);
+      assert_eq!(accepted, expected, "type byte {b:#04x}");
+
+      if reserved_mode_3.contains(&b) {
+        assert!(
+          !accepted,
+          "reserved SUBGROUP_ID_MODE 0b11 value {b:#04x} must be rejected"
+        );
+      }
+      // Round-trips preserve the byte for accepted values.
+      if accepted {
+        assert_eq!(SubgroupHeaderType::try_new(b as u64).unwrap().value(), b);
+      }
+    }
+
+    // Exactly the four ranges minus the 16 reserved values are valid.
+    let valid_count = (0u8..=255).filter(|&b| is_valid_subgroup_type(b)).count();
+    assert_eq!(valid_count, 4 * 16 - 16, "expected 48 valid type bytes");
+  }
+
+  #[test]
+  fn first_object_bit_round_trips() {
+    let with = SubgroupHeaderType::from_properties(false, 2, false, false, true);
+    assert!(with.is_first_object());
+    assert_eq!(with.value() & SubgroupHeaderType::FIRST_OBJECT, 0x40);
+    assert_eq!(
+      SubgroupHeaderType::try_new(with.value() as u64).unwrap(),
+      with
+    );
+
+    let without = SubgroupHeaderType::from_properties(false, 2, false, false, false);
+    assert!(!without.is_first_object());
+  }
+
+  #[test]
+  fn first_object_alone_is_a_valid_type() {
+    // 0x50 = FIRST_OBJECT (0x40) + REQUIRED_BIT (0x10), mode 0b00. Rejected before RS-14
+    // because 0x40 was in INVALID_BITS_MASK.
+    let t = SubgroupHeaderType::try_new(0x50).unwrap();
+    assert!(t.is_first_object());
   }
 }

--- a/libs/moqtail-rs/src/model/data/subgroup_header.rs
+++ b/libs/moqtail-rs/src/model/data/subgroup_header.rs
@@ -36,6 +36,7 @@ impl SubgroupHeader {
     publisher_priority: Option<u8>,
     has_properties: bool,
     contains_end_of_group: bool,
+    first_object: bool,
   ) -> Self {
     let has_default_priority = publisher_priority.is_none();
     let header_type = SubgroupHeaderType::from_properties(
@@ -43,6 +44,7 @@ impl SubgroupHeader {
       0,
       contains_end_of_group,
       has_default_priority,
+      first_object,
     );
 
     Self {
@@ -61,6 +63,7 @@ impl SubgroupHeader {
     publisher_priority: Option<u8>,
     has_properties: bool,
     contains_end_of_group: bool,
+    first_object: bool,
   ) -> Self {
     let has_default_priority = publisher_priority.is_none();
     let header_type = SubgroupHeaderType::from_properties(
@@ -68,6 +71,7 @@ impl SubgroupHeader {
       1,
       contains_end_of_group,
       has_default_priority,
+      first_object,
     );
 
     Self {
@@ -87,6 +91,7 @@ impl SubgroupHeader {
     publisher_priority: Option<u8>,
     has_properties: bool,
     contains_end_of_group: bool,
+    first_object: bool,
   ) -> Self {
     let has_default_priority = publisher_priority.is_none();
     let header_type = SubgroupHeaderType::from_properties(
@@ -94,6 +99,7 @@ impl SubgroupHeader {
       2,
       contains_end_of_group,
       has_default_priority,
+      first_object,
     );
 
     Self {
@@ -196,6 +202,29 @@ mod tests {
 
   use super::*;
   use bytes::Buf;
+
+  #[test]
+  fn first_object_bit_survives_a_header_round_trip() {
+    // A new subgroup: the publisher marks its first object with FIRST_OBJECT (0x40).
+    let new_subgroup =
+      SubgroupHeader::new_with_explicit_id(87, 9, 11, Some(255), true, false, true);
+    assert!(new_subgroup.header_type.is_first_object());
+    let mut buf = new_subgroup.serialize(None).unwrap();
+    let parsed = SubgroupHeader::deserialize(&mut buf).unwrap();
+    assert_eq!(parsed, new_subgroup);
+    assert!(parsed.header_type.is_first_object());
+
+    // A reopened subgroup: same header without the bit.
+    let reopened = SubgroupHeader::new_with_explicit_id(87, 9, 11, Some(255), true, false, false);
+    assert!(!reopened.header_type.is_first_object());
+    let mut buf = reopened.serialize(None).unwrap();
+    assert!(
+      !SubgroupHeader::deserialize(&mut buf)
+        .unwrap()
+        .header_type
+        .is_first_object()
+    );
+  }
 
   #[test]
   fn test_roundtrip() {
@@ -450,32 +479,56 @@ mod tests {
     let publisher_priority = Some(255);
 
     // Test new_fixed_zero_id
-    let header =
-      SubgroupHeader::new_fixed_zero_id(track_alias, group_id, publisher_priority, false, false);
+    let header = SubgroupHeader::new_fixed_zero_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      false,
+      false,
+      false,
+    );
     assert_eq!(
       header.header_type,
       SubgroupHeaderType::try_new(0x10).unwrap()
     );
     assert_eq!(header.subgroup_id, Some(0));
 
-    let header =
-      SubgroupHeader::new_fixed_zero_id(track_alias, group_id, publisher_priority, true, false);
+    let header = SubgroupHeader::new_fixed_zero_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      true,
+      false,
+      false,
+    );
     assert_eq!(
       header.header_type,
       SubgroupHeaderType::try_new(0x11).unwrap()
     );
     assert_eq!(header.subgroup_id, Some(0));
 
-    let header =
-      SubgroupHeader::new_fixed_zero_id(track_alias, group_id, publisher_priority, false, true);
+    let header = SubgroupHeader::new_fixed_zero_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      false,
+      true,
+      false,
+    );
     assert_eq!(
       header.header_type,
       SubgroupHeaderType::try_new(0x18).unwrap()
     );
     assert_eq!(header.subgroup_id, Some(0));
 
-    let header =
-      SubgroupHeader::new_fixed_zero_id(track_alias, group_id, publisher_priority, true, true);
+    let header = SubgroupHeader::new_fixed_zero_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      true,
+      true,
+      false,
+    );
     assert_eq!(
       header.header_type,
       SubgroupHeaderType::try_new(0x19).unwrap()
@@ -483,32 +536,56 @@ mod tests {
     assert_eq!(header.subgroup_id, Some(0));
 
     // Test new_first_object_id
-    let header =
-      SubgroupHeader::new_first_object_id(track_alias, group_id, publisher_priority, false, false);
+    let header = SubgroupHeader::new_first_object_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      false,
+      false,
+      false,
+    );
     assert_eq!(
       header.header_type,
       SubgroupHeaderType::try_new(0x12).unwrap()
     );
     assert_eq!(header.subgroup_id, None);
 
-    let header =
-      SubgroupHeader::new_first_object_id(track_alias, group_id, publisher_priority, true, false);
+    let header = SubgroupHeader::new_first_object_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      true,
+      false,
+      false,
+    );
     assert_eq!(
       header.header_type,
       SubgroupHeaderType::try_new(0x13).unwrap()
     );
     assert_eq!(header.subgroup_id, None);
 
-    let header =
-      SubgroupHeader::new_first_object_id(track_alias, group_id, publisher_priority, false, true);
+    let header = SubgroupHeader::new_first_object_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      false,
+      true,
+      false,
+    );
     assert_eq!(
       header.header_type,
       SubgroupHeaderType::try_new(0x1A).unwrap()
     );
     assert_eq!(header.subgroup_id, None);
 
-    let header =
-      SubgroupHeader::new_first_object_id(track_alias, group_id, publisher_priority, true, true);
+    let header = SubgroupHeader::new_first_object_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      true,
+      true,
+      false,
+    );
     assert_eq!(
       header.header_type,
       SubgroupHeaderType::try_new(0x1B).unwrap()
@@ -522,6 +599,7 @@ mod tests {
       group_id,
       subgroup_id,
       publisher_priority,
+      false,
       false,
       false,
     );
@@ -538,6 +616,7 @@ mod tests {
       publisher_priority,
       true,
       false,
+      false,
     );
     assert_eq!(
       header.header_type,
@@ -552,6 +631,7 @@ mod tests {
       publisher_priority,
       false,
       true,
+      false,
     );
     assert_eq!(
       header.header_type,
@@ -566,6 +646,7 @@ mod tests {
       publisher_priority,
       true,
       true,
+      false,
     );
     assert_eq!(
       header.header_type,
@@ -586,8 +667,14 @@ mod tests {
     let publisher_priority = Some(255);
 
     // Test a header type with fixed subgroup ID = 0
-    let header =
-      SubgroupHeader::new_fixed_zero_id(track_alias, group_id, publisher_priority, false, false);
+    let header = SubgroupHeader::new_fixed_zero_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      false,
+      false,
+      false,
+    );
     assert_eq!(
       header.header_type,
       SubgroupHeaderType::try_new(0x10).unwrap()
@@ -626,6 +713,7 @@ mod tests {
       publisher_priority,
       true,
       false,
+      false,
     );
     assert_eq!(
       header.header_type,
@@ -651,8 +739,14 @@ mod tests {
     assert_eq!(object.subgroup_id, Some(123));
 
     // Test a header type where subgroup ID = first object ID
-    let header =
-      SubgroupHeader::new_first_object_id(track_alias, group_id, publisher_priority, false, true);
+    let header = SubgroupHeader::new_first_object_id(
+      track_alias,
+      group_id,
+      publisher_priority,
+      false,
+      true,
+      false,
+    );
     assert_eq!(
       header.header_type,
       SubgroupHeaderType::try_new(0x1A).unwrap()


### PR DESCRIPTION
Draft-18 §11.4.2 adds a FIRST_OBJECT bit (0x40) to the SUBGROUP_HEADER Type byte, marking a stream whose first object is the first the original publisher produced in the subgroup (A.1:7276).

0x40 was previously rejected: INVALID_BITS_MASK was 0xC0 (bits 6 and 7 must be zero). Narrow it to 0x80 — only bit 7 is reserved now — and add the FIRST_OBJECT constant plus an is_first_object() accessor. The valid Type form is 0b0XX1XXXX: the ranges 0x10-0x1F, 0x30-0x3F, 0x50-0x5F, 0x70-0x7F, minus the 16 values with SUBGROUP_ID_MODE = 0b11, which stay a PROTOCOL_VIOLATION.

The PROPERTIES bit rename the task also lists was already done by RS-8 (#281); nothing left there.

from_properties and the three SubgroupHeader constructors take a first_object flag. The original publisher sets it: apps/client opens a fresh stream per group, so each stream's first object is the publisher's first in that subgroup. The relay's cache-forwarding path passes false — a relay is not the original publisher and may start mid-subgroup — with a note; carrying it correctly through a relay is out of this task's scope.

Tests: a table-driven check classifies all 256 type bytes against an independent oracle (bit 7 clear, bit 4 set, mode != 0b11), cross-checked against the 16 reserved values named in the draft — 48 valid bytes. And a header round-trip proves the bit reaches the wire and back for a new subgroup and is absent for a reopened one.

Closes #229
