### PR TITLE
feat(relay): enforce Mandatory Track Properties (0x4000-0x7FFF)

### DIFF
--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -29,6 +29,7 @@ use moqtail::model::error::TerminationCode;
 use moqtail::model::parameter::constant::MessageParameterType;
 use moqtail::model::parameter::message_parameter::apply_message_parameter_update;
 use moqtail::model::parameter::message_parameter::{MessageParameter, MessageParameterVecExt};
+use moqtail::model::property::track_property::has_unsupported_mandatory;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
@@ -57,6 +58,22 @@ pub async fn handle(
           );
           return Err(TerminationCode::TooManyRequests);
         }
+      }
+
+      // §2.5.1: reject a PUBLISH with an unsupported mandatory track property.
+      if has_unsupported_mandatory(&m.track_properties) {
+        let reason_phrase =
+          ReasonPhrase::try_new("Unsupported mandatory track property".to_string())
+            .map_err(|_| TerminationCode::InternalError)?;
+        let publish_error = Box::new(RequestError::new(
+          request_id,
+          RequestErrorCode::UnsupportedExtension,
+          0,
+          reason_phrase,
+        ));
+        return control_stream_handler
+          .send(&ControlMessage::RequestError(publish_error))
+          .await;
       }
 
       // Validate track namespace authorization

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -26,6 +26,7 @@ use moqtail::model::error::TerminationCode;
 use moqtail::model::parameter::message_parameter::{
   MessageParameter, MessageParameterVecExt, apply_message_parameter_update,
 };
+use moqtail::model::property::track_property::has_unsupported_mandatory;
 use moqtail::model::{
   common::reason_phrase::ReasonPhrase, control::control_message::ControlMessage,
 };
@@ -305,6 +306,24 @@ async fn handle_subscribe_ok_message(
       }
     }
   };
+
+  // §2.5.1: SUBSCRIBE_OK with an unsupported mandatory track property. Reuse the
+  // RequestError fan-out to cancel and notify downstream subscribers.
+  if has_unsupported_mandatory(&msg.track_properties) {
+    warn!(
+      "SubscribeOk for request {} carries an unsupported mandatory track property; rejecting",
+      request_id
+    );
+    let reason = ReasonPhrase::try_new("Unsupported mandatory track property".to_string())
+      .map_err(|_| TerminationCode::InternalError)?;
+    let err = RequestError::new(
+      request_id,
+      RequestErrorCode::UnsupportedExtension,
+      0,
+      reason,
+    );
+    return handle_subscribe_error_message(_client, _control_stream_handler, err, context).await;
+  }
 
   let full_track_name = sub_request.original_subscribe_request.get_full_track_name();
 

--- a/dev/conformance/draft18/request_error_codes.json
+++ b/dev/conformance/draft18/request_error_codes.json
@@ -44,7 +44,7 @@
       "name": "UNSUPPORTED_EXTENSION",
       "value": "0x33",
       "spec": "Section 10.6",
-      "pending": { "rs": 238, "ts": 260 }
+      "pending": { "ts": 260 }
     },
     {
       "name": "REDIRECT",

--- a/libs/moqtail-rs/src/model/control/constant.rs
+++ b/libs/moqtail-rs/src/model/control/constant.rs
@@ -217,6 +217,7 @@ pub enum RequestErrorCode {
   Uninterested = 0x20,
   PrefixOverlap = 0x30,
   InvalidJoiningRequestId = 0x32,
+  UnsupportedExtension = 0x33,
 }
 
 impl TryFrom<u64> for RequestErrorCode {
@@ -237,6 +238,7 @@ impl TryFrom<u64> for RequestErrorCode {
       0x20 => Ok(RequestErrorCode::Uninterested),
       0x30 => Ok(RequestErrorCode::PrefixOverlap),
       0x32 => Ok(RequestErrorCode::InvalidJoiningRequestId),
+      0x33 => Ok(RequestErrorCode::UnsupportedExtension),
       _ => Err(ParseError::InvalidType {
         context: "RequestErrorCode::try_from(u64)",
         details: format!("Invalid type, got {value}"),

--- a/libs/moqtail-rs/src/model/property/track_property.rs
+++ b/libs/moqtail-rs/src/model/property/track_property.rs
@@ -27,14 +27,46 @@ use bytes::Bytes;
 /// properties).
 #[derive(Debug, Clone, PartialEq)]
 pub enum TrackProperty {
-  ObjectDeliveryTimeout { timeout_ms: u64 },
-  SubgroupDeliveryTimeout { timeout_ms: u64 },
-  MaxCacheDuration { duration_ms: u64 },
-  ImmutableProperties { properties: Vec<KeyValuePair> },
-  DefaultPublisherPriority { priority: u8 },
-  DefaultPublisherGroupOrder { order: GroupOrder },
-  DynamicGroups { enabled: bool },
-  Unknown { kvp: KeyValuePair },
+  ObjectDeliveryTimeout {
+    timeout_ms: u64,
+  },
+  SubgroupDeliveryTimeout {
+    timeout_ms: u64,
+  },
+  MaxCacheDuration {
+    duration_ms: u64,
+  },
+  ImmutableProperties {
+    properties: Vec<KeyValuePair>,
+  },
+  DefaultPublisherPriority {
+    priority: u8,
+  },
+  DefaultPublisherGroupOrder {
+    order: GroupOrder,
+  },
+  DynamicGroups {
+    enabled: bool,
+  },
+  Unknown {
+    kvp: KeyValuePair,
+  },
+  /// Unrecognized property in the mandatory range (§2.5.1). Preserved through
+  /// parsing so the handler can reject the request instead of the parser
+  /// killing the session.
+  UnknownMandatory {
+    kvp: KeyValuePair,
+  },
+}
+
+/// §2.5.1 Mandatory Track Properties range.
+pub const MANDATORY_TRACK_PROPERTY_RANGE: std::ops::RangeInclusive<u64> = 0x4000..=0x7FFF;
+
+/// True if any property is an unrecognized Mandatory Track Property (§2.5.1).
+pub fn has_unsupported_mandatory(properties: &[TrackProperty]) -> bool {
+  properties
+    .iter()
+    .any(|p| matches!(p, TrackProperty::UnknownMandatory { .. }))
 }
 
 impl TrackProperty {
@@ -50,7 +82,7 @@ impl TrackProperty {
         TrackPropertyType::DefaultPublisherGroupOrder as u64
       }
       Self::DynamicGroups { .. } => TrackPropertyType::DynamicGroups as u64,
-      Self::Unknown { kvp } => kvp.get_type(),
+      Self::Unknown { kvp } | Self::UnknownMandatory { kvp } => kvp.get_type(),
     }
   }
 
@@ -66,7 +98,16 @@ impl TrackProperty {
     let type_value = kvp.get_type();
     let ext_type = match TrackPropertyType::try_from(type_value) {
       Ok(t) => t,
-      Err(_) => return Ok(Self::Unknown { kvp }),
+      Err(_) => {
+        // §2.5.1: keep mandatory-range unknowns as UnknownMandatory (handler
+        // rejects them); forward ordinary unknowns. Check the full u64 — a u16
+        // cast would alias high types into the range (e.g. 0x14000 -> 0x4000).
+        if MANDATORY_TRACK_PROPERTY_RANGE.contains(&type_value) {
+          return Ok(Self::UnknownMandatory { kvp });
+        } else {
+          return Ok(Self::Unknown { kvp });
+        }
+      }
     };
 
     match ext_type {
@@ -181,7 +222,7 @@ impl TryInto<KeyValuePair> for TrackProperty {
         TrackPropertyType::DynamicGroups as u64,
         if enabled { 1 } else { 0 },
       ),
-      Self::Unknown { kvp } => Ok(kvp),
+      Self::Unknown { kvp } | Self::UnknownMandatory { kvp } => Ok(kvp),
     }
   }
 }
@@ -329,6 +370,80 @@ mod tests {
       TrackProperty::deserialize(kvp).unwrap_err(),
       ParseError::ProtocolViolation { .. }
     ));
+  }
+
+  #[test]
+  fn test_mandatory_range_unknown_is_preserved() {
+    // §2.5.1: unknown types in 0x4000-0x7FFF are preserved as UnknownMandatory
+    // (the handling layer rejects the request), including the range boundaries.
+    // Even types carry a VarInt, odd types carry Bytes.
+    let varint_types = [0x4000u64, 0x5000, 0x7FFE];
+    for ty in varint_types {
+      let kvp = KeyValuePair::try_new_varint(ty, 1).unwrap();
+      assert_eq!(
+        TrackProperty::deserialize(kvp.clone()).unwrap(),
+        TrackProperty::UnknownMandatory { kvp: kvp.clone() },
+        "type {ty:#x} should be UnknownMandatory"
+      );
+      // Byte-identical on round-trip so a REQUEST_ERROR path can still inspect it.
+      assert_eq!(
+        roundtrip(TrackProperty::UnknownMandatory { kvp: kvp.clone() }).type_value(),
+        ty
+      );
+    }
+    let bytes_types = [0x4001u64, 0x7FFF];
+    for ty in bytes_types {
+      let kvp = KeyValuePair::try_new_bytes(ty, Bytes::from_static(b"x")).unwrap();
+      assert_eq!(
+        TrackProperty::deserialize(kvp.clone()).unwrap(),
+        TrackProperty::UnknownMandatory { kvp },
+        "type {ty:#x} should be UnknownMandatory"
+      );
+    }
+  }
+
+  #[test]
+  fn test_has_unsupported_mandatory_helper() {
+    let ordinary = vec![
+      TrackProperty::ObjectDeliveryTimeout { timeout_ms: 1 },
+      TrackProperty::Unknown {
+        kvp: KeyValuePair::try_new_varint(0x8000, 1).unwrap(),
+      },
+    ];
+    assert!(!has_unsupported_mandatory(&ordinary));
+
+    let mut with_mandatory = ordinary.clone();
+    with_mandatory.push(TrackProperty::UnknownMandatory {
+      kvp: KeyValuePair::try_new_varint(0x4000, 1).unwrap(),
+    });
+    assert!(has_unsupported_mandatory(&with_mandatory));
+  }
+
+  #[test]
+  fn test_outside_mandatory_range_forwarded_verbatim() {
+    // Just below (0x3FFF), just above (0x8000), and a low value are all unknown
+    // ordinary properties: preserved as Unknown and byte-identical on round-trip.
+    let below = KeyValuePair::try_new_bytes(0x3FFF, Bytes::from_static(b"lo")).unwrap();
+    let above = KeyValuePair::try_new_varint(0x8000, 42).unwrap();
+    for kvp in [below, above] {
+      let ext = TrackProperty::Unknown { kvp: kvp.clone() };
+      assert_eq!(roundtrip(ext.clone()), ext);
+      assert_eq!(
+        TrackProperty::deserialize(kvp.clone()).unwrap(),
+        TrackProperty::Unknown { kvp }
+      );
+    }
+  }
+
+  #[test]
+  fn test_mandatory_range_check_uses_full_u64() {
+    // Regression: 0x14000 truncates to 0x4000 in u16, but as a full u64 it is far
+    // above the mandatory range and must be forwarded as Unknown, not flagged.
+    let kvp = KeyValuePair::try_new_varint(0x14000, 7).unwrap();
+    assert_eq!(
+      TrackProperty::deserialize(kvp.clone()).unwrap(),
+      TrackProperty::Unknown { kvp }
+    );
   }
 
   #[test]


### PR DESCRIPTION
Per draft-18 §2.5.1, an unrecognized property in the Mandatory Track Properties range must not be processed or forwarded. Rather than failing at parse (which would tear down the session), preserve it as a new TrackProperty::UnknownMandatory variant and reject at the handler layer:

- PUBLISH: respond REQUEST_ERROR UNSUPPORTED_EXTENSION.
- SUBSCRIBE_OK: cancel and send REQUEST_ERROR UNSUPPORTED_EXTENSION to downstream subscribers via the existing RequestError fan-out.

Add RequestErrorCode::UnsupportedExtension (0x33) and a has_unsupported_mandatory helper. Range-check the full u64 so high types whose low bits alias into the range (e.g. 0x14000) are not misflagged. Clear the rs pending marker for UNSUPPORTED_EXTENSION in the conformance fixture.

Closes #231 (RL-1).
