### PR TITLE
feat: use a pair of uni streams for the control plane

### DIFF
--- a/apps/client/src/connection.rs
+++ b/apps/client/src/connection.rs
@@ -14,7 +14,7 @@
 
 use anyhow::Result;
 use moqtail::model::control::constant::SUPPORTED_VERSIONS;
-use moqtail::model::control::control_message::ControlMessage;
+use moqtail::model::control::control_message::ControlMessageTrait;
 use moqtail::model::error::TerminationCode;
 use moqtail::model::{
   control::setup::{Setup, SetupSender},
@@ -63,22 +63,30 @@ impl MoqConnection {
     info!("Connected! Connection ID: {}", connection.stable_id());
     let connection = Arc::new(connection);
 
-    // Open bidirectional stream for control messages
-    info!("Opening control stream...");
-    let (send_stream, recv_stream) = connection.open_bi().await?;
+    // The control plane is a pair of unidirectional streams. Open our send half
+    // and write CLIENT_SETUP first so it goes out without waiting on the
+    // server's stream, then accept the server's half.
+    info!("Opening control stream and sending SETUP...");
+    let mut send_stream = connection.open_uni().await?;
+    let client_setup = Setup::new(setup_options);
+    let setup_bytes = client_setup
+      .serialize()
+      .map_err(|e| anyhow::anyhow!("Failed to serialize CLIENT_SETUP: {e:?}"))?;
+    send_stream
+      .write_all(&setup_bytes)
+      .await
+      .map_err(|e| anyhow::anyhow!("Failed to send CLIENT_SETUP: {e:?}"))?;
+
+    info!("Waiting for server control stream...");
+    let recv_stream = connection.accept_uni().await?;
     let mut control_stream = ControlStreamHandler::new(send_stream, recv_stream);
 
-    // Send SETUP
-    info!("Sending SETUP...");
-    let client_setup = Setup::new(setup_options);
-    control_stream.send_impl(&client_setup).await?;
-
-    // Receive the peer's SETUP
-    // If the server does not support the requested version, the connection will
-    // be terminated with VersionNegotiationFailed rather than receiving a SETUP.
+    // Receive the server's SETUP, which must be the first message. If the server
+    // does not support the requested version, the connection is terminated with
+    // VersionNegotiationFailed rather than a SETUP arriving.
     info!("Waiting for SETUP...");
-    match control_stream.next_message().await {
-      Ok(ControlMessage::Setup(m)) => {
+    match control_stream.read_setup().await {
+      Ok(m) => {
         // AUTHORITY and PATH are client-only; a server sending either closes the
         // session (§10.3.1.1, §10.3.1.2).
         if let Err(code) = m.validate_incoming(SetupSender::Server, connection.kind()) {
@@ -87,15 +95,14 @@ impl MoqConnection {
         }
         info!("SETUP received: {:?}", m);
       }
-      Ok(m) => {
-        error!("Unexpected message: {:?}", m);
-        anyhow::bail!("Expected SETUP, got {:?}", m);
-      }
       Err(TerminationCode::VersionNegotiationFailed) => {
         anyhow::bail!(
           "Version negotiation failed: server does not support versions: {}",
           SUPPORTED_VERSIONS
         );
+      }
+      Err(TerminationCode::ProtocolViolation) => {
+        anyhow::bail!("Server control stream did not begin with SETUP");
       }
       Err(e) => {
         error!("Failed to receive SETUP: {:?}", e);

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -156,8 +156,23 @@ impl Session {
   }
 
   async fn accept_control_stream(context: Arc<SessionContext>) -> Result<()> {
-    match context.connection.accept_bi().await {
-      Ok((send_stream, recv_stream)) => {
+    // The control plane is a pair of unidirectional streams. Accept the peer's
+    // control stream (recv half) and open our own (send half), each beginning
+    // with SETUP.
+    let recv_stream = match context.connection.accept_uni().await {
+      Ok(recv_stream) => recv_stream,
+      Err(e) => {
+        error!("Failed to accept control stream: {:?}", e);
+        Self::close_session(
+          context.clone(),
+          TerminationCode::InternalError,
+          "Error in control stream handler",
+        );
+        return Err(e.into());
+      }
+    };
+    match context.connection.open_uni().await {
+      Ok(send_stream) => {
         let session_context = context.clone();
         let connection_id = session_context.connection_id;
         let transport = session_context.transport_kind;
@@ -192,7 +207,7 @@ impl Session {
         Ok(())
       }
       Err(e) => {
-        error!("Failed to accept stream: {:?}", e);
+        error!("Failed to open control send stream: {:?}", e);
         Self::close_session(
           context.clone(),
           TerminationCode::InternalError,
@@ -818,18 +833,15 @@ impl Session {
     control_stream_handler: &mut ControlStreamHandler,
   ) -> Result<Arc<MOQTClient>, TerminationCode> {
     debug!("Negotiating with client...");
-    let client_setup = match control_stream_handler.next_message().await {
-      Ok(ControlMessage::Setup(m)) => *m,
-      Ok(_) => {
-        error!("Unexpected message received");
-        return Err(TerminationCode::ProtocolViolation);
-      }
+    // The client's control stream MUST begin with SETUP.
+    let client_setup = match control_stream_handler.read_setup().await {
+      Ok(m) => m,
       Err(TerminationCode::NoError) => {
         info!("Client disconnected during negotiation");
         return Err(TerminationCode::NoError);
       }
       Err(e) => {
-        error!("Failed to deserialize message: {:?}", e);
+        error!("Client control stream did not begin with SETUP: {:?}", e);
         return Err(e);
       }
     };

--- a/libs/moqtail-rs/src/transport/control_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/control_stream_handler.rs
@@ -17,6 +17,7 @@ use tokio::time::{Duration, Instant, sleep_until};
 use tracing::{error, info, warn};
 
 use crate::model::control::control_message::{ControlMessage, ControlMessageTrait};
+use crate::model::control::setup::Setup;
 use crate::model::error::{ParseError, TerminationCode};
 use crate::transport::connection::{TransportReadError, TransportRecvStream, TransportSendStream};
 
@@ -67,6 +68,21 @@ impl ControlStreamHandler {
       return Err(TerminationCode::InternalError);
     }
     Ok(())
+  }
+
+  /// Reads the first message on a control stream, which must be SETUP. Any other
+  /// first message closes the session with PROTOCOL_VIOLATION.
+  pub async fn read_setup(&mut self) -> Result<Setup, TerminationCode> {
+    match self.next_message().await? {
+      ControlMessage::Setup(setup) => Ok(*setup),
+      other => {
+        warn!(
+          "Control stream did not begin with SETUP, got {:?}",
+          other.get_type()
+        );
+        Err(TerminationCode::ProtocolViolation)
+      }
+    }
   }
 
   pub async fn next_message(&mut self) -> Result<ControlMessage, TerminationCode> {
@@ -443,6 +459,58 @@ mod tests {
     assert_eq!(buf, [1, 2, 3, 4]);
 
     Ok(())
+  }
+
+  /// The control plane is a pair of uni streams, each beginning with SETUP.
+  /// Drive the full client<->server handshake and assert both sides read SETUP
+  /// as the first message.
+  #[tokio::test]
+  async fn test_setup_handshake_over_two_uni_streams() -> Result<(), Box<dyn Error>> {
+    let setup = TestSetup::new().await?;
+
+    // Client opens its control send stream and writes CLIENT_SETUP first.
+    let mut client_send = setup.client.open_uni().await?.await?;
+    let client_setup = create_test_client_setup();
+    client_send.write_all(&client_setup.serialize()?).await?;
+
+    // Server accepts the client's control stream and opens its own, SETUP first.
+    let server_recv = setup.server.accept_uni().await?;
+    let mut server_send = setup.server.open_uni().await?.await?;
+    let server_setup = create_test_server_setup();
+    server_send.write_all(&server_setup.serialize()?).await?;
+
+    let client_recv = setup.client.accept_uni().await?;
+
+    let mut server_plane = ControlStreamHandler::new(
+      TransportSendStream::WebTransport(server_send),
+      TransportRecvStream::WebTransport(server_recv),
+    );
+    let mut client_plane = ControlStreamHandler::new(
+      TransportSendStream::WebTransport(client_send),
+      TransportRecvStream::WebTransport(client_recv),
+    );
+
+    // Each direction's first message is SETUP.
+    assert_eq!(server_plane.read_setup().await.unwrap(), client_setup);
+    assert_eq!(client_plane.read_setup().await.unwrap(), server_setup);
+
+    Ok(())
+  }
+
+  /// A control stream whose first message is not SETUP is a PROTOCOL_VIOLATION.
+  #[tokio::test]
+  async fn test_first_message_not_setup_is_protocol_violation() -> Result<(), Box<dyn Error>> {
+    let setup = TestSetup::new().await?;
+    let (mut plane, mut server_send) = setup.create_control_plane().await?;
+
+    // Send a non-SETUP message as the first message on the control stream.
+    let announce = ControlMessage::PublishNamespace(Box::new(create_test_publish_namespace()));
+    server_send.write_all(&announce.serialize()?).await?;
+
+    match plane.read_setup().await {
+      Err(TerminationCode::ProtocolViolation) => Ok(()),
+      other => panic!("Expected ProtocolViolation, got {other:?}"),
+    }
   }
 
   #[tokio::test]


### PR DESCRIPTION
Per draft-18, the control plane is two unidirectional streams rather than one bidirectional stream, each beginning with SETUP. This lets either peer send as soon as it is able.

- Client (connection.rs): open_uni and write CLIENT_SETUP first, then accept_uni for the server's control stream and read SERVER_SETUP.
- Relay (session.rs): accept_uni for the peer's control stream and open_uni for our own; negotiate reads CLIENT_SETUP and replies with SERVER_SETUP.
- Add ControlStreamHandler::read_setup, which requires the first message to be SETUP and returns PROTOCOL_VIOLATION otherwise; used by both sides.

Tests: a full handshake over two uni streams asserting SETUP is first in each direction, and a non-SETUP first message yielding PROTOCOL_VIOLATION. Verified live: Rust client <-> Rust relay handshake and publish over raw QUIC.

Closes #232 (RS-4).
