### PR TITLE
feat(moqtail-rs): add GREASE support and reserve Property ranges

### DIFF
--- a/libs/moqtail-rs/src/conformance.rs
+++ b/libs/moqtail-rs/src/conformance.rs
@@ -103,6 +103,35 @@ pub struct PropertyTypes {
   #[serde(flatten)]
   pub registry: Registry,
   pub provisional: Registry,
+  pub ranges: PropertyRanges,
+}
+
+/// The registration-policy ranges for the Property Type space.
+#[derive(Debug, Deserialize)]
+pub struct PropertyRanges {
+  pub entries: Vec<RangeEntry>,
+}
+
+/// One registration-policy range. Bounds are 0x-prefixed hex strings on the wire
+/// (like every codepoint in these fixtures); use the accessors to get numbers.
+/// `to` is absent for the open-ended top range.
+#[derive(Debug, Deserialize)]
+pub struct RangeEntry {
+  pub from: String,
+  pub to: Option<String>,
+  pub policy: String,
+}
+
+impl RangeEntry {
+  /// Inclusive lower bound as a number.
+  pub fn from_codepoint(&self) -> u64 {
+    parse_hex(&self.from)
+  }
+
+  /// Inclusive upper bound as a number, or `None` for an open-ended range.
+  pub fn to_codepoint(&self) -> Option<u64> {
+    self.to.as_deref().map(parse_hex)
+  }
 }
 
 pub fn message_types() -> Registry {
@@ -397,6 +426,42 @@ mod enum_conformance {
         .ok()
         .map(|p| format!("{p:?}"))
     });
+  }
+
+  /// This crate's Property-range constants must match the fixture's ranges,
+  /// in order, including the open-ended First Come First Served range.
+  #[test]
+  fn property_ranges_match_fixture() {
+    use crate::model::property::constant::property_ranges as r;
+
+    let expected: Vec<(u64, Option<u64>)> = vec![
+      (
+        *r::STANDARDS_ACTION.start(),
+        Some(*r::STANDARDS_ACTION.end()),
+      ),
+      (
+        *r::APP_SPECIFIC_1BYTE.start(),
+        Some(*r::APP_SPECIFIC_1BYTE.end()),
+      ),
+      (*r::SPEC_REQUIRED.start(), Some(*r::SPEC_REQUIRED.end())),
+      (
+        *r::APP_SPECIFIC_2BYTE.start(),
+        Some(*r::APP_SPECIFIC_2BYTE.end()),
+      ),
+      (*r::MANDATORY_TRACK.start(), Some(*r::MANDATORY_TRACK.end())),
+      (r::FCFS_START, None),
+    ];
+
+    let fixture = property_types().ranges.entries;
+    assert_eq!(
+      fixture.len(),
+      expected.len(),
+      "range count differs from the fixture"
+    );
+    for (entry, (from, to)) in fixture.iter().zip(expected) {
+      assert_eq!(entry.from_codepoint(), from, "start for {:?}", entry.policy);
+      assert_eq!(entry.to_codepoint(), to, "end for {:?}", entry.policy);
+    }
   }
 
   /// The LOC properties are registered in the same number space as the draft's own

--- a/libs/moqtail-rs/src/model/common.rs
+++ b/libs/moqtail-rs/src/model/common.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod grease;
 pub mod location;
 pub mod pair;
 pub mod reason_phrase;

--- a/libs/moqtail-rs/src/model/common/grease.rs
+++ b/libs/moqtail-rs/src/model/common/grease.rs
@@ -1,0 +1,67 @@
+// Copyright 2026 The MOQtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! GREASE reservations. Values matching `0x7f * N + 0x9D` are reserved across
+//! several registries (Setup Options, Properties, error codes) so peers can emit
+//! them to exercise unknown-value handling. Receivers treat them like any other
+//! unknown value: ignore, never fatal.
+
+/// Step between successive GREASE values.
+pub const GREASE_STEP: u64 = 0x7f;
+/// The smallest GREASE value (N = 0).
+pub const GREASE_BASE: u64 = 0x9d;
+
+/// Returns true if `value` is a reserved GREASE value, i.e. `0x7f * N + 0x9D`
+/// for some non-negative `N`.
+pub fn is_grease(value: u64) -> bool {
+  value >= GREASE_BASE && (value - GREASE_BASE).is_multiple_of(GREASE_STEP)
+}
+
+/// The `N`-th GREASE value, `0x7f * N + 0x9D`. Returns `None` if it would
+/// overflow `u64` (the pattern is capped at `0x3fffffffffffffde`).
+pub fn grease_value(n: u64) -> Option<u64> {
+  GREASE_STEP.checked_mul(n)?.checked_add(GREASE_BASE)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn recognizes_the_documented_grease_values() {
+    // 0x9D, 0x11C, ..., 0x3fffffffffffffde.
+    assert!(is_grease(0x9d));
+    assert!(is_grease(0x11c));
+    assert!(is_grease(0x3fffffffffffffde));
+    for n in 0..1000 {
+      assert!(is_grease(grease_value(n).unwrap()), "N={n}");
+    }
+  }
+
+  #[test]
+  fn rejects_non_grease_values() {
+    for v in [0u64, 1, 0x02, 0x9c, 0x9e, 0x11b, 0x11d, 0x4000] {
+      assert!(!is_grease(v), "{v:#x} must not be grease");
+    }
+  }
+
+  #[test]
+  fn grease_value_matches_the_formula() {
+    assert_eq!(grease_value(0), Some(0x9d));
+    assert_eq!(grease_value(1), Some(0x11c));
+    // The largest grease value the spec lists.
+    assert_eq!(grease_value(0x8102040810203f), Some(0x3fffffffffffffde));
+    assert_eq!(grease_value(u64::MAX), None);
+  }
+}

--- a/libs/moqtail-rs/src/model/control/constant.rs
+++ b/libs/moqtail-rs/src/model/control/constant.rs
@@ -247,6 +247,15 @@ impl TryFrom<u64> for RequestErrorCode {
   }
 }
 
+impl RequestErrorCode {
+  /// Maps a received error code to a known variant, treating any unknown value
+  /// (including GREASE) as `InternalError`. An unknown error code is never fatal
+  /// and never closes the session.
+  pub fn from_wire(value: u64) -> Self {
+    Self::try_from(value).unwrap_or(Self::InternalError)
+  }
+}
+
 impl From<RequestErrorCode> for u64 {
   fn from(value: RequestErrorCode) -> Self {
     value as u64
@@ -360,8 +369,47 @@ impl TryFrom<u64> for PublishDoneStatusCode {
   }
 }
 
+impl PublishDoneStatusCode {
+  /// Maps a received status code to a known variant, treating any unknown value
+  /// (including GREASE) as `InternalError`. An unknown code is never fatal.
+  pub fn from_wire(value: u64) -> Self {
+    Self::try_from(value).unwrap_or(Self::InternalError)
+  }
+}
+
 impl From<PublishDoneStatusCode> for u64 {
   fn from(value: PublishDoneStatusCode) -> Self {
     value as u64
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::model::common::grease::grease_value;
+
+  #[test]
+  fn from_wire_maps_unknown_and_grease_to_internal_error() {
+    // Known codes are preserved.
+    assert_eq!(
+      RequestErrorCode::from_wire(0x1),
+      RequestErrorCode::Unauthorized
+    );
+    assert_eq!(
+      PublishDoneStatusCode::from_wire(0x2),
+      PublishDoneStatusCode::TrackEnded
+    );
+
+    // Unknown and grease codes fall back to InternalError instead of failing.
+    for raw in [0x7Eu64, grease_value(0).unwrap(), grease_value(5).unwrap()] {
+      assert_eq!(
+        RequestErrorCode::from_wire(raw),
+        RequestErrorCode::InternalError
+      );
+      assert_eq!(
+        PublishDoneStatusCode::from_wire(raw),
+        PublishDoneStatusCode::InternalError
+      );
+    }
   }
 }

--- a/libs/moqtail-rs/src/model/control/publish_done.rs
+++ b/libs/moqtail-rs/src/model/control/publish_done.rs
@@ -71,8 +71,9 @@ impl ControlMessageTrait for PublishDone {
 
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
     let request_id = payload.get_vi()?;
+    // An unknown or GREASE status code is not fatal; treat it as InternalError.
     let status_code_raw = payload.get_vi()?;
-    let status_code = PublishDoneStatusCode::try_from(status_code_raw)?;
+    let status_code = PublishDoneStatusCode::from_wire(status_code_raw);
     let stream_count = payload.get_vi()?;
     let reason_phrase = ReasonPhrase::deserialize(payload)?;
 

--- a/libs/moqtail-rs/src/model/control/publish_namespace_cancel.rs
+++ b/libs/moqtail-rs/src/model/control/publish_namespace_cancel.rs
@@ -64,8 +64,9 @@ impl ControlMessageTrait for PublishNamespaceCancel {
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
     let request_id = payload.get_vi()?;
 
+    // An unknown or GREASE error code is not fatal; treat it as InternalError.
     let error_code_raw = payload.get_vi()?;
-    let error_code = RequestErrorCode::try_from(error_code_raw)?;
+    let error_code = RequestErrorCode::from_wire(error_code_raw);
     let reason_phrase = ReasonPhrase::deserialize(payload)?;
 
     Ok(Box::new(PublishNamespaceCancel {

--- a/libs/moqtail-rs/src/model/control/request_error.rs
+++ b/libs/moqtail-rs/src/model/control/request_error.rs
@@ -73,8 +73,9 @@ impl ControlMessageTrait for RequestError {
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
     let request_id = payload.get_vi()?;
 
+    // An unknown or GREASE error code is not fatal; treat it as InternalError.
     let error_code_raw = payload.get_vi()?;
-    let error_code = RequestErrorCode::try_from(error_code_raw)?;
+    let error_code = RequestErrorCode::from_wire(error_code_raw);
 
     let retry_interval = payload.get_vi()?;
 
@@ -96,7 +97,29 @@ impl ControlMessageTrait for RequestError {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::model::common::grease::grease_value;
+  use crate::model::common::varint::BufMutVarIntExt;
   use bytes::Buf;
+
+  /// A REQUEST_ERROR carrying a grease (unknown) error code must parse, not fail,
+  /// and is surfaced as InternalError.
+  #[test]
+  fn grease_error_code_parses_as_internal_error() {
+    let mut payload = BytesMut::new();
+    payload.put_vi(42).unwrap(); // request_id
+    payload.put_vi(grease_value(3).unwrap()).unwrap(); // grease error code
+    payload.put_vi(0).unwrap(); // retry_interval
+    payload.extend_from_slice(
+      &ReasonPhrase::try_new("grease".to_string())
+        .unwrap()
+        .serialize()
+        .unwrap(),
+    );
+    let mut buf = payload.freeze();
+    let parsed = RequestError::parse_payload(&mut buf).unwrap();
+    assert_eq!(parsed.error_code, RequestErrorCode::InternalError);
+    assert!(!buf.has_remaining());
+  }
 
   #[test]
   fn test_roundtrip() {

--- a/libs/moqtail-rs/src/model/control/setup.rs
+++ b/libs/moqtail-rs/src/model/control/setup.rs
@@ -145,6 +145,33 @@ mod tests {
   }
 
   #[test]
+  fn test_grease_setup_option_is_preserved_and_ignored() {
+    use crate::model::common::grease::grease_value;
+    // grease_value(0) = 0x9D is odd (Bytes KVP).
+    let grease =
+      KeyValuePair::try_new_bytes(grease_value(0).unwrap(), Bytes::from_static(b"anything"))
+        .unwrap();
+    let setup = Setup {
+      setup_options: vec![KeyValuePair::try_new_varint(0, 10).unwrap(), grease],
+    };
+
+    // The grease option survives a round-trip untouched.
+    let mut buf = setup.serialize().unwrap();
+    let _ = buf.get_vi().unwrap();
+    let _ = buf.get_u16();
+    let deserialized = Setup::parse_payload(&mut buf).unwrap();
+    assert_eq!(*deserialized, setup);
+
+    // And it is ignored by validation, even from a server over WebTransport,
+    // where a real AUTHORITY/PATH option would be rejected.
+    assert!(
+      deserialized
+        .validate_incoming(SetupSender::Server, TransportKind::WebTransport)
+        .is_ok()
+    );
+  }
+
+  #[test]
   fn test_roundtrip_no_options() {
     let setup = Setup {
       setup_options: vec![],

--- a/libs/moqtail-rs/src/model/property/constant.rs
+++ b/libs/moqtail-rs/src/model/property/constant.rs
@@ -94,6 +94,30 @@ impl From<TrackPropertyType> for u64 {
   }
 }
 
+/// Registration-policy ranges for the Property Type space.
+pub mod property_ranges {
+  use std::ops::RangeInclusive;
+
+  /// Standards Action or IESG Approval (1-byte encoding).
+  pub const STANDARDS_ACTION: RangeInclusive<u64> = 0x00..=0x77;
+  /// Application-specific use, no registration permitted (1-byte encoding).
+  pub const APP_SPECIFIC_1BYTE: RangeInclusive<u64> = 0x78..=0x7f;
+  /// Specification Required (2-byte encoding).
+  pub const SPEC_REQUIRED: RangeInclusive<u64> = 0x80..=0x37ff;
+  /// Application-specific use, no registration permitted (2-byte encoding).
+  pub const APP_SPECIFIC_2BYTE: RangeInclusive<u64> = 0x3800..=0x3fff;
+  /// Mandatory Track Properties; Track scope only.
+  pub const MANDATORY_TRACK: RangeInclusive<u64> = 0x4000..=0x7fff;
+  /// First Come First Served begins here (open-ended).
+  pub const FCFS_START: u64 = 0x8000;
+
+  /// True if a Property Type is reserved for application-specific use (either
+  /// encoding-width range), for which no IANA registration is permitted.
+  pub fn is_application_specific(type_value: u64) -> bool {
+    APP_SPECIFIC_1BYTE.contains(&type_value) || APP_SPECIFIC_2BYTE.contains(&type_value)
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/libs/moqtail-rs/src/model/property/track_property.rs
+++ b/libs/moqtail-rs/src/model/property/track_property.rs
@@ -59,8 +59,9 @@ pub enum TrackProperty {
   },
 }
 
-/// §2.5.1 Mandatory Track Properties range.
-pub const MANDATORY_TRACK_PROPERTY_RANGE: std::ops::RangeInclusive<u64> = 0x4000..=0x7FFF;
+/// Mandatory Track Properties range.
+pub const MANDATORY_TRACK_PROPERTY_RANGE: std::ops::RangeInclusive<u64> =
+  super::constant::property_ranges::MANDATORY_TRACK;
 
 /// True if any property is an unrecognized Mandatory Track Property (§2.5.1).
 pub fn has_unsupported_mandatory(properties: &[TrackProperty]) -> bool {
@@ -433,6 +434,18 @@ mod tests {
         TrackProperty::Unknown { kvp }
       );
     }
+  }
+
+  #[test]
+  fn test_grease_property_is_forwarded_as_unknown() {
+    use crate::model::common::grease::grease_value;
+    // grease_value(1) = 0x11C is even (VarInt); it is unknown and outside the
+    // mandatory range, so it is preserved as an ordinary Unknown property.
+    let kvp = KeyValuePair::try_new_varint(grease_value(1).unwrap(), 7).unwrap();
+    assert_eq!(
+      TrackProperty::deserialize(kvp.clone()).unwrap(),
+      TrackProperty::Unknown { kvp }
+    );
   }
 
   #[test]


### PR DESCRIPTION
Reserve the 0x7f * N + 0x9D GREASE pattern and handle unknown values gracefully across registries so a peer emitting grease interops.

- New common::grease with is_grease / grease_value helpers.
- Property registry ranges (property_ranges) matching property_types.json, with a conformance test; consolidate the mandatory-track range.
- Error codes: RequestErrorCode::from_wire and PublishDoneStatusCode::from_wire map unknown/grease codes to InternalError instead of failing the parse, applied in REQUEST_ERROR, PUBLISH_NAMESPACE_CANCEL, and PUBLISH_DONE.
- Setup Options and Properties already ignore unknowns; add tests confirming greased values round-trip and are ignored.

Closes #234 (RS-18).
