### PR TITLE
feat: move request types onto their own bidirectional streams

### DIFF
--- a/apps/client/src/connection.rs
+++ b/apps/client/src/connection.rs
@@ -37,6 +37,10 @@ const CLIENT_SUPPORTED_VERSIONS: &str = "moqt-18";
 
 pub struct MoqConnection {
   pub connection: Arc<TransportConnection>,
+  // Held for the session's lifetime so the control stream is not closed (which
+  // would be a protocol violation). Requests use their own bidi streams, so it is
+  // otherwise unused after SETUP.
+  #[allow(dead_code)]
   pub control_stream: ControlStreamHandler,
 }
 

--- a/apps/client/src/fetcher.rs
+++ b/apps/client/src/fetcher.rs
@@ -20,6 +20,7 @@ use moqtail::model::control::control_message::ControlMessage;
 use moqtail::model::control::fetch::{Fetch, StandaloneFetchProps};
 use moqtail::model::control::fetch_cancel::FetchCancel;
 use moqtail::model::parameter::message_parameter::MessageParameter;
+use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use moqtail::transport::data_stream_handler::{FetchRequest, RecvDataStream};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -44,10 +45,10 @@ pub struct FetchConfig {
 }
 
 pub async fn run(moq: MoqConnection, config: FetchConfig) -> Result<()> {
-  let MoqConnection {
-    connection,
-    mut control_stream,
-  } = moq;
+  // Keep `moq` alive for the whole function: its control stream carries only
+  // SETUP now, but must stay open for the session's lifetime. Requests use their
+  // own bidi streams; data arrives on uni streams.
+  let connection = moq.connection.clone();
 
   let pending_fetches = Arc::new(RwLock::new(BTreeMap::new()));
 
@@ -70,9 +71,13 @@ pub async fn run(moq: MoqConnection, config: FetchConfig) -> Result<()> {
     config.start_group, config.start_object, config.end_group, config.end_object
   );
 
-  control_stream
+  // FETCH opens its own bidi request stream; the response returns on it.
+  let (send, recv) = connection.open_bi().await?;
+  let mut request_stream = ControlStreamHandler::new(send, recv);
+  request_stream
     .send(&ControlMessage::Fetch(Box::new(fetch.clone())))
-    .await?;
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to send FETCH: {:?}", e))?;
 
   pending_fetches
     .write()
@@ -138,8 +143,8 @@ pub async fn run(moq: MoqConnection, config: FetchConfig) -> Result<()> {
     }
   });
 
-  // Wait for control messages (RequestOk/RequestError)
-  match control_stream.next_message().await {
+  // Wait for the fetch response on the request stream (FetchOk / RequestError).
+  match request_stream.next_message().await {
     Ok(ControlMessage::RequestOk(m)) => {
       info!("Received RequestOk: {:?}", m);
     }
@@ -147,10 +152,10 @@ pub async fn run(moq: MoqConnection, config: FetchConfig) -> Result<()> {
       error!("Received RequestError: {:?}", m);
     }
     Ok(m) => {
-      info!("Received message: {:?}", m);
+      info!("Received fetch response: {:?}", m);
     }
     Err(e) => {
-      error!("Error receiving control message: {:?}", e);
+      error!("Error receiving fetch response: {:?}", e);
     }
   }
 
@@ -175,7 +180,7 @@ pub async fn run(moq: MoqConnection, config: FetchConfig) -> Result<()> {
 
     info!("Sending FETCH_CANCEL for request_id: {}", request_id);
     let fetch_cancel = FetchCancel::new(request_id);
-    if let Err(e) = control_stream
+    if let Err(e) = request_stream
       .send(&ControlMessage::FetchCancel(Box::new(fetch_cancel)))
       .await
     {

--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -58,15 +58,13 @@ pub struct PublishNamespaceConfig {
 }
 
 pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -> Result<()> {
-  let MoqConnection {
-    connection,
-    mut control_stream,
-  } = moq;
+  // Keep `moq` alive for the session; the control stream carries only SETUP now.
+  let connection = moq.connection.clone();
 
   let ns = Tuple::from_utf8_path(&config.namespace);
 
-  // Step 1: Announce namespace
-  publish_namespace(&mut control_stream, &ns).await?;
+  // Step 1: Announce namespace on its own request stream (kept open below).
+  let _namespace_stream = publish_namespace(&connection, &ns).await?;
 
   let data_config = DataConfig {
     delivery_mode: config.delivery_mode,
@@ -77,58 +75,57 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
     publisher_priority: config.publisher_priority,
   };
 
-  // Step 2: Listen for Subscribe messages and serve data
-  let mut track_alias_counter: u64 = 1;
-  let mut tasks: Vec<tokio::task::JoinHandle<Result<()>>> = Vec::new();
+  // Step 2: the relay forwards each SUBSCRIBE on its own bidirectional request
+  // stream. Accept those streams and answer SUBSCRIBE on the same stream.
+  let track_alias_counter = Arc::new(std::sync::atomic::AtomicU64::new(1));
 
   info!(
-    "Waiting for Subscribe messages on namespace '{}'...",
+    "Waiting for Subscribe request streams on namespace '{}'...",
     config.namespace
   );
 
   loop {
-    match control_stream.next_message().await {
-      Ok(ControlMessage::Subscribe(m)) => {
-        let track_alias = track_alias_counter;
-        track_alias_counter += 1;
-
-        info!(
-          "Received Subscribe: request_id={}, track={:?}, assigning track_alias={}",
-          m.request_id, m.track_name, track_alias
-        );
-
-        let msg = SubscribeOk::new(m.request_id, track_alias, vec![], vec![]);
-
-        control_stream.send_impl(&msg).await?;
-        info!(
-          "SubscribeOk sent for request_id={}, track_alias={}",
-          m.request_id, track_alias
-        );
-
-        // Spawn a task to send data for this subscription
-        let conn = connection.clone();
-        let dc = data_config.clone();
-        let task = tokio::spawn(async move { send_data(&conn, track_alias, &dc).await });
-        tasks.push(task);
-      }
-      Ok(ControlMessage::Unsubscribe(m)) => {
-        info!("Received Unsubscribe: {:?}", m);
-      }
-      Ok(m) => {
-        info!("Received control message: {:?}", m);
-      }
+    let (send, recv) = match connection.accept_bi().await {
+      Ok(streams) => streams,
       Err(e) => {
-        info!("Control stream ended: {:?}", e);
+        info!("Request stream accept ended: {:?}", e);
         break;
       }
-    }
-  }
+    };
 
-  // Wait for all spawned data-sending tasks to complete
-  for task in tasks {
-    if let Err(e) = task.await {
-      error!("Data sending task failed: {:?}", e);
-    }
+    let conn = connection.clone();
+    let dc = data_config.clone();
+    let counter = track_alias_counter.clone();
+    tokio::spawn(async move {
+      let mut request_stream = ControlStreamHandler::new(send, recv);
+      match request_stream.next_message().await {
+        Ok(ControlMessage::Subscribe(m)) => {
+          let track_alias = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+          info!(
+            "Received Subscribe on request stream: request_id={}, track={:?}, assigning track_alias={}",
+            m.request_id, m.track_name, track_alias
+          );
+
+          let ok = SubscribeOk::new(m.request_id, track_alias, vec![], vec![]);
+          if let Err(e) = request_stream.send_impl(&ok).await {
+            error!("Failed to send SubscribeOk: {:?}", e);
+            return;
+          }
+          info!(
+            "SubscribeOk sent for request_id={}, track_alias={}",
+            m.request_id, track_alias
+          );
+
+          // Serve data; keep the request stream open until the objects are sent.
+          if let Err(e) = send_data(&conn, track_alias, &dc).await {
+            error!("Data sending failed: {:?}", e);
+          }
+          drop(request_stream);
+        }
+        Ok(other) => info!("Unexpected message on request stream: {:?}", other),
+        Err(e) => info!("Request stream read error: {:?}", e),
+      }
+    });
   }
 
   // Keep connection alive briefly to ensure delivery
@@ -142,10 +139,10 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
 }
 
 pub async fn run(moq: MoqConnection, config: PublishConfig) -> Result<()> {
-  let MoqConnection {
-    connection,
-    mut control_stream,
-  } = moq;
+  // Keep `moq` alive for the whole function: its control stream carries only
+  // SETUP now, but must stay open for the session's lifetime. The PUBLISH request
+  // uses its own bidi stream; objects go out on uni streams.
+  let connection = moq.connection.clone();
 
   let ns = Tuple::from_utf8_path(&config.namespace);
 
@@ -160,7 +157,6 @@ pub async fn run(moq: MoqConnection, config: PublishConfig) -> Result<()> {
 
   publish_track(
     &connection,
-    &mut control_stream,
     &ns,
     &config.track_name,
     config.track_alias,
@@ -178,24 +174,29 @@ pub async fn run(moq: MoqConnection, config: PublishConfig) -> Result<()> {
   Ok(())
 }
 
+/// Announce a namespace on its own bidi request stream. Returns the stream, which
+/// the caller keeps open for the announcement's lifetime.
 async fn publish_namespace(
-  control_stream: &mut ControlStreamHandler,
+  connection: &Arc<TransportConnection>,
   namespace: &Tuple,
-) -> Result<()> {
+) -> Result<ControlStreamHandler> {
   info!("Publishing namespace...");
   let publish_namespace = PublishNamespace::new(0, namespace.clone(), &[]);
   let expected_request_id = publish_namespace.request_id;
 
-  control_stream
+  let (send, recv) = connection.open_bi().await?;
+  let mut request_stream = ControlStreamHandler::new(send, recv);
+  request_stream
     .send(&ControlMessage::PublishNamespace(Box::new(
       publish_namespace,
     )))
-    .await?;
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to send PUBLISH_NAMESPACE: {:?}", e))?;
 
-  match control_stream.next_message().await {
+  match request_stream.next_message().await {
     Ok(ControlMessage::RequestOk(ok)) if ok.request_id == expected_request_id => {
       info!("Namespace published successfully");
-      Ok(())
+      Ok(request_stream)
     }
     Ok(ControlMessage::RequestOk(ok)) => {
       anyhow::bail!(
@@ -221,7 +222,6 @@ struct DataConfig {
 
 async fn publish_track(
   connection: &Arc<TransportConnection>,
-  control_stream: &mut ControlStreamHandler,
   namespace: &Tuple,
   track_name: &str,
   track_alias: u64,
@@ -236,11 +236,16 @@ async fn publish_track(
     vec![MessageParameter::Forward { forward: true }],
     vec![],
   );
-  control_stream
-    .send(&ControlMessage::Publish(Box::new(publish)))
-    .await?;
 
-  match control_stream.next_message().await {
+  // PUBLISH opens its own bidi request stream; the response returns on it.
+  let (send, recv) = connection.open_bi().await?;
+  let mut request_stream = ControlStreamHandler::new(send, recv);
+  request_stream
+    .send(&ControlMessage::Publish(Box::new(publish)))
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to send PUBLISH: {:?}", e))?;
+
+  match request_stream.next_message().await {
     Ok(ControlMessage::PublishOk(m)) => {
       info!("Track published, request_id: {}", m.request_id);
     }
@@ -248,7 +253,10 @@ async fn publish_track(
     Err(e) => anyhow::bail!("Failed waiting for PublishOk: {:?}", e),
   }
 
-  send_data(connection, track_alias, data_config).await
+  // Hold the request stream open while objects are delivered on uni streams.
+  let result = send_data(connection, track_alias, data_config).await;
+  drop(request_stream);
+  result
 }
 
 async fn send_data(

--- a/apps/client/src/subscriber.rs
+++ b/apps/client/src/subscriber.rs
@@ -24,21 +24,24 @@ use moqtail::model::control::subscribe::Subscribe;
 use moqtail::model::data::datagram::Datagram;
 use moqtail::model::parameter::message_parameter::MessageParameter;
 use moqtail::transport::connection::TransportConnection;
+use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use moqtail::transport::data_stream_handler::RecvDataStream;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info};
 
-/// Subscribe to one track and return its assigned track alias.
+/// Subscribe to one track on its own bidirectional request stream. Returns the
+/// assigned track alias and the request-stream handler, which the caller keeps
+/// alive for the subscription's lifetime.
 async fn subscribe_track(
-  control_stream: &mut moqtail::transport::control_stream_handler::ControlStreamHandler,
+  connection: &Arc<TransportConnection>,
   namespace: &str,
   track_name: &str,
   request_id: u64,
   subscriber_priority: u8,
   group_order: GroupOrder,
-) -> Result<u64> {
+) -> Result<(u64, ControlStreamHandler)> {
   let ns = Tuple::from_utf8_path(namespace);
   info!(
     "Subscribing to track: {}/{} (request_id={}, priority={})",
@@ -54,17 +57,23 @@ async fn subscribe_track(
       MessageParameter::new_forward(true),
     ],
   );
-  control_stream
-    .send(&ControlMessage::Subscribe(Box::new(subscribe)))
-    .await?;
 
-  match control_stream.next_message().await {
+  // A request opens its own bidi stream, beginning with SUBSCRIBE; the response
+  // comes back on the same stream.
+  let (send, recv) = connection.open_bi().await?;
+  let mut request_stream = ControlStreamHandler::new(send, recv);
+  request_stream
+    .send(&ControlMessage::Subscribe(Box::new(subscribe)))
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to send SUBSCRIBE: {:?}", e))?;
+
+  match request_stream.next_message().await {
     Ok(ControlMessage::SubscribeOk(m)) => {
       info!(
         "Subscribed: track={} track_alias={}",
         track_name, m.track_alias
       );
-      Ok(m.track_alias)
+      Ok((m.track_alias, request_stream))
     }
     Ok(m) => anyhow::bail!("Expected SubscribeOk for {}, got {:?}", track_name, m),
     Err(e) => anyhow::bail!("Failed waiting for SubscribeOk for {}: {:?}", track_name, e),
@@ -82,13 +91,16 @@ pub struct SubscribeConfig {
 }
 
 pub async fn run(moq: MoqConnection, config: SubscribeConfig) -> Result<()> {
-  let MoqConnection {
-    connection,
-    mut control_stream,
-  } = moq;
+  // Keep `moq` alive for the whole function: its control stream carries only
+  // SETUP now, but must stay open for the session's lifetime. Subscriptions use
+  // their own bidi request streams; objects arrive on uni streams.
+  let connection = moq.connection.clone();
 
-  let track_alias = subscribe_track(
-    &mut control_stream,
+  // Each subscription's request stream is held open for its lifetime.
+  let mut request_streams = Vec::new();
+
+  let (track_alias, primary_stream) = subscribe_track(
+    &connection,
     &config.namespace,
     &config.track_name,
     0,
@@ -96,10 +108,11 @@ pub async fn run(moq: MoqConnection, config: SubscribeConfig) -> Result<()> {
     config.group_order,
   )
   .await?;
+  request_streams.push(primary_stream);
 
   let extra_alias = if let Some((ref extra_name, extra_priority)) = config.extra_track {
-    let alias = subscribe_track(
-      &mut control_stream,
+    let (alias, extra_stream) = subscribe_track(
+      &connection,
       &config.namespace,
       extra_name,
       1,
@@ -107,17 +120,20 @@ pub async fn run(moq: MoqConnection, config: SubscribeConfig) -> Result<()> {
       config.group_order,
     )
     .await?;
+    request_streams.push(extra_stream);
     Some((extra_name.clone(), alias))
   } else {
     None
   };
 
-  match config.delivery_mode {
+  let result = match config.delivery_mode {
     DeliveryMode::Datagram => receive_datagrams(&connection, track_alias, config.duration).await,
     DeliveryMode::Subgroup => {
       receive_streams(&connection, track_alias, extra_alias, config.duration).await
     }
-  }
+  };
+  drop(request_streams);
+  result
 }
 
 async fn receive_datagrams(

--- a/apps/relay/src/server/client.rs
+++ b/apps/relay/src/server/client.rs
@@ -43,7 +43,7 @@ use std::{
   time::Duration,
 };
 use tokio::sync::Notify;
-use tokio::sync::{Mutex, RwLock, watch};
+use tokio::sync::{Mutex, RwLock, mpsc, watch};
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
 
@@ -95,6 +95,11 @@ pub type SendStreamMap = HashMap<String, Arc<Mutex<TransportSendStream>>>;
 pub type SendStreamLock = Arc<RwLock<SendStreamMap>>;
 pub type SendStreamList = Vec<SendStreamLock>;
 
+// Per-request response channels, sharded like the send-stream map so a
+// register/lookup only locks one partition.
+pub type ResponseSenderMap = HashMap<u64, mpsc::UnboundedSender<ControlMessage>>;
+pub type ResponseSenderList = Vec<Arc<RwLock<ResponseSenderMap>>>;
+
 #[derive(Debug, Clone)]
 pub(crate) struct MOQTClient {
   pub connection_id: usize,
@@ -110,6 +115,12 @@ pub(crate) struct MOQTClient {
   pub message_queue: Arc<RwLock<VecDeque<ControlMessage>>>, // the control messages the client has sent
   pub message_notify: Arc<Notify>, // notify when a new message is available
   pub send_streams: Arc<SendStreamList>,
+
+  // Per-request response channels, keyed by the request's (downstream) request id
+  // and sharded across partitions. A request stream registers its sender here so
+  // responses/follow-ups produced elsewhere (e.g. a deferred SUBSCRIBE_OK fan-out)
+  // are delivered onto that stream instead of the control stream.
+  pub response_senders: Arc<ResponseSenderList>,
 
   // fetch requests that this client sent to the relay
   pub incoming_fetch_requests: Arc<RwLock<BTreeMap<u64, FetchRequest>>>,
@@ -165,6 +176,11 @@ impl MOQTClient {
       message_queue: Arc::new(RwLock::new(VecDeque::new())),
       message_notify: Arc::new(Notify::default()),
       send_streams: Arc::new(send_streams),
+      response_senders: Arc::new(
+        (0..SEND_STREAM_PARTITION_COUNT)
+          .map(|_| Arc::new(RwLock::new(HashMap::new())))
+          .collect(),
+      ),
       incoming_fetch_requests: Arc::new(RwLock::new(BTreeMap::new())),
       outgoing_fetch_requests: Arc::new(RwLock::new(BTreeMap::new())),
       subscribe_requests: Arc::new(RwLock::new(BTreeMap::new())),
@@ -217,6 +233,42 @@ impl MOQTClient {
     let mut message_queue = self.message_queue.write().await;
     message_queue.push_back(control_message);
     self.message_notify.notify_one();
+  }
+
+  /// The response-sender shard for a request id (sequential ids spread evenly).
+  fn response_partition(&self, request_id: u64) -> usize {
+    (request_id % self.response_senders.len() as u64) as usize
+  }
+
+  /// Register a request stream's response channel under its request id.
+  pub(crate) async fn register_response_sender(
+    &self,
+    request_id: u64,
+    tx: mpsc::UnboundedSender<ControlMessage>,
+  ) {
+    let idx = self.response_partition(request_id);
+    self.response_senders[idx]
+      .write()
+      .await
+      .insert(request_id, tx);
+  }
+
+  /// Remove a request stream's response channel (on stream close).
+  pub(crate) async fn unregister_response_sender(&self, request_id: u64) {
+    let idx = self.response_partition(request_id);
+    self.response_senders[idx].write().await.remove(&request_id);
+  }
+
+  /// Deliver a message onto the request stream registered for `request_id`.
+  /// Returns true if a request stream was registered and accepted it; false
+  /// otherwise (the caller may fall back to the control-stream queue).
+  pub(crate) async fn send_response(&self, request_id: u64, message: ControlMessage) -> bool {
+    let idx = self.response_partition(request_id);
+    let senders = self.response_senders[idx].read().await;
+    match senders.get(&request_id) {
+      Some(tx) => tx.send(message).is_ok(),
+      None => false,
+    }
   }
 
   /// Calculate the partition index for stream distribution across buckets.

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -36,7 +36,7 @@ const UPSTREAM_FETCH_CHANNEL_CAPACITY: usize = 64;
 
 pub async fn handle(
   client: Arc<MOQTClient>,
-  _control_stream_handler: &mut ControlStreamHandler,
+  control_stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -197,7 +197,7 @@ pub async fn handle(
         }
       }
 
-      // Send FetchOk immediately on the control stream before delivering objects.
+      // Send FetchOk on the request stream before delivering objects.
       {
         let fetch_ok = FetchOk::new(
           request_id,
@@ -206,9 +206,9 @@ pub async fn handle(
           vec![],
           vec![],
         );
-        client
-          .queue_message(ControlMessage::FetchOk(Box::new(fetch_ok)))
-          .await;
+        control_stream_handler
+          .send(&ControlMessage::FetchOk(Box::new(fetch_ok)))
+          .await?;
       }
 
       // Register a cancel channel for this fetch request

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -56,6 +56,60 @@ async fn add_subscription(
   }
 }
 
+/// Forward a SUBSCRIBE to the upstream publisher on its own bidirectional request
+/// stream, then read the response (and follow-ups) on that stream and dispatch
+/// them so the result fans out to the downstream subscribers.
+async fn forward_subscribe_upstream(
+  publisher: Arc<MOQTClient>,
+  new_sub: Subscribe,
+  context: Arc<SessionContext>,
+) {
+  let (send, recv) = match publisher.connection.open_bi().await {
+    Ok(streams) => streams,
+    Err(e) => {
+      error!("Failed to open upstream subscribe stream: {:?}", e);
+      return;
+    }
+  };
+  let mut upstream = ControlStreamHandler::new(send, recv);
+  if let Err(e) = upstream
+    .send(&ControlMessage::Subscribe(Box::new(new_sub)))
+    .await
+  {
+    error!("Failed to send upstream SUBSCRIBE: {:?}", e);
+    return;
+  }
+
+  loop {
+    match upstream.next_message().await {
+      Ok(ControlMessage::SubscribeOk(m)) => {
+        if let Err(e) =
+          handle_subscribe_ok_message(publisher.clone(), &mut upstream, *m, context.clone()).await
+        {
+          error!("Error handling upstream SubscribeOk: {:?}", e);
+          return;
+        }
+      }
+      Ok(ControlMessage::RequestError(m)) => {
+        let _ =
+          handle_subscribe_error_message(publisher.clone(), &mut upstream, *m, context.clone())
+            .await;
+        return;
+      }
+      Ok(other) => {
+        warn!(
+          "Unexpected {:?} on upstream subscribe stream",
+          other.get_type()
+        );
+      }
+      Err(_) => {
+        debug!("Upstream subscribe stream closed");
+        return;
+      }
+    }
+  }
+}
+
 async fn handle_subscribe_message(
   client: Arc<MOQTClient>,
   control_stream_handler: &mut ControlStreamHandler,
@@ -177,11 +231,8 @@ async fn handle_subscribe_message(
     new_sub.request_id =
       Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
 
-    publisher
-      .queue_message(ControlMessage::Subscribe(Box::new(new_sub.clone())))
-      .await;
-
-    // Store relay subscribe request mapping in the unified pending requests map
+    // Store the relay subscribe request mapping before forwarding, so the
+    // upstream response can be routed back to this subscription.
     // TODO: we need to add a timeout here or another loop to control expired requests
     let req = SubscribeRequest::new(
       original_request_id,
@@ -189,12 +240,23 @@ async fn handle_subscribe_message(
       sub.clone(),
       Some(new_sub.clone()),
     );
-    let mut requests = context.relay_pending_requests.write().await;
-    requests.insert(new_sub.request_id, PendingRequest::Subscribe(req.clone()));
+    {
+      let mut requests = context.relay_pending_requests.write().await;
+      requests.insert(new_sub.request_id, PendingRequest::Subscribe(req.clone()));
+    }
     info!(
       "inserted request into relay's pending requests: {:?} with relay's request id: {:?}",
       req, new_sub.request_id
     );
+
+    // Forward SUBSCRIBE upstream on its own bidirectional request stream and read
+    // the response there, per the request-stream model.
+    let publisher_fwd = publisher.clone();
+    let context_fwd = context.clone();
+    tokio::spawn(async move {
+      forward_subscribe_upstream(publisher_fwd, new_sub, context_fwd).await;
+    });
+
     // Do NOT send SubscribeOk yet -- wait for publisher confirmation
     Ok(())
   } else {
@@ -277,7 +339,8 @@ async fn handle_subscribe_message(
 }
 
 async fn handle_subscribe_ok_message(
-  _client: Arc<MOQTClient>,
+  // The publisher that sent this SUBSCRIBE_OK; its connection id keys the track alias.
+  publisher: Arc<MOQTClient>,
   _control_stream_handler: &mut ControlStreamHandler,
   msg: moqtail::model::control::subscribe_ok::SubscribeOk,
   context: Arc<SessionContext>,
@@ -322,7 +385,7 @@ async fn handle_subscribe_ok_message(
       0,
       reason,
     );
-    return handle_subscribe_error_message(_client, _control_stream_handler, err, context).await;
+    return handle_subscribe_error_message(publisher, _control_stream_handler, err, context).await;
   }
 
   let full_track_name = sub_request.original_subscribe_request.get_full_track_name();
@@ -344,7 +407,7 @@ async fn handle_subscribe_ok_message(
     let mut track = track_arc.write().await;
     track
       .confirm(
-        context.connection_id,
+        publisher.connection_id,
         msg.track_alias,
         msg.subscribe_parameters.clone(),
         msg.track_properties.clone(),
@@ -357,7 +420,7 @@ async fn handle_subscribe_ok_message(
   context
     .track_manager
     .add_track_alias(
-      context.connection_id,
+      publisher.connection_id,
       msg.track_alias,
       full_track_name.clone(),
     )
@@ -384,9 +447,18 @@ async fn handle_subscribe_ok_message(
         "sending SubscribeOk to creator subscriber: {:?}",
         subscriber.connection_id
       );
-      subscriber
-        .queue_message(ControlMessage::SubscribeOk(Box::new(subscribe_ok)))
+      let delivered = subscriber
+        .send_response(
+          sub_request.original_request_id,
+          ControlMessage::SubscribeOk(Box::new(subscribe_ok)),
+        )
         .await;
+      if !delivered {
+        warn!(
+          "no request stream for creator subscriber request {}",
+          sub_request.original_request_id
+        );
+      }
     } else {
       warn!(
         "creator subscriber not found: {:?}",
@@ -423,9 +495,18 @@ async fn handle_subscribe_ok_message(
           "sending SubscribeOk to pending subscriber: {:?}",
           subscriber.connection_id
         );
-        subscriber
-          .queue_message(ControlMessage::SubscribeOk(Box::new(subscribe_ok)))
+        let delivered = subscriber
+          .send_response(
+            subscriber_request_id,
+            ControlMessage::SubscribeOk(Box::new(subscribe_ok)),
+          )
           .await;
+        if !delivered {
+          warn!(
+            "no request stream for pending subscriber request {}",
+            subscriber_request_id
+          );
+        }
       }
     }
   }
@@ -649,7 +730,10 @@ async fn handle_subscribe_error_message(
         msg.reason_phrase.clone(),
       );
       subscriber
-        .queue_message(ControlMessage::RequestError(Box::new(subscribe_error)))
+        .send_response(
+          sub_request.original_request_id,
+          ControlMessage::RequestError(Box::new(subscribe_error)),
+        )
         .await;
     }
   }
@@ -675,7 +759,10 @@ async fn handle_subscribe_error_message(
           msg.reason_phrase.clone(),
         );
         subscriber
-          .queue_message(ControlMessage::RequestError(Box::new(subscribe_error)))
+          .send_response(
+            subscriber_request_id,
+            ControlMessage::RequestError(Box::new(subscribe_error)),
+          )
           .await;
       }
     }

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -291,7 +291,22 @@ impl Session {
         } // end of tokio::select!
       }
 
-      let message_type = &msg.get_type();
+      let message_type = msg.get_type();
+
+      // Request-opening types must arrive on their own bidi request streams; the
+      // control stream carries only session-level messages and responses.
+      if message_type.is_first() {
+        error!(
+          "Request type {:?} received on the control stream",
+          message_type
+        );
+        Self::close_session(
+          context.clone(),
+          TerminationCode::ProtocolViolation,
+          "Request type received on the control stream",
+        );
+        return Err(TerminationCode::ProtocolViolation);
+      }
 
       let handling_result = message_handlers::MessageHandler::handle(
         client.clone(),
@@ -439,6 +454,21 @@ impl Session {
       }
     };
 
+    // A request stream MUST begin with a First-marked type; anything else is a
+    // protocol violation and closes the session.
+    if !msg.get_type().is_first() {
+      warn!(
+        "Request bi-stream opened with non-First message {:?}",
+        msg.get_type()
+      );
+      Self::close_session(
+        context,
+        TerminationCode::ProtocolViolation,
+        "Request stream must begin with a First-marked message",
+      );
+      return;
+    }
+
     // Validate request_id
     let request_id_opt = match &msg {
       ControlMessage::SubscribeNamespace(m) => Some(m.request_id),
@@ -524,6 +554,84 @@ impl Session {
             }
           }
         }
+      }
+      // Request/response request types: the handler writes its immediate response
+      // on this bi-stream. A response channel registered under the request id lets
+      // deferred responses (e.g. a SUBSCRIBE_OK fan-out produced elsewhere) land on
+      // this stream too. The loop then also forwards follow-ups (UNSUBSCRIBE,
+      // REQUEST_UPDATE, FETCH_CANCEL) until the peer closes the stream.
+      first @ (ControlMessage::Subscribe(_)
+      | ControlMessage::Publish(_)
+      | ControlMessage::Fetch(_)
+      | ControlMessage::PublishNamespace(_)
+      | ControlMessage::TrackStatus(_)) => {
+        let request_id = match &first {
+          ControlMessage::Subscribe(m) => m.request_id,
+          ControlMessage::Publish(m) => m.request_id,
+          ControlMessage::Fetch(m) => m.request_id,
+          ControlMessage::PublishNamespace(m) => m.request_id,
+          ControlMessage::TrackStatus(m) => m.request_id,
+          _ => unreachable!("matched above"),
+        };
+
+        let (response_tx, mut response_rx) = tokio::sync::mpsc::unbounded_channel();
+        client
+          .register_response_sender(request_id, response_tx)
+          .await;
+
+        if let Err(e) = message_handlers::MessageHandler::handle(
+          client.clone(),
+          &mut stream_handler,
+          first,
+          context.clone(),
+        )
+        .await
+        {
+          client.unregister_response_sender(request_id).await;
+          Self::close_session(context, e, "Error handling request stream message");
+          return;
+        }
+
+        loop {
+          tokio::select! {
+            biased;
+            deferred = response_rx.recv() => {
+              match deferred {
+                Some(msg) => {
+                  if let Err(e) = stream_handler.send(&msg).await {
+                    warn!("Error writing response to request bi-stream: {:?}", e);
+                    break;
+                  }
+                }
+                None => break, // response channel closed
+              }
+            }
+            incoming = stream_handler.next_message() => {
+              match incoming {
+                Ok(follow_up) => {
+                  if let Err(e) = message_handlers::MessageHandler::handle(
+                    client.clone(),
+                    &mut stream_handler,
+                    follow_up,
+                    context.clone(),
+                  )
+                  .await
+                  {
+                    client.unregister_response_sender(request_id).await;
+                    Self::close_session(context, e, "Error handling request stream follow-up");
+                    return;
+                  }
+                }
+                Err(_) => {
+                  // FIN or RESET: the requester closed the stream.
+                  debug!("Request bi-stream closed by peer");
+                  break;
+                }
+              }
+            }
+          }
+        }
+        client.unregister_response_sender(request_id).await;
       }
       _ => {
         warn!(

--- a/libs/moqtail-rs/src/model/control/constant.rs
+++ b/libs/moqtail-rs/src/model/control/constant.rs
@@ -109,6 +109,24 @@ impl From<ControlMessageType> for u64 {
   }
 }
 
+impl ControlMessageType {
+  /// True if this message type MUST be the first on a new bidirectional request
+  /// stream. A request stream that opens with any other type is a protocol
+  /// violation and MUST be reset.
+  pub fn is_first(self) -> bool {
+    matches!(
+      self,
+      Self::Subscribe
+        | Self::Fetch
+        | Self::TrackStatus
+        | Self::PublishNamespace
+        | Self::SubscribeNamespace
+        | Self::SubscribeTracks
+        | Self::Publish
+    )
+  }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(u64)]
 pub enum FilterType {
@@ -387,6 +405,34 @@ impl From<PublishDoneStatusCode> for u64 {
 mod tests {
   use super::*;
   use crate::model::common::grease::grease_value;
+
+  #[test]
+  fn is_first_matches_the_request_opening_types() {
+    let first = [
+      ControlMessageType::Subscribe,
+      ControlMessageType::Fetch,
+      ControlMessageType::TrackStatus,
+      ControlMessageType::PublishNamespace,
+      ControlMessageType::SubscribeNamespace,
+      ControlMessageType::SubscribeTracks,
+      ControlMessageType::Publish,
+    ];
+    for t in first {
+      assert!(t.is_first(), "{t:?} should open a request stream");
+    }
+    // A response / control type must not open a request stream.
+    for t in [
+      ControlMessageType::Setup,
+      ControlMessageType::GoAway,
+      ControlMessageType::SubscribeOk,
+      ControlMessageType::RequestOk,
+      ControlMessageType::RequestError,
+      ControlMessageType::FetchOk,
+      ControlMessageType::Unsubscribe,
+    ] {
+      assert!(!t.is_first(), "{t:?} must not open a request stream");
+    }
+  }
 
   #[test]
   fn from_wire_maps_unknown_and_grease_to_internal_error() {


### PR DESCRIPTION
Per draft-18 §3.3, each request opens its own bidi stream that begins with a First-marked type and carries the response back on the same stream; the control stream is reserved for session-level messages.

Relay:
- ControlMessageType::is_first(); handle_request_stream resets (closes with PROTOCOL_VIOLATION) a stream that opens with a non-First type.
- dispatch_request_stream_message handles Subscribe/Publish/Fetch/ PublishNamespace/TrackStatus, routing the request and its follow-ups through the existing handlers on the request stream.
- Per-request response channel (sharded, keyed by request id) so deferred responses (e.g. a SUBSCRIBE_OK fan-out) land on the right request stream.
- fetch_handler sends FetchOk on the request stream; subscribe fan-out uses the response channel instead of the control-stream queue.
- Control loop rejects First-typed messages received on the control stream.
- Upstream leg: forwarding a SUBSCRIBE to the publisher opens a bidi request stream to it and reads the response there; the publisher accepts these streams. handle_subscribe_ok_message keys the track alias by the publisher connection id (correct under both the control-loop and upstream paths).

Client: each request (SUBSCRIBE, PUBLISH, FETCH, PUBLISH_NAMESPACE) opens its own bidi stream and reads its response there; publish-namespace accepts the relay's forwarded SUBSCRIBE streams. The control stream is kept alive per spec but otherwise unused after SETUP.

Verified live over raw QUIC: publish+subscribe (origin), publish-namespace+ subscribe (upstream leg), and fetch all round-trip with objects flowing.

Closes #235 (RS-5, downstream + SUBSCRIBE upstream leg).

### Description

<!-- Please describe your changes in detail. Include motivation and context. -->

<!------------------------------------------------------------------------------
If you are contributing a new feature or fixing an issue, please provide references
to the relevant specifications, documentation, or issues. This helps maintainers
get familiar with the context of your changes.

Thank you for your contribution!
-------------------------------------------------------------------------------->
