### PR TITLE
feat: handle REQUEST_UPDATE rejection and failure side-effects (#239)

### DIFF
--- a/apps/relay/src/server/client.rs
+++ b/apps/relay/src/server/client.rs
@@ -17,6 +17,7 @@ pub(crate) mod track_subscription_map;
 
 use crate::server::{
   client::track_subscription_map::TrackSubscriptionMap,
+  message_handlers::fetch_handler::FetchStop,
   session_context::PendingRequest,
   stream_id::{StreamId, StreamType},
   utils,
@@ -134,7 +135,7 @@ pub(crate) struct MOQTClient {
   pub inbound_requests: Arc<RwLock<BTreeMap<u64, PendingRequest>>>,
 
   // Senders for cancelling active fetch tasks, keyed by request_id.
-  pub fetch_cancel_senders: Arc<RwLock<HashMap<u64, watch::Sender<bool>>>>,
+  pub fetch_cancel_senders: Arc<RwLock<HashMap<u64, watch::Sender<FetchStop>>>>,
 
   // this contains the subscriptions made by the client
   pub subscriptions: TrackSubscriptionMap,

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -46,7 +46,7 @@ pub enum FetchStop {
 
 pub async fn handle(
   client: Arc<MOQTClient>,
-  control_stream_handler: &mut ControlStreamHandler,
+  stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -202,7 +202,7 @@ pub async fn handle(
           vec![],
           vec![],
         );
-        control_stream_handler
+        stream_handler
           .send(&ControlMessage::FetchOk(Box::new(fetch_ok)))
           .await?;
       }

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -24,6 +24,7 @@ use moqtail::model::control::fetch_ok::FetchOk;
 use moqtail::model::control::request_error::RequestError;
 use moqtail::model::data::fetch_header::FetchHeader;
 use moqtail::model::error::RequestErrorCode;
+use moqtail::model::error::StreamResetCode;
 use moqtail::model::error::TerminationCode;
 use moqtail::model::{common::reason_phrase::ReasonPhrase, control::constant::FetchType};
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
@@ -33,6 +34,15 @@ use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info, warn};
 
 const UPSTREAM_FETCH_CHANNEL_CAPACITY: usize = 64;
+
+/// Why a fetch's object stream is torn down early. A normal cancel closes the
+/// stream with a FIN; a failed REQUEST_UPDATE resets it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FetchStop {
+  Running,
+  Cancelled,
+  UpdateFailed,
+}
 
 pub async fn handle(
   client: Arc<MOQTClient>,
@@ -198,7 +208,7 @@ pub async fn handle(
       }
 
       // Register a cancel channel for this fetch request
-      let (cancel_tx, mut cancel_rx) = watch::channel(false);
+      let (cancel_tx, mut cancel_rx) = watch::channel(FetchStop::Running);
       {
         let mut senders = client.fetch_cancel_senders.write().await;
         senders.insert(request_id, cancel_tx);
@@ -234,19 +244,20 @@ pub async fn handle(
         let mut object_count = 0;
         let mut upstream_gap_count: u64 = 0;
         let mut send_stream = None;
-        let mut cancelled = false;
+        let mut stop_reason = FetchStop::Running;
         let mut fetch_prev_ctx: Option<moqtail::model::data::fetch_object::FetchObjectContext> =
           None;
         let group_order = fetch.group_order();
         let mut group_id = start_location.group;
 
         while group_id <= end_location.group {
-          if *cancel_rx.borrow() {
+          let reason = *cancel_rx.borrow();
+          if reason != FetchStop::Running {
             info!(
-              "handle_fetch_messages | Fetch cancelled for request_id: {}",
-              request_id
+              "handle_fetch_messages | Fetch stopped ({:?}) for request_id: {}",
+              reason, request_id
             );
-            cancelled = true;
+            stop_reason = reason;
             break;
           }
 
@@ -452,11 +463,12 @@ pub async fn handle(
                     }
                   }
                   _ = cancel_rx.changed() => {
+                    let reason = *cancel_rx.borrow();
                     info!(
-                      "handle_fetch_messages | Fetch cancelled during upstream fetch for request_id: {}",
-                      request_id
+                      "handle_fetch_messages | Fetch stopped ({:?}) during upstream fetch for request_id: {}",
+                      reason, request_id
                     );
-                    cancelled = true;
+                    stop_reason = reason;
                     break;
                   }
                 }
@@ -484,20 +496,25 @@ pub async fn handle(
           }
         }
 
-        if cancelled {
-          // Close the stream promptly as per the spec
+        if stop_reason != FetchStop::Running {
           if let Some(the_stream) = send_stream {
-            if let Err(e) = the_stream.lock().await.finish().await {
+            let mut stream = the_stream.lock().await;
+            let result = match stop_reason {
+              FetchStop::UpdateFailed => stream.reset(StreamResetCode::Cancelled.to_u64()),
+              _ => stream.finish().await,
+            };
+            if let Err(e) = result {
               error!(
-                "handle_fetch_messages | Error closing stream on cancel: {:?}",
-                e
+                "handle_fetch_messages | Error closing stream on stop ({:?}): {:?}",
+                stop_reason, e
               );
             } else {
               info!(
-                "handle_fetch_messages | closed fetch stream on cancel: {:?}",
-                &stream_id
+                "handle_fetch_messages | closed fetch stream on stop ({:?}): {:?}",
+                stop_reason, &stream_id
               );
             }
+            drop(stream);
             client.remove_stream_by_stream_id(&stream_id).await;
           }
         } else if object_count == 0 {
@@ -585,7 +602,7 @@ pub async fn handle(
       }
 
       if let Some(tx) = cancel_tx {
-        let _ = tx.send(true);
+        let _ = tx.send(FetchStop::Cancelled);
         info!(
           "handle_fetch_messages | Sent cancel signal for request_id: {}",
           request_id
@@ -616,6 +633,21 @@ pub async fn handle(
         return Err(TerminationCode::InternalError);
       }
 
+      Ok(())
+    }
+    ControlMessage::RequestUpdate(m) => {
+      warn!(
+        "REQUEST_UPDATE for FETCH request {} cannot be applied; stopping delivery",
+        m.existing_request_id
+      );
+      let cancel_tx = client
+        .fetch_cancel_senders
+        .write()
+        .await
+        .remove(&m.existing_request_id);
+      if let Some(tx) = cancel_tx {
+        let _ = tx.send(FetchStop::UpdateFailed);
+      }
       Ok(())
     }
     _ => {

--- a/apps/relay/src/server/message_handlers/mod.rs
+++ b/apps/relay/src/server/message_handlers/mod.rs
@@ -41,19 +41,14 @@ pub struct MessageHandler {}
 impl MessageHandler {
   pub async fn handle(
     client: Arc<MOQTClient>,
-    control_stream_handler: &mut ControlStreamHandler,
+    stream_handler: &mut ControlStreamHandler,
     msg: ControlMessage,
     context: Arc<SessionContext>,
   ) -> Result<(), TerminationCode> {
     let handling_result = match &msg {
       ControlMessage::PublishNamespace(_) => {
-        publish_namespace_handler::handle(
-          client.clone(),
-          control_stream_handler,
-          msg,
-          context.clone(),
-        )
-        .await
+        publish_namespace_handler::handle(client.clone(), stream_handler, msg, context.clone())
+          .await
       }
       ControlMessage::SubscribeNamespace(_) => {
         warn!("SUBSCRIBE_NAMESPACE received on control stream — must use a dedicated bi-stream");
@@ -63,18 +58,17 @@ impl MessageHandler {
       | ControlMessage::SubscribeOk(_)
       | ControlMessage::Unsubscribe(_)
       | ControlMessage::Switch(_) => {
-        subscribe_handler::handle(client.clone(), control_stream_handler, msg, context.clone())
-          .await
+        subscribe_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
       }
 
       ControlMessage::TrackStatus(_) => {
-        track_status_handler::handle(control_stream_handler, msg, context.clone()).await
+        track_status_handler::handle(stream_handler, msg, context.clone()).await
       }
       ControlMessage::Fetch(_) | ControlMessage::FetchCancel(_) | ControlMessage::FetchOk(_) => {
-        fetch_handler::handle(client.clone(), control_stream_handler, msg, context.clone()).await
+        fetch_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
       }
       ControlMessage::Publish(_) | ControlMessage::PublishDone(_) => {
-        publish_handler::handle(client.clone(), control_stream_handler, msg, context.clone()).await
+        publish_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
       }
 
       ControlMessage::RequestOk(_)
@@ -122,37 +116,29 @@ impl MessageHandler {
         // 4. Route to the appropriate handler (defined only once!)
         match route {
           Route::Fetch => {
-            fetch_handler::handle(client.clone(), control_stream_handler, msg, context.clone())
-              .await
+            fetch_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
           }
           Route::Publish => {
-            publish_handler::handle(client.clone(), control_stream_handler, msg, context.clone())
-              .await
+            publish_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
           }
           Route::PublishNamespace => {
-            publish_namespace_handler::handle(
-              client.clone(),
-              control_stream_handler,
-              msg,
-              context.clone(),
-            )
-            .await
+            publish_namespace_handler::handle(client.clone(), stream_handler, msg, context.clone())
+              .await
           }
           Route::Subscribe => {
-            subscribe_handler::handle(client.clone(), control_stream_handler, msg, context.clone())
-              .await
+            subscribe_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
           }
           Route::SubscribeNamespace => {
             subscribe_namespace_handler::handle(
               client.clone(),
-              control_stream_handler,
+              stream_handler,
               msg,
               context.clone(),
             )
             .await
           }
           Route::TrackStatus => {
-            track_status_handler::handle(control_stream_handler, msg, context.clone()).await
+            track_status_handler::handle(stream_handler, msg, context.clone()).await
           }
           Route::NotFound => {
             warn!(
@@ -172,7 +158,7 @@ impl MessageHandler {
                   0,
                   ReasonPhrase::try_new("REQUEST_UPDATE is not applicable".to_string()).unwrap(),
                 );
-                control_stream_handler
+                stream_handler
                   .send(&ControlMessage::RequestError(Box::new(err)))
                   .await
               }

--- a/apps/relay/src/server/message_handlers/mod.rs
+++ b/apps/relay/src/server/message_handlers/mod.rs
@@ -14,7 +14,11 @@
 
 use bytes::Bytes;
 use moqtail::{
-  model::{control::control_message::ControlMessage, error::TerminationCode},
+  model::{
+    common::reason_phrase::ReasonPhrase,
+    control::{control_message::ControlMessage, request_error::RequestError},
+    error::{RequestErrorCode, TerminationCode},
+  },
   transport::control_stream_handler::ControlStreamHandler,
 };
 use tracing::{info, warn};
@@ -24,7 +28,7 @@ use crate::server::{
   session_context::{PendingRequest, SessionContext},
 };
 use std::sync::Arc;
-mod fetch_handler;
+pub(crate) mod fetch_handler;
 mod publish_handler;
 mod publish_namespace_handler;
 mod subscribe_handler;
@@ -157,11 +161,22 @@ impl MessageHandler {
               target_req_id
             );
 
-            // Draft-16: Unknown Update = ProtocolViolation. Unknown Response = Ignore.
-            if !is_response_to_relay {
-              Err(TerminationCode::ProtocolViolation)
-            } else {
-              Ok(())
+            // A REQUEST_UPDATE that cannot be applied (e.g. a TRACK_STATUS target,
+            // or an unknown request) is answered with REQUEST_ERROR; an unknown
+            // response is ignored.
+            match &msg {
+              ControlMessage::RequestUpdate(m) => {
+                let err = RequestError::new(
+                  m.request_id,
+                  RequestErrorCode::NotSupported,
+                  0,
+                  ReasonPhrase::try_new("REQUEST_UPDATE is not applicable".to_string()).unwrap(),
+                );
+                control_stream_handler
+                  .send(&ControlMessage::RequestError(Box::new(err)))
+                  .await
+              }
+              _ => Ok(()),
             }
           }
         }

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -36,7 +36,7 @@ use tracing::{debug, info, warn};
 
 pub async fn handle(
   client: Arc<MOQTClient>,
-  control_stream_handler: &mut ControlStreamHandler,
+  stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -57,7 +57,7 @@ pub async fn handle(
           0,
           reason_phrase,
         ));
-        return control_stream_handler
+        return stream_handler
           .send(&ControlMessage::RequestError(publish_error))
           .await;
       }
@@ -78,7 +78,7 @@ pub async fn handle(
           reason_phrase,
         ));
 
-        return control_stream_handler
+        return stream_handler
           .send(&ControlMessage::RequestError(publish_error))
           .await;
       }
@@ -274,7 +274,7 @@ pub async fn handle(
         m_clone.track_name, m_clone.track_alias
       );
 
-      control_stream_handler
+      stream_handler
         .send(&ControlMessage::RequestOk(publish_ok))
         .await
     }
@@ -466,7 +466,7 @@ pub async fn handle(
 
       use moqtail::model::control::request_ok::RequestOk;
       let ok_msg = RequestOk::new(update_req_id, vec![]);
-      control_stream_handler
+      stream_handler
         .send(&ControlMessage::RequestOk(Box::new(ok_msg)))
         .await?;
 

--- a/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
@@ -25,7 +25,7 @@ use tracing::{debug, info, warn};
 
 pub async fn handle(
   client: Arc<MOQTClient>,
-  control_stream_handler: &mut ControlStreamHandler,
+  stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -89,7 +89,7 @@ pub async fn handle(
         vec![], // No parameters needed for a basic namespace OK
       ));
 
-      control_stream_handler
+      stream_handler
         .send(&ControlMessage::RequestOk(request_ok))
         .await
     }
@@ -146,7 +146,7 @@ pub async fn handle(
               "REQUEST_UPDATE for PUBLISH_NAMESPACE request {} cannot be applied; closing the stream",
               existing_req_id
             );
-            control_stream_handler.reset(StreamResetCode::Cancelled.to_u64());
+            stream_handler.reset(StreamResetCode::Cancelled.to_u64());
             return Ok(());
           }
         }
@@ -204,7 +204,7 @@ pub async fn handle(
       }
 
       let ok_msg = RequestOk::new(update_req_id, vec![]);
-      control_stream_handler
+      stream_handler
         .send(&ControlMessage::RequestOk(Box::new(ok_msg)))
         .await?;
 

--- a/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
@@ -17,7 +17,7 @@ use crate::server::session_context::{PendingRequest, SessionContext};
 use core::result::Result;
 use moqtail::model::control::namespace::Namespace;
 use moqtail::model::control::{control_message::ControlMessage, request_ok::RequestOk};
-use moqtail::model::error::TerminationCode;
+use moqtail::model::error::{StreamResetCode, TerminationCode};
 use moqtail::model::parameter::message_parameter::apply_message_parameter_update;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use std::sync::Arc;
@@ -143,10 +143,11 @@ pub async fn handle(
           }
           _ => {
             warn!(
-              "Request {} is not a valid PublishNamespace request",
+              "REQUEST_UPDATE for PUBLISH_NAMESPACE request {} cannot be applied; closing the stream",
               existing_req_id
             );
-            return Err(TerminationCode::ProtocolViolation);
+            control_stream_handler.reset(StreamResetCode::Cancelled.to_u64());
+            return Ok(());
           }
         }
       };

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -115,7 +115,7 @@ async fn forward_subscribe_upstream(
 
 async fn handle_subscribe_message(
   client: Arc<MOQTClient>,
-  control_stream_handler: &mut ControlStreamHandler,
+  stream_handler: &mut ControlStreamHandler,
   sub: Subscribe,
   context: Arc<SessionContext>,
   is_switch: bool,
@@ -168,10 +168,7 @@ async fn handle_subscribe_message(
       0, //TODO: Maybe decide on another retry interval?
       ReasonPhrase::try_new("Unknown track namespace".to_string()).unwrap(),
     );
-    control_stream_handler
-      .send_impl(&subscribe_error)
-      .await
-      .unwrap();
+    stream_handler.send_impl(&subscribe_error).await.unwrap();
     return Ok(());
   };
 
@@ -273,7 +270,7 @@ async fn handle_subscribe_message(
           params,
           cached_properties,
         );
-        control_stream_handler.send_impl(&subscribe_ok).await
+        stream_handler.send_impl(&subscribe_ok).await
       }
       TrackStatus::Pending => {
         info!(
@@ -298,7 +295,7 @@ async fn handle_subscribe_message(
           0, //TODO: Maybe decide on another retry interval?
           reason_phrase,
         );
-        control_stream_handler.send_impl(&subscribe_error).await
+        stream_handler.send_impl(&subscribe_error).await
       }
     }
   };
@@ -329,7 +326,7 @@ async fn handle_subscribe_message(
 async fn handle_subscribe_ok_message(
   // The publisher that sent this SUBSCRIBE_OK; its connection id keys the track alias.
   publisher: Arc<MOQTClient>,
-  _control_stream_handler: &mut ControlStreamHandler,
+  _stream_handler: &mut ControlStreamHandler,
   msg: moqtail::model::control::subscribe_ok::SubscribeOk,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -373,7 +370,7 @@ async fn handle_subscribe_ok_message(
       0,
       reason,
     );
-    return handle_subscribe_error_message(publisher, _control_stream_handler, err, context).await;
+    return handle_subscribe_error_message(publisher, _stream_handler, err, context).await;
   }
 
   let full_track_name = sub_request.original_subscribe_request.get_full_track_name();
@@ -506,7 +503,7 @@ async fn handle_subscribe_ok_message(
 
 async fn handle_unsubscribe_message(
   client: Arc<MOQTClient>,
-  _control_stream_handler: &mut ControlStreamHandler,
+  _stream_handler: &mut ControlStreamHandler,
   unsubscribe_message: moqtail::model::control::unsubscribe::Unsubscribe,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -568,7 +565,7 @@ async fn handle_unsubscribe_message(
 
 pub async fn handle_request_update(
   client: Arc<MOQTClient>,
-  control_stream_handler: &mut ControlStreamHandler,
+  stream_handler: &mut ControlStreamHandler,
   update_msg: moqtail::model::control::request_update::RequestUpdate,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -638,7 +635,7 @@ pub async fn handle_request_update(
         full_track_name
       );
       let ok_msg = RequestOk::new(update_req_id, vec![]);
-      let _ = control_stream_handler.send_impl(&ok_msg).await;
+      let _ = stream_handler.send_impl(&ok_msg).await;
     }
     Some(Err(e)) => {
       error!(
@@ -653,7 +650,7 @@ pub async fn handle_request_update(
         ReasonPhrase::try_new(format!("Update failed: {:?}", e))
           .unwrap_or_else(|_| ReasonPhrase::try_new("Update failed".to_string()).unwrap()),
       );
-      let _ = control_stream_handler.send_impl(&err_msg).await;
+      let _ = stream_handler.send_impl(&err_msg).await;
 
       // A failed update terminates the subscription with PUBLISH_DONE(UPDATE_FAILED).
       let done = PublishDone::new(
@@ -662,7 +659,7 @@ pub async fn handle_request_update(
         0,
         ReasonPhrase::try_new("REQUEST_UPDATE failed".to_string()).unwrap(),
       );
-      let _ = control_stream_handler.send_impl(&done).await;
+      let _ = stream_handler.send_impl(&done).await;
 
       track_arc
         .write()
@@ -686,7 +683,7 @@ pub async fn handle_request_update(
         0,
         ReasonPhrase::try_new("Subscription not found".to_string()).unwrap(),
       );
-      let _ = control_stream_handler.send_impl(&err_msg).await;
+      let _ = stream_handler.send_impl(&err_msg).await;
     }
   }
 
@@ -694,7 +691,7 @@ pub async fn handle_request_update(
 }
 async fn handle_subscribe_error_message(
   _client: Arc<MOQTClient>,
-  _control_stream_handler: &mut ControlStreamHandler,
+  _stream_handler: &mut ControlStreamHandler,
   subscribe_error_message: RequestError,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -795,7 +792,7 @@ async fn handle_subscribe_error_message(
 
 async fn handle_switch_message(
   client: Arc<MOQTClient>,
-  control_stream_handler: &mut ControlStreamHandler,
+  stream_handler: &mut ControlStreamHandler,
   switch_message: moqtail::model::control::switch::Switch,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -890,7 +887,7 @@ async fn handle_switch_message(
 
   if let Err(e) = handle_subscribe_message(
     client.clone(),
-    control_stream_handler,
+    stream_handler,
     subscribe,
     context.clone(),
     true, // is_switch
@@ -921,29 +918,27 @@ async fn handle_switch_message(
 
 pub async fn handle(
   client: Arc<MOQTClient>,
-  control_stream_handler: &mut ControlStreamHandler,
+  stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
   match msg {
     ControlMessage::Subscribe(m) => {
-      handle_subscribe_message(client, control_stream_handler, *m, context, false).await
+      handle_subscribe_message(client, stream_handler, *m, context, false).await
     }
     ControlMessage::SubscribeOk(m) => {
-      handle_subscribe_ok_message(client, control_stream_handler, *m, context).await
+      handle_subscribe_ok_message(client, stream_handler, *m, context).await
     }
     ControlMessage::Unsubscribe(m) => {
-      handle_unsubscribe_message(client, control_stream_handler, *m, context).await
+      handle_unsubscribe_message(client, stream_handler, *m, context).await
     }
     ControlMessage::RequestUpdate(m) => {
-      handle_request_update(client, control_stream_handler, *m, context).await
+      handle_request_update(client, stream_handler, *m, context).await
     }
     ControlMessage::RequestError(m) => {
-      handle_subscribe_error_message(client, control_stream_handler, *m, context).await
+      handle_subscribe_error_message(client, stream_handler, *m, context).await
     }
-    ControlMessage::Switch(m) => {
-      handle_switch_message(client, control_stream_handler, *m, context).await
-    }
+    ControlMessage::Switch(m) => handle_switch_message(client, stream_handler, *m, context).await,
     _ => {
       // no-op
       Ok(())

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -19,7 +19,10 @@ use crate::server::session_context::{PendingRequest, SessionContext};
 use crate::server::track::{Track, TrackStatus};
 use core::result::Result;
 use moqtail::model::common::location::Location;
+use moqtail::model::control::constant::PublishDoneStatusCode;
+use moqtail::model::control::publish_done::PublishDone;
 use moqtail::model::control::request_error::RequestError;
+use moqtail::model::control::request_ok::RequestOk;
 use moqtail::model::control::subscribe::Subscribe;
 use moqtail::model::error::RequestErrorCode;
 use moqtail::model::error::TerminationCode;
@@ -611,52 +614,80 @@ pub async fn handle_request_update(
   }
 
   let track_arc = track_lock.unwrap();
-  let track_guard = track_arc.read().await;
 
-  // 3. Update the actual active edge subscription
-  if let Some(subscription) = track_guard.get_subscription(client.connection_id).await {
-    let sub = subscription.read().await;
-
-    match sub.update_subscription(update_msg.clone()).await {
-      Ok(_) => {
-        info!(
-          "Subscription updated successfully for track: {:?}",
-          full_track_name
-        );
-
-        use moqtail::model::control::request_ok::RequestOk;
-        let ok_msg = RequestOk::new(update_req_id, vec![]);
-        let _ = control_stream_handler.send_impl(&ok_msg).await;
-      }
-      Err(e) => {
-        error!(
-          "Subscription update failed for track: {:?}, error: {:?}",
-          full_track_name, e
-        );
-
-        let err_msg = RequestError::new(
-          update_req_id,
-          RequestErrorCode::InternalError,
-          0,
-          ReasonPhrase::try_new(format!("Update failed: {:?}", e))
-            .unwrap_or_else(|_| ReasonPhrase::try_new("Update failed".to_string()).unwrap()),
-        );
-        let _ = control_stream_handler.send_impl(&err_msg).await;
-      }
+  // Apply the update, releasing the track/sub read locks before responding or
+  // terminating so termination can take the track write lock.
+  let update_result = {
+    let track_guard = track_arc.read().await;
+    match track_guard.get_subscription(client.connection_id).await {
+      Some(subscription) => Some(
+        subscription
+          .read()
+          .await
+          .update_subscription(update_msg)
+          .await,
+      ),
+      None => None,
     }
-  } else {
-    warn!(
-      "No active subscription found for client {} on track {:?}",
-      client.connection_id, full_track_name
-    );
+  };
 
-    let err_msg = RequestError::new(
-      update_req_id,
-      RequestErrorCode::DoesNotExist,
-      0,
-      ReasonPhrase::try_new("Subscription not found".to_string()).unwrap(),
-    );
-    let _ = control_stream_handler.send_impl(&err_msg).await;
+  match update_result {
+    Some(Ok(())) => {
+      info!(
+        "Subscription updated successfully for track: {:?}",
+        full_track_name
+      );
+      let ok_msg = RequestOk::new(update_req_id, vec![]);
+      let _ = control_stream_handler.send_impl(&ok_msg).await;
+    }
+    Some(Err(e)) => {
+      error!(
+        "Subscription update failed for track: {:?}, error: {:?}",
+        full_track_name, e
+      );
+
+      let err_msg = RequestError::new(
+        update_req_id,
+        RequestErrorCode::InternalError,
+        0,
+        ReasonPhrase::try_new(format!("Update failed: {:?}", e))
+          .unwrap_or_else(|_| ReasonPhrase::try_new("Update failed".to_string()).unwrap()),
+      );
+      let _ = control_stream_handler.send_impl(&err_msg).await;
+
+      // A failed update terminates the subscription with PUBLISH_DONE(UPDATE_FAILED).
+      let done = PublishDone::new(
+        existing_req_id,
+        PublishDoneStatusCode::UpdateFailed,
+        0,
+        ReasonPhrase::try_new("REQUEST_UPDATE failed".to_string()).unwrap(),
+      );
+      let _ = control_stream_handler.send_impl(&done).await;
+
+      track_arc
+        .write()
+        .await
+        .remove_subscription(client.connection_id)
+        .await;
+      client
+        .subscriptions
+        .remove_subscription(&full_track_name)
+        .await;
+    }
+    None => {
+      warn!(
+        "No active subscription found for client {} on track {:?}",
+        client.connection_id, full_track_name
+      );
+
+      let err_msg = RequestError::new(
+        update_req_id,
+        RequestErrorCode::DoesNotExist,
+        0,
+        ReasonPhrase::try_new("Subscription not found".to_string()).unwrap(),
+      );
+      let _ = control_stream_handler.send_impl(&err_msg).await;
+    }
   }
 
   Ok(())

--- a/apps/relay/src/server/message_handlers/subscribe_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_namespace_handler.rs
@@ -21,8 +21,8 @@ use moqtail::model::control::namespace::Namespace;
 use moqtail::model::control::request_error::RequestError;
 use moqtail::model::control::request_ok::RequestOk;
 use moqtail::model::control::subscribe_namespace::SubscribeNamespace;
-use moqtail::model::error::RequestErrorCode;
 use moqtail::model::error::TerminationCode;
+use moqtail::model::error::{RequestErrorCode, StreamResetCode};
 use moqtail::model::parameter::message_parameter::apply_message_parameter_update;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use std::sync::Arc;
@@ -255,10 +255,11 @@ pub async fn handle(
           }
           _ => {
             warn!(
-              "Request {} is not a valid SubscribeNamespace request",
+              "REQUEST_UPDATE for SUBSCRIBE_NAMESPACE request {} cannot be applied; closing the stream",
               existing_req_id
             );
-            return Err(TerminationCode::ProtocolViolation);
+            handler.reset(StreamResetCode::Cancelled.to_u64());
+            return Ok(());
           }
         }
       };

--- a/apps/relay/src/server/message_handlers/track_status_handler.rs
+++ b/apps/relay/src/server/message_handlers/track_status_handler.rs
@@ -223,12 +223,36 @@ pub async fn handle(
 
     ControlMessage::RequestUpdate(m) => {
       warn!(
-        "Protocol Violation: Client attempted to update TrackStatus request ID {}",
+        "REQUEST_UPDATE is not valid for a TRACK_STATUS request (id {})",
         m.existing_request_id
       );
-      Err(TerminationCode::ProtocolViolation)
+      let err = track_status_update_error(m.request_id);
+      control_stream_handler
+        .send(&ControlMessage::RequestError(Box::new(err)))
+        .await
     }
 
     _ => Ok(()),
+  }
+}
+
+fn track_status_update_error(request_id: u64) -> RequestError {
+  RequestError::new(
+    request_id,
+    RequestErrorCode::NotSupported,
+    0,
+    ReasonPhrase::try_new("TRACK_STATUS does not support REQUEST_UPDATE".to_string()).unwrap(),
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn request_update_on_track_status_is_not_supported() {
+    let err = track_status_update_error(42);
+    assert_eq!(err.request_id, 42);
+    assert_eq!(err.error_code, RequestErrorCode::NotSupported);
   }
 }

--- a/apps/relay/src/server/message_handlers/track_status_handler.rs
+++ b/apps/relay/src/server/message_handlers/track_status_handler.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 pub async fn handle(
-  control_stream_handler: &mut ControlStreamHandler,
+  stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -50,7 +50,7 @@ pub async fn handle(
         )];
 
         let ok_msg = RequestOk::new(request_id, params);
-        control_stream_handler
+        stream_handler
           .send(&ControlMessage::RequestOk(Box::new(ok_msg)))
           .await
           .unwrap();
@@ -81,7 +81,7 @@ pub async fn handle(
           0, //TODO: Maybe decide on another retry interval?
           ReasonPhrase::try_new("No publisher found".to_string()).unwrap(),
         );
-        control_stream_handler.send_impl(&err).await.unwrap();
+        stream_handler.send_impl(&err).await.unwrap();
         return Ok(());
       };
 
@@ -227,7 +227,7 @@ pub async fn handle(
         m.existing_request_id
       );
       let err = track_status_update_error(m.request_id);
-      control_stream_handler
+      stream_handler
         .send(&ControlMessage::RequestError(Box::new(err)))
         .await
     }

--- a/libs/moqtail-rs/src/transport/control_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/control_stream_handler.rs
@@ -55,6 +55,14 @@ impl ControlStreamHandler {
     Ok(())
   }
 
+  /// Resets this request stream with an application error code (QUIC
+  /// RESET_STREAM). Used to abort a request, e.g. a failed REQUEST_UPDATE.
+  pub fn reset(&mut self, code: u64) {
+    if let Err(e) = self.send.reset(code) {
+      warn!("Error resetting request stream: {:?}", e);
+    }
+  }
+
   // TODO: refactor here, implement Serializable trait for ControlMessage
   pub async fn send_impl(
     &mut self,


### PR DESCRIPTION
Reject REQUEST_UPDATE for TRACK_STATUS with REQUEST_ERROR(NotSupported) instead of tearing down the session, since TRACK_STATUS is not an updatable request type.

Wire the per-request-type failure behaviors: a failed SUBSCRIBE update terminates the subscription with PUBLISH_DONE(UPDATE_FAILED); a failed FETCH update stops delivery and resets the uni object stream; a failed PUBLISH_NAMESPACE or SUBSCRIBE_NAMESPACE update closes the request bidi stream.

<!-- Please describe your changes in detail. Include motivation and context. -->

<!------------------------------------------------------------------------------
If you are contributing a new feature or fixing an issue, please provide references
to the relevant specifications, documentation, or issues. This helps maintainers
get familiar with the context of your changes.

Thank you for your contribution!
-------------------------------------------------------------------------------->
