### PR TITLE
feat: remove Request ID from response messages (#242)

### DIFF
--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -21,6 +21,7 @@ use moqtail::model::common::tuple::{Tuple, TupleField};
 use moqtail::model::control::control_message::ControlMessage;
 use moqtail::model::control::publish::Publish;
 use moqtail::model::control::publish_namespace::PublishNamespace;
+use moqtail::model::control::request_ok::RequestOk;
 use moqtail::model::control::subscribe_ok::SubscribeOk;
 use moqtail::model::data::datagram::Datagram;
 use moqtail::model::data::object::Object;
@@ -106,7 +107,7 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
             m.request_id, m.track_name, track_alias
           );
 
-          let ok = SubscribeOk::new(m.request_id, track_alias, vec![], vec![]);
+          let ok = SubscribeOk::new(track_alias, vec![], vec![]);
           if let Err(e) = request_stream.send_impl(&ok).await {
             error!("Failed to send SubscribeOk: {:?}", e);
             return;
@@ -119,6 +120,28 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
           // Serve data; keep the request stream open until the objects are sent.
           if let Err(e) = send_data(&conn, track_alias, &dc).await {
             error!("Data sending failed: {:?}", e);
+          }
+          drop(request_stream);
+        }
+        Ok(ControlMessage::TrackStatus(m)) => {
+          info!(
+            "Received TrackStatus on request stream for track={:?}",
+            m.track_name
+          );
+          let ok = RequestOk::new(vec![]);
+          if let Err(e) = request_stream.send_impl(&ok).await {
+            error!("Failed to send TrackStatus RequestOk: {:?}", e);
+          }
+          drop(request_stream);
+        }
+        Ok(ControlMessage::Publish(m)) => {
+          info!(
+            "Received pushed Publish on request stream for track={:?}",
+            m.track_name
+          );
+          let ok = RequestOk::new(vec![]);
+          if let Err(e) = request_stream.send_impl(&ok).await {
+            error!("Failed to send PublishOk: {:?}", e);
           }
           drop(request_stream);
         }
@@ -182,7 +205,6 @@ async fn publish_namespace(
 ) -> Result<ControlStreamHandler> {
   info!("Publishing namespace...");
   let publish_namespace = PublishNamespace::new(0, namespace.clone(), &[]);
-  let expected_request_id = publish_namespace.request_id;
 
   let (send, recv) = connection.open_bi().await?;
   let mut request_stream = ControlStreamHandler::new(send, recv);
@@ -193,17 +215,11 @@ async fn publish_namespace(
     .await
     .map_err(|e| anyhow::anyhow!("Failed to send PUBLISH_NAMESPACE: {:?}", e))?;
 
+  // The response returns on this same request stream, so it needs no request id.
   match request_stream.next_message().await {
-    Ok(ControlMessage::RequestOk(ok)) if ok.request_id == expected_request_id => {
+    Ok(ControlMessage::RequestOk(_)) => {
       info!("Namespace published successfully");
       Ok(request_stream)
-    }
-    Ok(ControlMessage::RequestOk(ok)) => {
-      anyhow::bail!(
-        "PublishNamespace got RequestOk for another request ID: expected {}, got {}",
-        expected_request_id,
-        ok.request_id
-      )
     }
     Ok(m) => anyhow::bail!("Expected RequestOk, got {:?}", m),
     Err(e) => anyhow::bail!("Failed waiting for RequestOk: {:?}", e),
@@ -250,7 +266,7 @@ async fn publish_track(
     Ok(ControlMessage::RequestOk(m)) => {
       m.validate_track_properties(false)
         .map_err(|_| anyhow::anyhow!("PUBLISH_OK carried Track Properties"))?;
-      info!("Track published, request_id: {}", m.request_id);
+      info!("Track published");
     }
     Ok(m) => anyhow::bail!("Expected REQUEST_OK, got {:?}", m),
     Err(e) => anyhow::bail!("Failed waiting for REQUEST_OK: {:?}", e),

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -195,13 +195,7 @@ pub async fn handle(
 
       // Send FetchOk on the request stream before delivering objects.
       {
-        let fetch_ok = FetchOk::new(
-          request_id,
-          false,
-          end_location.clone().unwrap(),
-          vec![],
-          vec![],
-        );
+        let fetch_ok = FetchOk::new(false, end_location.clone().unwrap(), vec![], vec![]);
         stream_handler
           .send(&ControlMessage::FetchOk(Box::new(fetch_ok)))
           .await?;
@@ -518,21 +512,13 @@ pub async fn handle(
             client.remove_stream_by_stream_id(&stream_id).await;
           }
         } else if object_count == 0 {
-          // Draft 16: If range is valid but empty, send FETCH_OK + Empty Stream with FIN.
+          // Range is valid but empty: FETCH_OK was already sent on the request
+          // stream, so just open the data stream, write the header, and FIN.
           info!(
-            "handle_fetch_messages | Empty range for request_id: {}. Sending FETCH_OK and empty stream.",
+            "handle_fetch_messages | Empty range for request_id: {}. Sending empty stream.",
             request_id
           );
 
-          // 1. Send FETCH_OK
-          let end_loc = start_location.clone();
-          let fetch_ok = FetchOk::new(request_id, false, end_loc, vec![], vec![]);
-
-          client
-            .queue_message(ControlMessage::FetchOk(Box::new(fetch_ok)))
-            .await;
-
-          // 2. Open Stream, Write Header, and Close (FIN)
           if let Some(the_stream) = stream_fn(client.clone(), &stream_id).await {
             let mut stream_lock = the_stream.lock().await;
             if let Err(e) = stream_lock.finish().await {
@@ -612,25 +598,6 @@ pub async fn handle(
           "handle_fetch_messages | FetchCancel received but no active fetch for request_id: {}",
           request_id
         );
-      }
-
-      Ok(())
-    }
-    ControlMessage::FetchOk(m) => {
-      info!("received FetchOk message: {:?}", m);
-      let msg = *m;
-
-      // TODO: When the relay sends a fetch request to the publisher,
-      // it will wait for Fetch OK. However this is not implemented yet.
-      // Here is just a preliminary attempt for this, validating request id
-      let pending_request = {
-        let map = context.relay_pending_requests.read().await;
-        map.get(&msg.request_id).cloned()
-      };
-
-      if pending_request.is_none() {
-        error!("handle_fetch_messages | FetchOk | request_id does not exist in pending registry");
-        return Err(TerminationCode::InternalError);
       }
 
       Ok(())
@@ -769,10 +736,13 @@ async fn send_request_error(
   // TODO: Implement this later.
   // Draft 16 requires a retry interval. Setting to 0 (no retries) for now.
   let retry_interval = 0;
-  let request_error = RequestError::new(request_id, error_code, retry_interval, reason_phrase);
+  let request_error = RequestError::new(error_code, retry_interval, reason_phrase);
 
   client
-    .queue_message(ControlMessage::RequestError(Box::new(request_error)))
+    .send_response(
+      request_id,
+      ControlMessage::RequestError(Box::new(request_error)),
+    )
     .await;
   // Remove the request from the client maps on error
   client.inbound_requests.write().await.remove(&request_id);

--- a/apps/relay/src/server/message_handlers/mod.rs
+++ b/apps/relay/src/server/message_handlers/mod.rs
@@ -14,11 +14,7 @@
 
 use bytes::Bytes;
 use moqtail::{
-  model::{
-    common::reason_phrase::ReasonPhrase,
-    control::{control_message::ControlMessage, request_error::RequestError},
-    error::{RequestErrorCode, TerminationCode},
-  },
+  model::{control::control_message::ControlMessage, error::TerminationCode},
   transport::control_stream_handler::ControlStreamHandler,
 };
 use tracing::{info, warn};
@@ -54,33 +50,35 @@ impl MessageHandler {
         warn!("SUBSCRIBE_NAMESPACE received on control stream — must use a dedicated bi-stream");
         Err(TerminationCode::ProtocolViolation)
       }
-      ControlMessage::Subscribe(_)
-      | ControlMessage::SubscribeOk(_)
-      | ControlMessage::Unsubscribe(_)
-      | ControlMessage::Switch(_) => {
+      ControlMessage::Subscribe(_) | ControlMessage::Unsubscribe(_) | ControlMessage::Switch(_) => {
         subscribe_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
       }
 
       ControlMessage::TrackStatus(_) => {
         track_status_handler::handle(stream_handler, msg, context.clone()).await
       }
-      ControlMessage::Fetch(_) | ControlMessage::FetchCancel(_) | ControlMessage::FetchOk(_) => {
+      ControlMessage::Fetch(_) | ControlMessage::FetchCancel(_) => {
         fetch_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
       }
       ControlMessage::Publish(_) | ControlMessage::PublishDone(_) => {
         publish_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
       }
 
+      // A response is read on the request's own bidi stream; reaching the control
+      // stream is a disallowed action.
       ControlMessage::RequestOk(_)
       | ControlMessage::RequestError(_)
-      | ControlMessage::RequestUpdate(_) => {
-        // 1. Extract the target ID and the directionality (response vs update)
-        let (target_req_id, is_response_to_relay) = match &msg {
-          ControlMessage::RequestOk(m) => (m.request_id, true),
-          ControlMessage::RequestError(m) => (m.request_id, true),
-          ControlMessage::RequestUpdate(m) => (m.existing_request_id, false),
-          _ => unreachable!(),
-        };
+      | ControlMessage::SubscribeOk(_)
+      | ControlMessage::FetchOk(_) => {
+        warn!(
+          "{:?} on the control stream; closing session",
+          msg.get_type()
+        );
+        Err(TerminationCode::ProtocolViolation)
+      }
+
+      ControlMessage::RequestUpdate(m) => {
+        let target_req_id = m.existing_request_id;
 
         enum Route {
           Fetch,
@@ -92,7 +90,7 @@ impl MessageHandler {
           NotFound,
         }
 
-        // 2. Helper closure to map a PendingRequest to a Route
+        // Map a PendingRequest to a Route
         let determine_route = |req: Option<&PendingRequest>| match req {
           Some(PendingRequest::Fetch(_)) => Route::Fetch,
           Some(PendingRequest::Publish { .. }) => Route::Publish,
@@ -104,16 +102,12 @@ impl MessageHandler {
           None => Route::NotFound,
         };
 
-        // 3. Lock the appropriate map, determine the route, and immediately drop the lock
-        let route = if is_response_to_relay {
-          let map = context.relay_pending_requests.read().await;
-          determine_route(map.get(&target_req_id))
-        } else {
+        let route = {
           let map = client.inbound_requests.read().await;
           determine_route(map.get(&target_req_id))
         };
 
-        // 4. Route to the appropriate handler (defined only once!)
+        // Route to the appropriate handler (defined only once!)
         match route {
           Route::Fetch => {
             fetch_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
@@ -141,29 +135,13 @@ impl MessageHandler {
             track_status_handler::handle(stream_handler, msg, context.clone()).await
           }
           Route::NotFound => {
+            // A REQUEST_UPDATE referencing an unknown request is disallowed: it
+            // must travel on the request's own stream.
             warn!(
-              "Router received generic message ({:?}) for untracked ID: {}",
-              msg.get_type(),
+              "REQUEST_UPDATE for untracked request id {}; closing session",
               target_req_id
             );
-
-            // A REQUEST_UPDATE that cannot be applied (e.g. a TRACK_STATUS target,
-            // or an unknown request) is answered with REQUEST_ERROR; an unknown
-            // response is ignored.
-            match &msg {
-              ControlMessage::RequestUpdate(m) => {
-                let err = RequestError::new(
-                  m.request_id,
-                  RequestErrorCode::NotSupported,
-                  0,
-                  ReasonPhrase::try_new("REQUEST_UPDATE is not applicable".to_string()).unwrap(),
-                );
-                stream_handler
-                  .send(&ControlMessage::RequestError(Box::new(err)))
-                  .await
-              }
-              _ => Ok(()),
-            }
+            Err(TerminationCode::ProtocolViolation)
           }
         }
       }

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -22,6 +22,7 @@ use moqtail::model::common::reason_phrase::ReasonPhrase;
 use moqtail::model::control::{
   constant::{FilterType, GroupOrder},
   control_message::ControlMessage,
+  publish::Publish,
   request_error::RequestError,
   request_ok::RequestOk,
 };
@@ -32,7 +33,7 @@ use moqtail::model::parameter::message_parameter::{MessageParameter, MessagePara
 use moqtail::model::property::track_property::has_unsupported_mandatory;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use std::sync::Arc;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 pub async fn handle(
   client: Arc<MOQTClient>,
@@ -52,7 +53,6 @@ pub async fn handle(
           ReasonPhrase::try_new("Unsupported mandatory track property".to_string())
             .map_err(|_| TerminationCode::InternalError)?;
         let publish_error = Box::new(RequestError::new(
-          request_id,
           RequestErrorCode::UnsupportedExtension,
           0,
           reason_phrase,
@@ -72,7 +72,6 @@ pub async fn handle(
             .map_err(|_| TerminationCode::InternalError)?;
 
         let publish_error = Box::new(RequestError::new(
-          request_id,
           RequestErrorCode::Unauthorized,
           0, //TODO: Maybe decide on another retry interval?
           reason_phrase,
@@ -208,13 +207,6 @@ pub async fn handle(
             );
           }
 
-          let m_clone2 = m_clone.clone();
-          tokio::spawn(async move {
-            sub_clone
-              .queue_message(ControlMessage::Publish(m_clone2))
-              .await;
-          });
-
           let track_write = track_arc.read().await;
           if let Err(e) = track_write
             .add_subscription(subscriber.clone(), (*m_clone).clone(), false)
@@ -225,6 +217,12 @@ pub async fn handle(
               subscriber.connection_id, e
             );
           }
+
+          // Push the PUBLISH on its own bidi stream and read PUBLISH_OK there.
+          let push_msg = *m_clone.clone();
+          tokio::spawn(async move {
+            forward_publish_downstream(sub_clone, push_msg).await;
+          });
         }
       } else {
         // Another publisher for the same track with a different alias.
@@ -259,15 +257,12 @@ pub async fn handle(
         MessageParameter::new_forward(true),
       );
       // PUBLISH is answered by REQUEST_OK (PUBLISH_OK); no Track Properties.
-      let publish_ok = Box::new(RequestOk::new(
-        request_id,
-        vec![
-          publish_forward_param,
-          MessageParameter::new_subscriber_priority(5),
-          MessageParameter::new_group_order(GroupOrder::Ascending),
-          MessageParameter::new_subscription_filter(FilterType::LatestObject, None, None),
-        ],
-      ));
+      let publish_ok = Box::new(RequestOk::new(vec![
+        publish_forward_param,
+        MessageParameter::new_subscriber_priority(5),
+        MessageParameter::new_group_order(GroupOrder::Ascending),
+        MessageParameter::new_subscription_filter(FilterType::LatestObject, None, None),
+      ]));
 
       info!(
         "Accepted publish request for track: {:?} with alias: {}",
@@ -301,74 +296,9 @@ pub async fn handle(
       Ok(())
     }
 
-    // PUBLISH_OK arrives as a REQUEST_OK (routed here by request type). Track
-    // Properties are only valid in TRACK_STATUS_OK, so they must be empty here.
-    ControlMessage::RequestOk(m) => {
-      info!("Received PublishOk for request_id: {}", m.request_id);
-      if m.validate_track_properties(false).is_err() {
-        return Err(TerminationCode::ProtocolViolation);
-      }
-
-      let pending_request = {
-        let map = context.relay_pending_requests.read().await;
-        map.get(&m.request_id).cloned()
-      };
-
-      match pending_request {
-        Some(PendingRequest::Publish { .. }) => {
-          // 1. Look up which track this PublishOk corresponds to using the connection_id and request_id
-          if let Some(full_track_name) = context
-            .track_manager
-            .get_track_name_by_publisher(client.connection_id, m.request_id)
-            .await
-          {
-            // 2. Fetch the track and the original publish message details
-            if let Some(track_arc) = context.track_manager.get_track(&full_track_name).await
-              && let Some(orig_publish) = context
-                .track_manager
-                .get_publish_message(&full_track_name, client.connection_id)
-                .await
-            {
-              info!(
-                "Publish accepted! Wiring up data stream for: {:?}",
-                full_track_name
-              );
-
-              let track_read = track_arc.read().await;
-              if let Err(e) = track_read
-                .add_subscription(client.clone(), orig_publish.clone(), false)
-                .await
-              {
-                warn!("Failed to auto-subscribe client after PublishOk: {:?}", e);
-              } else {
-                info!("Successfully wired data stream!");
-              }
-            }
-          } else {
-            warn!(
-              "Received PublishOk for an unknown push request_id: {}",
-              m.request_id
-            );
-          }
-        }
-        Some(_) => {
-          warn!("Mismatched request type for PublishOk: {}", m.request_id);
-        }
-        None => {
-          warn!(
-            "Received PublishOk for untracked request_id: {}",
-            m.request_id
-          );
-        }
-      }
-
-      Ok(())
-    }
-
     ControlMessage::RequestUpdate(m) => {
       let update_msg = *m;
       let publisher_req_id = update_msg.existing_request_id;
-      let update_req_id = update_msg.request_id;
 
       {
         let mut map = client.inbound_requests.write().await;
@@ -465,7 +395,7 @@ pub async fn handle(
       }
 
       use moqtail::model::control::request_ok::RequestOk;
-      let ok_msg = RequestOk::new(update_req_id, vec![]);
+      let ok_msg = RequestOk::new(vec![]);
       stream_handler
         .send(&ControlMessage::RequestOk(Box::new(ok_msg)))
         .await?;
@@ -473,6 +403,47 @@ pub async fn handle(
       Ok(())
     }
     _ => Ok(()),
+  }
+}
+
+/// Push a PUBLISH to a subscriber on its own bidirectional request stream and
+/// read the PUBLISH_OK (or REQUEST_ERROR) there. The subscription is already
+/// wired before this runs; a rejection is logged.
+async fn forward_publish_downstream(subscriber: Arc<MOQTClient>, publish: Publish) {
+  let (send, recv) = match subscriber.connection.open_bi().await {
+    Ok(streams) => streams,
+    Err(e) => {
+      error!("Failed to open downstream publish stream: {:?}", e);
+      return;
+    }
+  };
+  let mut stream = ControlStreamHandler::new(send, recv);
+  if let Err(e) = stream
+    .send(&ControlMessage::Publish(Box::new(publish)))
+    .await
+  {
+    error!("Failed to push PUBLISH downstream: {:?}", e);
+    return;
+  }
+
+  match stream.next_message().await {
+    Ok(ControlMessage::RequestOk(_)) => {
+      info!(
+        "Pushed PUBLISH accepted by subscriber {}",
+        subscriber.connection_id
+      );
+    }
+    Ok(ControlMessage::RequestError(m)) => {
+      warn!(
+        "Subscriber {} rejected pushed PUBLISH: {:?}",
+        subscriber.connection_id, m.error_code
+      );
+    }
+    Ok(other) => warn!(
+      "Unexpected {:?} on downstream publish stream",
+      other.get_type()
+    ),
+    Err(_) => debug!("Downstream publish stream closed"),
   }
 }
 

--- a/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
@@ -21,7 +21,7 @@ use moqtail::model::error::{StreamResetCode, TerminationCode};
 use moqtail::model::parameter::message_parameter::apply_message_parameter_update;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use std::sync::Arc;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 pub async fn handle(
   client: Arc<MOQTClient>,
@@ -84,55 +84,16 @@ pub async fn handle(
         }
       }
 
-      let request_ok = Box::new(RequestOk::new(
-        m.request_id,
-        vec![], // No parameters needed for a basic namespace OK
-      ));
+      let request_ok = Box::new(RequestOk::new(vec![]));
 
       stream_handler
         .send(&ControlMessage::RequestOk(request_ok))
         .await
     }
 
-    ControlMessage::RequestOk(m) => {
-      let msg = *m;
-
-      let mapping = {
-        let mut map = context.relay_pending_requests.write().await;
-        match map.remove(&msg.request_id) {
-          Some(PendingRequest::PublishNamespace {
-            client_connection_id,
-            ..
-          }) => Some(client_connection_id),
-          Some(_) => {
-            warn!(
-              "Mismatched request type for RequestOk (PublishNamespace): {}",
-              msg.request_id
-            );
-            None
-          }
-          None => None,
-        }
-      };
-
-      if let Some(client_connection_id) = mapping {
-        debug!(
-          "Received acknowledgment (RequestOk) from subscriber {} for PublishNamespace broadcast",
-          client_connection_id
-        );
-      } else {
-        debug!(
-          "PublishNamespace handler received RequestOk for untracked ID: {}",
-          msg.request_id
-        );
-      }
-      Ok(())
-    }
-
     ControlMessage::RequestUpdate(m) => {
       let update_msg = *m;
       let existing_req_id = update_msg.existing_request_id;
-      let update_req_id = update_msg.request_id;
 
       let target_namespace = {
         let mut map = client.inbound_requests.write().await;
@@ -203,7 +164,7 @@ pub async fn handle(
         }
       }
 
-      let ok_msg = RequestOk::new(update_req_id, vec![]);
+      let ok_msg = RequestOk::new(vec![]);
       stream_handler
         .send(&ControlMessage::RequestOk(Box::new(ok_msg)))
         .await?;

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -74,6 +74,9 @@ async fn forward_subscribe_upstream(
       return;
     }
   };
+  // The response returns on this stream, so correlate it by the relay request id
+  // we sent upstream rather than a field in the response.
+  let relay_request_id = new_sub.request_id;
   let mut upstream = ControlStreamHandler::new(send, recv);
   if let Err(e) = upstream
     .send(&ControlMessage::Subscribe(Box::new(new_sub)))
@@ -87,16 +90,15 @@ async fn forward_subscribe_upstream(
     match upstream.next_message().await {
       Ok(ControlMessage::SubscribeOk(m)) => {
         if let Err(e) =
-          handle_subscribe_ok_message(publisher.clone(), &mut upstream, *m, context.clone()).await
+          handle_subscribe_ok_message(publisher.clone(), relay_request_id, *m, context.clone())
+            .await
         {
           error!("Error handling upstream SubscribeOk: {:?}", e);
           return;
         }
       }
       Ok(ControlMessage::RequestError(m)) => {
-        let _ =
-          handle_subscribe_error_message(publisher.clone(), &mut upstream, *m, context.clone())
-            .await;
+        let _ = handle_subscribe_error_message(relay_request_id, *m, context.clone()).await;
         return;
       }
       Ok(other) => {
@@ -163,7 +165,6 @@ async fn handle_subscribe_message(
     );
     // send RequestError
     let subscribe_error = RequestError::new(
-      sub.request_id,
       RequestErrorCode::DoesNotExist,
       0, //TODO: Maybe decide on another retry interval?
       ReasonPhrase::try_new("Unknown track namespace".to_string()).unwrap(),
@@ -265,7 +266,6 @@ async fn handle_subscribe_message(
         let mut params = subscribe_parameters;
         params.push(MessageParameter::new_largest_object(largest_loc));
         let subscribe_ok = moqtail::model::control::subscribe_ok::SubscribeOk::new(
-          sub.request_id,
           track.relay_track_id,
           params,
           cached_properties,
@@ -290,7 +290,6 @@ async fn handle_subscribe_message(
           client.connection_id
         );
         let subscribe_error = RequestError::new(
-          sub.request_id,
           error_code,
           0, //TODO: Maybe decide on another retry interval?
           reason_phrase,
@@ -326,12 +325,12 @@ async fn handle_subscribe_message(
 async fn handle_subscribe_ok_message(
   // The publisher that sent this SUBSCRIBE_OK; its connection id keys the track alias.
   publisher: Arc<MOQTClient>,
-  _stream_handler: &mut ControlStreamHandler,
+  // The relay request id we sent upstream; this stream identifies the request.
+  request_id: u64,
   msg: moqtail::model::control::subscribe_ok::SubscribeOk,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
   info!("received SubscribeOk message: {:?}", msg);
-  let request_id = msg.request_id;
 
   // Look up the relay subscribe request from the unified map
   let sub_request = {
@@ -364,13 +363,8 @@ async fn handle_subscribe_ok_message(
     );
     let reason = ReasonPhrase::try_new("Unsupported mandatory track property".to_string())
       .map_err(|_| TerminationCode::InternalError)?;
-    let err = RequestError::new(
-      request_id,
-      RequestErrorCode::UnsupportedExtension,
-      0,
-      reason,
-    );
-    return handle_subscribe_error_message(publisher, _stream_handler, err, context).await;
+    let err = RequestError::new(RequestErrorCode::UnsupportedExtension, 0, reason);
+    return handle_subscribe_error_message(request_id, err, context).await;
   }
 
   let full_track_name = sub_request.original_subscribe_request.get_full_track_name();
@@ -423,7 +417,6 @@ async fn handle_subscribe_ok_message(
         track.track_properties.read().await.clone()
       };
       let subscribe_ok = moqtail::model::control::subscribe_ok::SubscribeOk::new(
-        sub_request.original_request_id,
         relay_track_id,
         msg.subscribe_parameters.clone(),
         cached_properties,
@@ -471,7 +464,6 @@ async fn handle_subscribe_ok_message(
           track.track_properties.read().await.clone()
         };
         let subscribe_ok = moqtail::model::control::subscribe_ok::SubscribeOk::new(
-          subscriber_request_id,
           relay_track_id,
           msg.subscribe_parameters.clone(),
           cached_properties,
@@ -570,7 +562,6 @@ pub async fn handle_request_update(
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
   let existing_req_id = update_msg.existing_request_id;
-  let update_req_id = update_msg.request_id;
 
   let full_track_name = {
     let mut client_requests = client.subscribe_requests.write().await;
@@ -634,7 +625,7 @@ pub async fn handle_request_update(
         "Subscription updated successfully for track: {:?}",
         full_track_name
       );
-      let ok_msg = RequestOk::new(update_req_id, vec![]);
+      let ok_msg = RequestOk::new(vec![]);
       let _ = stream_handler.send_impl(&ok_msg).await;
     }
     Some(Err(e)) => {
@@ -644,7 +635,6 @@ pub async fn handle_request_update(
       );
 
       let err_msg = RequestError::new(
-        update_req_id,
         RequestErrorCode::InternalError,
         0,
         ReasonPhrase::try_new(format!("Update failed: {:?}", e))
@@ -678,7 +668,6 @@ pub async fn handle_request_update(
       );
 
       let err_msg = RequestError::new(
-        update_req_id,
         RequestErrorCode::DoesNotExist,
         0,
         ReasonPhrase::try_new("Subscription not found".to_string()).unwrap(),
@@ -690,8 +679,8 @@ pub async fn handle_request_update(
   Ok(())
 }
 async fn handle_subscribe_error_message(
-  _client: Arc<MOQTClient>,
-  _stream_handler: &mut ControlStreamHandler,
+  // The relay request id we sent upstream; this stream identifies the request.
+  request_id: u64,
   subscribe_error_message: RequestError,
   context: Arc<SessionContext>,
 ) -> Result<(), TerminationCode> {
@@ -700,7 +689,6 @@ async fn handle_subscribe_error_message(
     subscribe_error_message
   );
   let msg = subscribe_error_message;
-  let request_id = msg.request_id;
 
   // Look up and remove the relay subscribe request from the unified map
   let sub_request = {
@@ -737,7 +725,6 @@ async fn handle_subscribe_error_message(
     };
     if let Some(subscriber) = subscriber {
       let subscribe_error = RequestError::new(
-        sub_request.original_request_id,
         msg.error_code,
         0, //TODO: Maybe decide on another retry interval?
         msg.reason_phrase.clone(),
@@ -766,7 +753,6 @@ async fn handle_subscribe_error_message(
       };
       if let Some(subscriber) = subscriber {
         let subscribe_error = RequestError::new(
-          subscriber_request_id,
           msg.error_code,
           0, //TODO: Maybe decide on another retry interval?
           msg.reason_phrase.clone(),
@@ -926,17 +912,11 @@ pub async fn handle(
     ControlMessage::Subscribe(m) => {
       handle_subscribe_message(client, stream_handler, *m, context, false).await
     }
-    ControlMessage::SubscribeOk(m) => {
-      handle_subscribe_ok_message(client, stream_handler, *m, context).await
-    }
     ControlMessage::Unsubscribe(m) => {
       handle_unsubscribe_message(client, stream_handler, *m, context).await
     }
     ControlMessage::RequestUpdate(m) => {
       handle_request_update(client, stream_handler, *m, context).await
-    }
-    ControlMessage::RequestError(m) => {
-      handle_subscribe_error_message(client, stream_handler, *m, context).await
     }
     ControlMessage::Switch(m) => handle_switch_message(client, stream_handler, *m, context).await,
     _ => {

--- a/apps/relay/src/server/message_handlers/subscribe_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_namespace_handler.rs
@@ -35,12 +35,10 @@ const MAX_NAMESPACE_PREFIX_FIELDS: usize = 32;
 /// A NAMESPACE_TOO_LARGE error if the prefix exceeds what the relay will
 /// enumerate, otherwise `None`.
 fn oversized_namespace_error(
-  request_id: u64,
   prefix: &moqtail::model::common::tuple::Tuple,
 ) -> Option<RequestError> {
   if prefix.fields.len() > MAX_NAMESPACE_PREFIX_FIELDS {
     Some(RequestError::new(
-      request_id,
       RequestErrorCode::NamespaceTooLarge,
       0,
       ReasonPhrase::try_new("Namespace prefix is too large".to_string()).unwrap(),
@@ -66,7 +64,7 @@ pub async fn handle_subscribe_namespace(
 
   // An over-large namespace prefix is rejected with NAMESPACE_TOO_LARGE on the
   // request stream (not a session teardown).
-  if let Some(err) = oversized_namespace_error(sub_ns.request_id, &sub_ns.track_namespace_prefix) {
+  if let Some(err) = oversized_namespace_error(&sub_ns.track_namespace_prefix) {
     warn!(
       "SUBSCRIBE_NAMESPACE prefix has {} fields, maximum is {}",
       sub_ns.track_namespace_prefix.fields.len(),
@@ -89,7 +87,6 @@ pub async fn handle_subscribe_namespace(
       sub_ns.track_namespace_prefix, existing_prefix
     );
     let err = RequestError::new(
-      sub_ns.request_id,
       RequestErrorCode::PrefixOverlap,
       0,
       ReasonPhrase::try_new("Namespace prefix overlaps with existing subscription".to_string())
@@ -126,7 +123,7 @@ pub async fn handle_subscribe_namespace(
   }
 
   // Send REQUEST_OK on the bi-stream
-  let ok = RequestOk::new(sub_ns.request_id, vec![]);
+  let ok = RequestOk::new(vec![]);
   stream_handler
     .send(&ControlMessage::RequestOk(Box::new(ok)))
     .await?;
@@ -244,7 +241,6 @@ pub async fn handle(
     ControlMessage::RequestUpdate(m) => {
       let update_msg = *m;
       let existing_req_id = update_msg.existing_request_id;
-      let update_req_id = update_msg.request_id;
 
       let target_prefix = {
         let mut map = client.inbound_requests.write().await;
@@ -278,7 +274,7 @@ pub async fn handle(
         )
         .await;
 
-      let ok_msg = RequestOk::new(update_req_id, vec![]);
+      let ok_msg = RequestOk::new(vec![]);
       handler
         .send(&ControlMessage::RequestOk(Box::new(ok_msg)))
         .await?;
@@ -307,8 +303,7 @@ mod tests {
         .map(|i| TupleField::from_utf8(&i.to_string()))
         .collect(),
     };
-    let err = oversized_namespace_error(7, &big).expect("over-long prefix must be rejected");
-    assert_eq!(err.request_id, 7);
+    let err = oversized_namespace_error(&big).expect("over-long prefix must be rejected");
     assert_eq!(err.error_code, RequestErrorCode::NamespaceTooLarge);
     assert_eq!(u64::from(err.error_code), 0x31);
   }
@@ -321,6 +316,6 @@ mod tests {
         TupleField::from_utf8("demo"),
       ],
     };
-    assert!(oversized_namespace_error(1, &small).is_none());
+    assert!(oversized_namespace_error(&small).is_none());
   }
 }

--- a/apps/relay/src/server/message_handlers/track_status_handler.rs
+++ b/apps/relay/src/server/message_handlers/track_status_handler.rs
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::server::client::MOQTClient;
 use crate::server::session::Session;
-use crate::server::session_context::{PendingRequest, SessionContext};
+use crate::server::session_context::SessionContext;
 use core::result::Result;
 use moqtail::model::error::{RequestErrorCode, TerminationCode};
 use moqtail::model::{
   common::reason_phrase::ReasonPhrase, control::control_message::ControlMessage,
   control::request_error::RequestError, control::request_ok::RequestOk,
-  control::subscribe::Subscribe, parameter::message_parameter::MessageParameter,
+  control::track_status::TrackStatus, parameter::message_parameter::MessageParameter,
 };
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
-use moqtail::transport::data_stream_handler::SubscribeRequest;
 use std::sync::Arc;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 pub async fn handle(
   stream_handler: &mut ControlStreamHandler,
@@ -49,7 +49,7 @@ pub async fn handle(
           largest_location.clone(),
         )];
 
-        let ok_msg = RequestOk::new(request_id, params);
+        let ok_msg = RequestOk::new(params);
         stream_handler
           .send(&ControlMessage::RequestOk(Box::new(ok_msg)))
           .await
@@ -76,7 +76,6 @@ pub async fn handle(
       } else {
         info!("No publisher found for {:?}", track_namespace);
         let err = RequestError::new(
-          request_id,
           RequestErrorCode::DoesNotExist,
           0, //TODO: Maybe decide on another retry interval?
           ReasonPhrase::try_new("No publisher found".to_string()).unwrap(),
@@ -85,139 +84,17 @@ pub async fn handle(
         return Ok(());
       };
 
-      // D. Forward to Publisher
-      info!(
-        "Forwarding TrackStatus to Publisher: {}",
-        publisher.connection_id
-      );
-
+      // D. Forward to the publisher on its own bidi stream and read the response
+      // there, then deliver it to the downstream requester's request stream.
       let mut new_req = status_req.clone();
-      let relay_request_id =
+      new_req.request_id =
         Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
-      new_req.request_id = relay_request_id;
 
-      publisher
-        .queue_message(ControlMessage::TrackStatus(Box::new(new_req.clone())))
-        .await;
+      let downstream = context.get_client().await;
+      tokio::spawn(async move {
+        forward_track_status_upstream(publisher, downstream, request_id, new_req, context).await;
+      });
 
-      // E. Store Mapping
-      // We convert TrackStatus -> Subscribe to fit it into 'SubscribeRequest' container
-      let mut fake_params = vec![
-        MessageParameter::new_forward(status_req.forward),
-        MessageParameter::new_subscriber_priority(status_req.subscriber_priority),
-        MessageParameter::new_subscription_filter(
-          status_req.filter_type,
-          status_req.start_location,
-          status_req.end_group,
-        ),
-      ];
-
-      fake_params.extend(status_req.subscribe_parameters.clone());
-
-      let fake_sub = Subscribe {
-        request_id: status_req.request_id,
-        track_namespace: status_req.track_namespace,
-        track_name: status_req.track_name,
-        subscribe_parameters: fake_params,
-      };
-
-      // We also need a fake "new_sub" for the relay-side mapping
-      let mut fake_new_sub = fake_sub.clone();
-      fake_new_sub.request_id = relay_request_id;
-
-      let req_mapping = SubscribeRequest::new(
-        request_id,
-        context.connection_id,
-        fake_sub,
-        Some(fake_new_sub),
-      );
-
-      let mut map = context.relay_pending_requests.write().await;
-      map.insert(relay_request_id, PendingRequest::TrackStatus(req_mapping));
-
-      Ok(())
-    }
-    ControlMessage::RequestOk(m) => {
-      info!("received RequestOk from Publisher: {:?}", m);
-      let msg = *m;
-
-      // A. Look up who asked for this and remove it from the map
-      let mapping = {
-        let mut map = context.relay_pending_requests.write().await;
-        match map.remove(&msg.request_id) {
-          Some(PendingRequest::TrackStatus(req)) => Some(req),
-          Some(_) => {
-            warn!(
-              "Mismatched request type for TrackStatusOk: {}",
-              msg.request_id
-            );
-            None
-          }
-          None => None,
-        }
-      };
-
-      if let Some(req) = mapping {
-        // C. Find the Client
-        let manager = context.client_manager.read().await;
-        if let Some(downstream_client) = manager.get(req.requested_by).await {
-          // D. Construct Forwarded Message
-          let forwarded_msg = RequestOk::new(req.original_request_id, msg.parameters);
-
-          info!(
-            "Forwarding RequestOk (for TrackStatus) to Client {}",
-            req.requested_by
-          );
-          downstream_client
-            .queue_message(ControlMessage::RequestOk(Box::new(forwarded_msg)))
-            .await;
-        } else {
-          warn!("Downstream client {} disconnected", req.requested_by);
-        }
-      } else {
-        // we shouldn't hit this normally
-        debug!(
-          "Received RequestOk for request ID {} (Not a TrackStatus relay)",
-          msg.request_id
-        );
-      }
-      Ok(())
-    }
-    ControlMessage::RequestError(m) => {
-      info!("received RequestError from Publisher: {:?}", m);
-      let msg = *m;
-
-      let mapping = {
-        let mut map = context.relay_pending_requests.write().await;
-        match map.remove(&msg.request_id) {
-          Some(PendingRequest::TrackStatus(req)) => Some(req),
-          Some(_) => {
-            warn!(
-              "Mismatched request type for RequestError: {}",
-              msg.request_id
-            );
-            None
-          }
-          None => None,
-        }
-      };
-
-      if let Some(req) = mapping {
-        let manager = context.client_manager.read().await;
-        if let Some(downstream_client) = manager.get(req.requested_by).await {
-          let forwarded_msg = RequestError::new(
-            req.original_request_id, // <--- Restore ID
-            msg.error_code,
-            0, //TODO: Maybe decide on another retry interval?
-            msg.reason_phrase,
-          );
-
-          info!("Forwarding RequestError to Client {}", req.requested_by);
-          downstream_client
-            .queue_message(ControlMessage::RequestError(Box::new(forwarded_msg)))
-            .await;
-        }
-      }
       Ok(())
     }
 
@@ -226,7 +103,7 @@ pub async fn handle(
         "REQUEST_UPDATE is not valid for a TRACK_STATUS request (id {})",
         m.existing_request_id
       );
-      let err = track_status_update_error(m.request_id);
+      let err = track_status_update_error();
       stream_handler
         .send(&ControlMessage::RequestError(Box::new(err)))
         .await
@@ -236,9 +113,62 @@ pub async fn handle(
   }
 }
 
-fn track_status_update_error(request_id: u64) -> RequestError {
+/// Forward a TRACK_STATUS to the publisher on its own bidirectional request
+/// stream, read the response there, and deliver it to the downstream requester's
+/// request stream.
+async fn forward_track_status_upstream(
+  publisher: Arc<MOQTClient>,
+  downstream: Option<Arc<MOQTClient>>,
+  downstream_request_id: u64,
+  new_req: TrackStatus,
+  _context: Arc<SessionContext>,
+) {
+  let (send, recv) = match publisher.connection.open_bi().await {
+    Ok(streams) => streams,
+    Err(e) => {
+      error!("Failed to open upstream track-status stream: {:?}", e);
+      return;
+    }
+  };
+  let mut upstream = ControlStreamHandler::new(send, recv);
+  if let Err(e) = upstream
+    .send(&ControlMessage::TrackStatus(Box::new(new_req)))
+    .await
+  {
+    error!("Failed to send upstream TRACK_STATUS: {:?}", e);
+    return;
+  }
+
+  let response = match upstream.next_message().await {
+    Ok(m @ ControlMessage::RequestOk(_)) => m,
+    Ok(m @ ControlMessage::RequestError(_)) => m,
+    Ok(other) => {
+      warn!(
+        "Unexpected {:?} on upstream track-status stream",
+        other.get_type()
+      );
+      return;
+    }
+    Err(_) => {
+      debug!("Upstream track-status stream closed");
+      return;
+    }
+  };
+
+  if let Some(downstream) = downstream
+    && !downstream
+      .send_response(downstream_request_id, response)
+      .await
+  {
+    warn!(
+      "no request stream for track-status requester {}",
+      downstream_request_id
+    );
+  }
+}
+
+fn track_status_update_error() -> RequestError {
   RequestError::new(
-    request_id,
     RequestErrorCode::NotSupported,
     0,
     ReasonPhrase::try_new("TRACK_STATUS does not support REQUEST_UPDATE".to_string()).unwrap(),
@@ -251,8 +181,7 @@ mod tests {
 
   #[test]
   fn request_update_on_track_status_is_not_supported() {
-    let err = track_status_update_error(42);
-    assert_eq!(err.request_id, 42);
+    let err = track_status_update_error();
     assert_eq!(err.error_code, RequestErrorCode::NotSupported);
   }
 }

--- a/apps/relay/src/server/track_manager.rs
+++ b/apps/relay/src/server/track_manager.rs
@@ -436,20 +436,6 @@ impl TrackManager {
     None
   }
 
-  // Retrieve the original Publish message used to create the track
-  pub async fn get_publish_message(
-    &self,
-    full_track_name: &FullTrackName,
-    connection_id: usize,
-  ) -> Option<Publish> {
-    let publishes = self.publishes.read().await;
-    if let Some(map) = publishes.get(full_track_name) {
-      let publish_opt = map.get(&connection_id);
-      return publish_opt.cloned();
-    }
-    None
-  }
-
   pub async fn get_track_name_by_publisher(
     &self,
     connection_id: usize,

--- a/libs/moqtail-rs/src/model/control/fetch_ok.rs
+++ b/libs/moqtail-rs/src/model/control/fetch_ok.rs
@@ -27,7 +27,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct FetchOk {
-  pub request_id: u64,
   pub end_of_track: bool,
   pub end_location: Location,
   pub subscribe_parameters: Vec<MessageParameter>,
@@ -36,14 +35,12 @@ pub struct FetchOk {
 
 impl FetchOk {
   pub fn new(
-    request_id: u64,
     end_of_track: bool,
     end_location: Location,
     subscribe_parameters: Vec<MessageParameter>,
     track_properties: Vec<TrackProperty>,
   ) -> Self {
     Self {
-      request_id,
       end_of_track,
       end_location,
       subscribe_parameters,
@@ -58,7 +55,6 @@ impl ControlMessageTrait for FetchOk {
     buf.put_vi(ControlMessageType::FetchOk)?;
 
     let mut payload = BytesMut::new();
-    payload.put_vi(self.request_id)?;
     payload.put_u8(if self.end_of_track { 1u8 } else { 0u8 });
     payload.extend_from_slice(&self.end_location.serialize()?);
     payload.put_vi(self.subscribe_parameters.len())?;
@@ -82,8 +78,6 @@ impl ControlMessageTrait for FetchOk {
   }
 
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
-    let request_id = payload.get_vi()?;
-
     if payload.remaining() < 1 {
       return Err(ParseError::NotEnoughBytes {
         context: "FetchOk::parse_payload(end_of_track)",
@@ -113,7 +107,6 @@ impl ControlMessageTrait for FetchOk {
     let track_properties = deserialize_track_properties(payload)?;
 
     Ok(Box::new(FetchOk {
-      request_id,
       end_of_track,
       end_location,
       subscribe_parameters,
@@ -136,7 +129,6 @@ mod tests {
   #[test]
   fn test_roundtrip() {
     let fetch_ok = FetchOk {
-      request_id: 271828,
       end_of_track: true,
       end_location: Location {
         group: 17,
@@ -158,7 +150,6 @@ mod tests {
   #[test]
   fn test_roundtrip_with_group_order_param() {
     let fetch_ok = FetchOk {
-      request_id: 271828,
       end_of_track: true,
       end_location: Location {
         group: 17,
@@ -180,7 +171,6 @@ mod tests {
   #[test]
   fn test_roundtrip_with_track_properties() {
     let fetch_ok = FetchOk {
-      request_id: 12345,
       end_of_track: false,
       end_location: Location {
         group: 5,
@@ -207,7 +197,6 @@ mod tests {
   #[test]
   fn test_excess_roundtrip() {
     let fetch_ok = FetchOk {
-      request_id: 271828,
       end_of_track: true,
       end_location: Location {
         group: 17,
@@ -238,7 +227,6 @@ mod tests {
   #[test]
   fn test_partial_message() {
     let fetch_ok = FetchOk {
-      request_id: 271828,
       end_of_track: true,
       end_location: Location {
         group: 17,

--- a/libs/moqtail-rs/src/model/control/request_error.rs
+++ b/libs/moqtail-rs/src/model/control/request_error.rs
@@ -21,7 +21,6 @@ use bytes::{BufMut, Bytes, BytesMut};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct RequestError {
-  pub request_id: u64,
   pub error_code: RequestErrorCode,
   pub retry_interval: u64,
   pub reason_phrase: ReasonPhrase,
@@ -29,13 +28,11 @@ pub struct RequestError {
 
 impl RequestError {
   pub fn new(
-    request_id: u64,
     error_code: RequestErrorCode,
     retry_interval: u64,
     reason_phrase: ReasonPhrase,
   ) -> Self {
     Self {
-      request_id,
       error_code,
       retry_interval,
       reason_phrase,
@@ -49,7 +46,6 @@ impl ControlMessageTrait for RequestError {
     buf.put_vi(ControlMessageType::RequestError)?;
 
     let mut payload = BytesMut::new();
-    payload.put_vi(self.request_id)?;
     payload.put_vi(self.error_code as u64)?;
     payload.put_vi(self.retry_interval)?;
     payload.extend_from_slice(&self.reason_phrase.serialize()?);
@@ -71,8 +67,6 @@ impl ControlMessageTrait for RequestError {
   }
 
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
-    let request_id = payload.get_vi()?;
-
     // An unknown or GREASE error code is not fatal; treat it as InternalError.
     let error_code_raw = payload.get_vi()?;
     let error_code = RequestErrorCode::from_wire(error_code_raw);
@@ -82,7 +76,6 @@ impl ControlMessageTrait for RequestError {
     let reason_phrase = ReasonPhrase::deserialize(payload)?;
 
     Ok(Box::new(RequestError {
-      request_id,
       error_code,
       retry_interval,
       reason_phrase,
@@ -106,7 +99,6 @@ mod tests {
   #[test]
   fn grease_error_code_parses_as_internal_error() {
     let mut payload = BytesMut::new();
-    payload.put_vi(42).unwrap(); // request_id
     payload.put_vi(grease_value(3).unwrap()).unwrap(); // grease error code
     payload.put_vi(0).unwrap(); // retry_interval
     payload.extend_from_slice(
@@ -123,12 +115,10 @@ mod tests {
 
   #[test]
   fn test_roundtrip() {
-    let request_id = 160669;
     let error_code = RequestErrorCode::InternalError; // Update to match your new constant
     let retry_interval = 0; // As requested, set to 0 to state no retries for now
     let reason_phrase = ReasonPhrase::try_new("They see me rollin'".to_string()).unwrap();
     let request_error = RequestError {
-      request_id,
       error_code,
       retry_interval,
       reason_phrase,
@@ -145,12 +135,10 @@ mod tests {
 
   #[test]
   fn test_excess_roundtrip() {
-    let request_id = 160669;
     let error_code = RequestErrorCode::InternalError;
     let retry_interval = 0;
     let reason_phrase = ReasonPhrase::try_new("They see me rollin'".to_string()).unwrap();
     let request_error = RequestError {
-      request_id,
       error_code,
       retry_interval,
       reason_phrase,
@@ -173,12 +161,10 @@ mod tests {
 
   #[test]
   fn test_partial_message() {
-    let request_id = 160669;
     let error_code = RequestErrorCode::InternalError;
     let retry_interval = 0;
     let reason_phrase = ReasonPhrase::try_new("They see me rollin'".to_string()).unwrap();
     let request_error = RequestError {
-      request_id,
       error_code,
       retry_interval,
       reason_phrase,

--- a/libs/moqtail-rs/src/model/control/request_ok.rs
+++ b/libs/moqtail-rs/src/model/control/request_ok.rs
@@ -30,7 +30,6 @@ use bytes::{BufMut, Bytes, BytesMut};
 /// shorthands, not distinct messages.
 #[derive(Debug, PartialEq, Clone)]
 pub struct RequestOk {
-  pub request_id: u64,
   pub parameters: Vec<MessageParameter>,
   /// Populated only in TRACK_STATUS_OK; empty for every other request type.
   pub track_properties: Vec<TrackProperty>,
@@ -38,9 +37,8 @@ pub struct RequestOk {
 
 impl RequestOk {
   /// A REQUEST_OK with no Track Properties (every request type except TRACK_STATUS).
-  pub fn new(request_id: u64, parameters: Vec<MessageParameter>) -> Self {
+  pub fn new(parameters: Vec<MessageParameter>) -> Self {
     Self {
-      request_id,
       parameters,
       track_properties: Vec::new(),
     }
@@ -48,12 +46,10 @@ impl RequestOk {
 
   /// A TRACK_STATUS_OK carrying Track Properties.
   pub fn new_track_status(
-    request_id: u64,
     parameters: Vec<MessageParameter>,
     track_properties: Vec<TrackProperty>,
   ) -> Self {
     Self {
-      request_id,
       parameters,
       track_properties,
     }
@@ -80,8 +76,6 @@ impl ControlMessageTrait for RequestOk {
     buf.put_vi(ControlMessageType::RequestOk)?;
 
     let mut payload = BytesMut::new();
-    payload.put_vi(self.request_id)?;
-
     payload.put_vi(self.parameters.len() as u64)?;
     payload.extend_from_slice(&serialize_message_parameters(&self.parameters)?);
 
@@ -105,7 +99,6 @@ impl ControlMessageTrait for RequestOk {
   }
 
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
-    let request_id = payload.get_vi()?;
     let param_count = payload.get_vi()?;
     let parameters =
       deserialize_message_parameters(payload, param_count, ControlMessageType::RequestOk)?;
@@ -114,7 +107,6 @@ impl ControlMessageTrait for RequestOk {
     let track_properties = deserialize_track_properties(payload)?;
 
     Ok(Box::new(RequestOk {
-      request_id,
       parameters,
       track_properties,
     }))
@@ -133,7 +125,7 @@ mod tests {
 
   #[test]
   fn test_roundtrip_no_params() {
-    let request_ok = RequestOk::new(12345, vec![]);
+    let request_ok = RequestOk::new(vec![]);
 
     let mut buf = request_ok.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();
@@ -147,13 +139,10 @@ mod tests {
 
   #[test]
   fn test_roundtrip_with_params() {
-    let request_ok = RequestOk::new(
-      67890,
-      vec![
-        MessageParameter::new_expires(3600),
-        MessageParameter::new_group_order(GroupOrder::Ascending),
-      ],
-    );
+    let request_ok = RequestOk::new(vec![
+      MessageParameter::new_expires(3600),
+      MessageParameter::new_group_order(GroupOrder::Ascending),
+    ]);
 
     let mut buf = request_ok.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();
@@ -167,7 +156,7 @@ mod tests {
 
   #[test]
   fn test_excess_roundtrip() {
-    let request_ok = RequestOk::new(112233, vec![MessageParameter::new_expires(3600)]);
+    let request_ok = RequestOk::new(vec![MessageParameter::new_expires(3600)]);
 
     let serialized = request_ok.serialize().unwrap();
     let mut excess = BytesMut::new();
@@ -189,7 +178,7 @@ mod tests {
 
   #[test]
   fn test_partial_message() {
-    let request_ok = RequestOk::new(112233, vec![MessageParameter::new_expires(3600)]);
+    let request_ok = RequestOk::new(vec![MessageParameter::new_expires(3600)]);
     let mut buf = request_ok.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();
     assert_eq!(msg_type, ControlMessageType::RequestOk as u64);
@@ -206,7 +195,6 @@ mod tests {
   fn test_roundtrip_track_status_with_track_properties() {
     use crate::model::property::track_property::TrackProperty;
     let request_ok = RequestOk::new_track_status(
-      555,
       vec![MessageParameter::new_expires(60)],
       vec![
         TrackProperty::MaxCacheDuration {
@@ -230,7 +218,6 @@ mod tests {
   fn test_track_properties_only_valid_for_track_status() {
     use crate::model::property::track_property::TrackProperty;
     let with_props = RequestOk::new_track_status(
-      1,
       vec![],
       vec![TrackProperty::MaxCacheDuration { duration_ms: 1 }],
     );
@@ -243,7 +230,7 @@ mod tests {
     ));
 
     // Empty properties are always fine.
-    let empty = RequestOk::new(2, vec![]);
+    let empty = RequestOk::new(vec![]);
     assert!(empty.validate_track_properties(false).is_ok());
     assert!(empty.validate_track_properties(true).is_ok());
   }

--- a/libs/moqtail-rs/src/model/control/subscribe_ok.rs
+++ b/libs/moqtail-rs/src/model/control/subscribe_ok.rs
@@ -26,7 +26,6 @@ use bytes::{BufMut, Bytes, BytesMut};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct SubscribeOk {
-  pub request_id: u64,
   pub track_alias: u64,
   pub subscribe_parameters: Vec<MessageParameter>,
   pub track_properties: Vec<TrackProperty>,
@@ -34,13 +33,11 @@ pub struct SubscribeOk {
 
 impl SubscribeOk {
   pub fn new(
-    request_id: u64,
     track_alias: u64,
     subscribe_parameters: Vec<MessageParameter>,
     track_properties: Vec<TrackProperty>,
   ) -> Self {
     Self {
-      request_id,
       track_alias,
       subscribe_parameters,
       track_properties,
@@ -54,7 +51,6 @@ impl ControlMessageTrait for SubscribeOk {
     buf.put_vi(ControlMessageType::SubscribeOk)?;
 
     let mut payload = BytesMut::new();
-    payload.put_vi(self.request_id)?;
     payload.put_vi(self.track_alias)?;
 
     payload.put_vi(self.subscribe_parameters.len() as u64)?;
@@ -80,7 +76,6 @@ impl ControlMessageTrait for SubscribeOk {
   }
 
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
-    let request_id = payload.get_vi()?;
     let track_alias = payload.get_vi()?;
 
     let param_count = payload.get_vi()?;
@@ -91,7 +86,6 @@ impl ControlMessageTrait for SubscribeOk {
     let track_properties = deserialize_track_properties(payload)?;
 
     Ok(Box::new(SubscribeOk {
-      request_id,
       track_alias,
       subscribe_parameters,
       track_properties,
@@ -114,7 +108,6 @@ mod tests {
   #[test]
   fn test_roundtrip() {
     let mut subscribe_ok = SubscribeOk {
-      request_id: 145136,
       track_alias: 0,
       subscribe_parameters: vec![
         MessageParameter::new_expires(16),
@@ -145,7 +138,6 @@ mod tests {
   #[test]
   fn test_roundtrip_with_track_properties() {
     let subscribe_ok = SubscribeOk {
-      request_id: 999,
       track_alias: 42,
       subscribe_parameters: vec![
         MessageParameter::new_expires(0),
@@ -170,7 +162,6 @@ mod tests {
   #[test]
   fn test_excess_roundtrip() {
     let subscribe_ok = SubscribeOk {
-      request_id: 145136,
       track_alias: 89123u64,
       subscribe_parameters: vec![
         MessageParameter::new_expires(16),
@@ -203,7 +194,6 @@ mod tests {
   #[test]
   fn test_partial_message() {
     let subscribe_ok = SubscribeOk {
-      request_id: 145136,
       track_alias: 1223u64,
       subscribe_parameters: vec![
         MessageParameter::new_expires(16),

--- a/libs/moqtail-rs/src/transport/control_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/control_stream_handler.rs
@@ -356,8 +356,7 @@ mod tests {
   }
 
   fn create_test_announce_ok() -> RequestOk {
-    let request_id = 12345;
-    RequestOk::new(request_id, vec![])
+    RequestOk::new(vec![])
   }
 
   fn create_test_announce_cancel() -> PublishNamespaceCancel {
@@ -404,7 +403,6 @@ mod tests {
     use crate::model::parameter::message_parameter::MessageParameter;
     use crate::model::property::track_property::TrackProperty;
     let mut subscribe_ok = SubscribeOk::new(
-      145136,
       999,
       vec![
         MessageParameter::new_expires(16),


### PR DESCRIPTION
Responses travel on the request's own bidirectional stream, so they no longer carry a Request ID. Remove request_id from the wire and structs of REQUEST_OK, SUBSCRIBE_OK, FETCH_OK and REQUEST_ERROR; requests keep their Request ID and the even/odd parity rule.

Correlation is now by stream throughout. The relay reads each forwarded request's response on the bidi stream it opened: the SUBSCRIBE, TRACK_STATUS and PUBLISH-push legs follow the same forward-and-read pattern, and the message router rejects any response that arrives on the control stream. The client answers incoming SUBSCRIBE, TRACK_STATUS and pushed PUBLISH on their request streams.


<!-- Please describe your changes in detail. Include motivation and context. -->

<!------------------------------------------------------------------------------
If you are contributing a new feature or fixing an issue, please provide references
to the relevant specifications, documentation, or issues. This helps maintainers
get familiar with the context of your changes.

Thank you for your contribution!
-------------------------------------------------------------------------------->
