### PR TITLE
feat: split SUBSCRIBE_NAMESPACE and SUBSCRIBE_TRACKS (#243)

### DIFF
--- a/apps/relay/src/server/message_handlers/mod.rs
+++ b/apps/relay/src/server/message_handlers/mod.rs
@@ -29,6 +29,7 @@ mod publish_handler;
 mod publish_namespace_handler;
 pub(crate) mod subscribe_handler;
 pub(crate) mod subscribe_namespace_handler;
+pub(crate) mod subscribe_tracks_handler;
 mod track_status_handler;
 use super::utils;
 
@@ -97,6 +98,7 @@ impl MessageHandler {
           Some(PendingRequest::PublishNamespace { .. }) => Route::PublishNamespace,
           Some(PendingRequest::Subscribe(_)) => Route::Subscribe,
           Some(PendingRequest::SubscribeNamespace { .. }) => Route::SubscribeNamespace,
+          Some(PendingRequest::SubscribeTracks { .. }) => Route::SubscribeNamespace,
           Some(PendingRequest::TrackStatus(_)) => Route::TrackStatus,
           Some(PendingRequest::RequestUpdate { .. }) => Route::NotFound,
           None => Route::NotFound,

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -17,6 +17,7 @@ use crate::server::session::Session;
 use crate::server::session_context::PendingRequest;
 use crate::server::session_context::SessionContext;
 use crate::server::track::{Track, TrackStatus};
+use crate::server::track_manager::SubscribeKind;
 use core::result::Result;
 use moqtail::model::common::reason_phrase::ReasonPhrase;
 use moqtail::model::control::{
@@ -167,7 +168,7 @@ pub async fn handle(
 
         let subscribers = context
           .track_manager
-          .get_namespace_subscribers(&m.track_namespace)
+          .get_namespace_subscribers(&m.track_namespace, SubscribeKind::Tracks)
           .await;
 
         if !subscribers.is_empty() {

--- a/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
@@ -14,6 +14,7 @@
 
 use crate::server::client::MOQTClient;
 use crate::server::session_context::{PendingRequest, SessionContext};
+use crate::server::track_manager::SubscribeKind;
 use core::result::Result;
 use moqtail::model::control::namespace::Namespace;
 use moqtail::model::control::{control_message::ControlMessage, request_ok::RequestOk};
@@ -65,7 +66,11 @@ pub async fn handle(
         let subs_map = context.track_manager.namespace_subscribers.read().await;
         for (prefix, subscribers) in subs_map.iter() {
           if m.track_namespace.starts_with(prefix) {
-            for (sub, _subscribe_ns_message, namespace_tx) in subscribers {
+            for (sub, kind, _params, namespace_tx) in subscribers {
+              // NAMESPACE advertisements go to discovery (SUBSCRIBE_NAMESPACE) subscribers.
+              if *kind != SubscribeKind::Namespace {
+                continue;
+              }
               // Don't echo back to announcer
               if sub.connection_id == client.connection_id {
                 continue;
@@ -125,7 +130,7 @@ pub async fn handle(
 
       let downstream_sessions = context
         .track_manager
-        .get_namespace_subscribers(&target_namespace)
+        .get_namespace_subscribers(&target_namespace, SubscribeKind::Namespace)
         .await;
 
       for session in downstream_sessions {

--- a/apps/relay/src/server/message_handlers/subscribe_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_namespace_handler.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::server::client::MOQTClient;
 use crate::server::session_context::{PendingRequest, SessionContext};
-use crate::server::{client::MOQTClient, session::Session};
+use crate::server::track_manager::SubscribeKind;
 use core::result::Result;
 use moqtail::model::common::reason_phrase::ReasonPhrase;
 use moqtail::model::control::control_message::ControlMessage;
@@ -30,11 +31,11 @@ use tokio::sync::mpsc::UnboundedSender;
 use tracing::{info, warn};
 
 /// The relay will not enumerate a namespace prefix broader than this many fields.
-const MAX_NAMESPACE_PREFIX_FIELDS: usize = 32;
+pub(crate) const MAX_NAMESPACE_PREFIX_FIELDS: usize = 32;
 
 /// A NAMESPACE_TOO_LARGE error if the prefix exceeds what the relay will
 /// enumerate, otherwise `None`.
-fn oversized_namespace_error(
+pub(crate) fn oversized_namespace_error(
   prefix: &moqtail::model::common::tuple::Tuple,
 ) -> Option<RequestError> {
   if prefix.fields.len() > MAX_NAMESPACE_PREFIX_FIELDS {
@@ -76,10 +77,14 @@ pub async fn handle_subscribe_namespace(
     return Ok(());
   }
 
-  // Check for prefix overlap per draft spec (PREFIX_OVERLAP)
+  // Independent overlap space: only other SUBSCRIBE_NAMESPACE prefixes conflict.
   if let Some(existing_prefix) = context
     .track_manager
-    .find_overlapping_namespace_subscription(client.connection_id, &sub_ns.track_namespace_prefix)
+    .find_overlapping_namespace_subscription(
+      client.connection_id,
+      &sub_ns.track_namespace_prefix,
+      SubscribeKind::Namespace,
+    )
     .await
   {
     warn!(
@@ -104,7 +109,8 @@ pub async fn handle_subscribe_namespace(
     .add_namespace_subscriber(
       sub_ns.track_namespace_prefix.clone(),
       client.clone(),
-      (*sub_ns).clone(),
+      SubscribeKind::Namespace,
+      sub_ns.parameters.clone(),
       namespace_tx,
     )
     .await;
@@ -132,99 +138,74 @@ pub async fn handle_subscribe_namespace(
     sub_ns.request_id
   );
 
-  // Catch-up: send NAMESPACE for each already-announced matching namespace
+  // Discovery: send NAMESPACE for each matching announced namespace, and echo the
+  // namespaces of tracks already published under the prefix.
+  send_namespace_catchup(stream_handler, &context, &sub_ns.track_namespace_prefix).await?;
+
+  Ok(())
+}
+
+/// Send NAMESPACE messages for a discovery subscription: matching announced
+/// namespaces and the namespaces of tracks already published under the prefix.
+async fn send_namespace_catchup(
+  stream_handler: &mut ControlStreamHandler,
+  context: &Arc<SessionContext>,
+  prefix: &moqtail::model::common::tuple::Tuple,
+) -> Result<(), TerminationCode> {
+  let mut seen: std::collections::HashSet<moqtail::model::common::tuple::Tuple> =
+    std::collections::HashSet::new();
+
   let matched_announcements = context
     .track_manager
-    .get_announcements_by_prefix(&sub_ns.track_namespace_prefix)
+    .get_announcements_by_prefix(prefix)
     .await;
-
   for ns in matched_announcements {
-    if let Some(suffix) = ns.suffix(&sub_ns.track_namespace_prefix) {
+    if seen.insert(ns.clone())
+      && let Some(suffix) = ns.suffix(prefix)
+    {
       let ns_msg = ControlMessage::Namespace(Box::new(Namespace::new(suffix)));
       stream_handler.send(&ns_msg).await?;
     }
   }
 
-  // Catch up on active published Tracks (via control stream)
   let matched_tracks = context
     .track_manager
-    .get_tracks_and_publishes_by_namespace_prefix(&sub_ns.track_namespace_prefix)
+    .get_tracks_and_publishes_by_namespace_prefix(prefix)
     .await;
-
-  for (full_track_name, track_arc, original_publish_message_opt) in matched_tracks {
-    if let Some(mut original_publish_message) = original_publish_message_opt {
-      info!(
-        "Forwarding existing track for new subscriber: {:?}",
-        full_track_name
-      );
-
-      let relay_track_id = {
-        let track = track_arc.read().await;
-        track.relay_track_id
-      };
-
-      let relay_publish_id =
-        Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
-      original_publish_message.request_id = relay_publish_id;
-      original_publish_message.track_alias = relay_track_id;
-
-      {
-        let mut map = context.relay_pending_requests.write().await;
-        map.insert(
-          relay_publish_id,
-          PendingRequest::Publish {
-            publisher_connection_id: client.connection_id,
-            original_request_id: relay_publish_id,
-            message: original_publish_message.clone(),
-          },
-        );
-      }
-
-      client
-        .queue_message(ControlMessage::Publish(Box::new(
-          original_publish_message.clone(),
-        )))
-        .await;
-
-      let track_read = track_arc.read().await;
-      if let Err(e) = track_read
-        .add_subscription(client.clone(), original_publish_message.clone(), false)
-        .await
-      {
-        warn!("Failed retroactive auto-subscribe for track: {:?}", e);
-      } else {
-        info!("Successfully initialized retroactive subscription.");
-      }
-    } else {
-      warn!(
-        "The track has no associated publish message, track: {:?}",
-        full_track_name
-      );
+  for (full_track_name, _track_arc, _publish) in matched_tracks {
+    let ns = full_track_name.namespace.clone();
+    if seen.insert(ns.clone())
+      && let Some(suffix) = ns.suffix(prefix)
+    {
+      let ns_msg = ControlMessage::Namespace(Box::new(Namespace::new(suffix)));
+      stream_handler.send(&ns_msg).await?;
     }
   }
-
   Ok(())
 }
 
 /// Remove the namespace subscription when the subscriber closes or resets the bi-stream.
 pub async fn cancel(client: Arc<MOQTClient>, request_id: u64, context: &Arc<SessionContext>) {
-  let prefix = {
+  let target = {
     let mut map = client.inbound_requests.write().await;
     match map.remove(&request_id) {
       Some(PendingRequest::SubscribeNamespace { message, .. }) => {
-        Some(message.track_namespace_prefix)
+        Some((message.track_namespace_prefix, SubscribeKind::Namespace))
+      }
+      Some(PendingRequest::SubscribeTracks { message, .. }) => {
+        Some((message.track_namespace_prefix, SubscribeKind::Tracks))
       }
       _ => None,
     }
   };
-  if let Some(prefix) = prefix {
+  if let Some((prefix, kind)) = target {
     context
       .track_manager
-      .remove_namespace_subscriber_by_prefix(&prefix, client.connection_id)
+      .remove_namespace_subscriber_by_prefix(&prefix, client.connection_id, kind)
       .await;
     info!(
-      "Cancelled namespace subscription for prefix {:?} (connection {})",
-      prefix, client.connection_id
+      "Cancelled {:?} subscription for prefix {:?} (connection {})",
+      kind, prefix, client.connection_id
     );
   }
 }
@@ -249,9 +230,13 @@ pub async fn handle(
             apply_message_parameter_update(&mut message.parameters, update_msg.parameters.clone());
             message.track_namespace_prefix.clone()
           }
+          Some(PendingRequest::SubscribeTracks { message, .. }) => {
+            apply_message_parameter_update(&mut message.parameters, update_msg.parameters.clone());
+            message.track_namespace_prefix.clone()
+          }
           _ => {
             warn!(
-              "REQUEST_UPDATE for SUBSCRIBE_NAMESPACE request {} cannot be applied; closing the stream",
+              "REQUEST_UPDATE for prefix subscription request {} cannot be applied; closing the stream",
               existing_req_id
             );
             handler.reset(StreamResetCode::Cancelled.to_u64());

--- a/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
@@ -1,0 +1,166 @@
+// Copyright 2026 The MOQtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::server::client::MOQTClient;
+use crate::server::message_handlers::subscribe_namespace_handler::{
+  MAX_NAMESPACE_PREFIX_FIELDS, oversized_namespace_error,
+};
+use crate::server::session::Session;
+use crate::server::session_context::{PendingRequest, SessionContext};
+use crate::server::track_manager::SubscribeKind;
+use core::result::Result;
+use moqtail::model::common::reason_phrase::ReasonPhrase;
+use moqtail::model::control::control_message::ControlMessage;
+use moqtail::model::control::request_error::RequestError;
+use moqtail::model::control::request_ok::RequestOk;
+use moqtail::model::control::subscribe_tracks::SubscribeTracks;
+use moqtail::model::error::{RequestErrorCode, TerminationCode};
+use moqtail::transport::control_stream_handler::ControlStreamHandler;
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::{info, warn};
+
+/// SUBSCRIBE_TRACKS: request a PUBLISH for every track already published under
+/// the prefix (present and future). Independent overlap space from
+/// SUBSCRIBE_NAMESPACE.
+pub async fn handle_subscribe_tracks(
+  client: Arc<MOQTClient>,
+  stream_handler: &mut ControlStreamHandler,
+  sub_tracks: Box<SubscribeTracks>,
+  context: Arc<SessionContext>,
+  namespace_tx: UnboundedSender<ControlMessage>,
+) -> Result<(), TerminationCode> {
+  info!(
+    "Received SubscribeTracks message: {:?}",
+    sub_tracks.track_namespace_prefix
+  );
+
+  if let Some(err) = oversized_namespace_error(&sub_tracks.track_namespace_prefix) {
+    warn!(
+      "SUBSCRIBE_TRACKS prefix has {} fields, maximum is {}",
+      sub_tracks.track_namespace_prefix.fields.len(),
+      MAX_NAMESPACE_PREFIX_FIELDS
+    );
+    stream_handler
+      .send(&ControlMessage::RequestError(Box::new(err)))
+      .await?;
+    return Ok(());
+  }
+
+  // Independent overlap space: only other SUBSCRIBE_TRACKS prefixes conflict.
+  if let Some(existing_prefix) = context
+    .track_manager
+    .find_overlapping_namespace_subscription(
+      client.connection_id,
+      &sub_tracks.track_namespace_prefix,
+      SubscribeKind::Tracks,
+    )
+    .await
+  {
+    warn!(
+      "SUBSCRIBE_TRACKS overlap: new={:?} conflicts with existing={:?}",
+      sub_tracks.track_namespace_prefix, existing_prefix
+    );
+    let err = RequestError::new(
+      RequestErrorCode::PrefixOverlap,
+      0,
+      ReasonPhrase::try_new("Track prefix overlaps with existing subscription".to_string())
+        .unwrap(),
+    );
+    stream_handler
+      .send(&ControlMessage::RequestError(Box::new(err)))
+      .await?;
+    return Ok(());
+  }
+
+  context
+    .track_manager
+    .add_namespace_subscriber(
+      sub_tracks.track_namespace_prefix.clone(),
+      client.clone(),
+      SubscribeKind::Tracks,
+      sub_tracks.parameters.clone(),
+      namespace_tx,
+    )
+    .await;
+
+  {
+    let mut map = client.inbound_requests.write().await;
+    map.insert(
+      sub_tracks.request_id,
+      PendingRequest::SubscribeTracks {
+        client_connection_id: client.connection_id,
+        original_request_id: sub_tracks.request_id,
+        message: (*sub_tracks).clone(),
+      },
+    );
+  }
+
+  let ok = RequestOk::new(vec![]);
+  stream_handler
+    .send(&ControlMessage::RequestOk(Box::new(ok)))
+    .await?;
+
+  // Forward a PUBLISH for every track already published under the prefix.
+  let matched_tracks = context
+    .track_manager
+    .get_tracks_and_publishes_by_namespace_prefix(&sub_tracks.track_namespace_prefix)
+    .await;
+
+  for (full_track_name, track_arc, original_publish_message_opt) in matched_tracks {
+    if let Some(mut original_publish_message) = original_publish_message_opt {
+      info!("Forwarding existing track to SUBSCRIBE_TRACKS subscriber: {full_track_name:?}");
+
+      let relay_track_id = {
+        let track = track_arc.read().await;
+        track.relay_track_id
+      };
+
+      let relay_publish_id =
+        Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
+      original_publish_message.request_id = relay_publish_id;
+      original_publish_message.track_alias = relay_track_id;
+
+      {
+        let mut map = context.relay_pending_requests.write().await;
+        map.insert(
+          relay_publish_id,
+          PendingRequest::Publish {
+            publisher_connection_id: client.connection_id,
+            original_request_id: relay_publish_id,
+            message: original_publish_message.clone(),
+          },
+        );
+      }
+
+      client
+        .queue_message(ControlMessage::Publish(Box::new(
+          original_publish_message.clone(),
+        )))
+        .await;
+
+      let track_read = track_arc.read().await;
+      if let Err(e) = track_read
+        .add_subscription(client.clone(), original_publish_message.clone(), false)
+        .await
+      {
+        warn!("Failed retroactive auto-subscribe for track: {:?}", e);
+      }
+    } else {
+      warn!("The track has no associated publish message, track: {full_track_name:?}");
+    }
+  }
+
+  Ok(())
+}

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -486,27 +486,46 @@ impl Session {
     context: Arc<SessionContext>,
   ) {
     match msg {
-      ControlMessage::SubscribeNamespace(sub_ns) => {
-        let request_id = sub_ns.request_id;
+      first @ (ControlMessage::SubscribeNamespace(_) | ControlMessage::SubscribeTracks(_)) => {
+        let request_id = match &first {
+          ControlMessage::SubscribeNamespace(m) => m.request_id,
+          ControlMessage::SubscribeTracks(m) => m.request_id,
+          _ => unreachable!("matched above"),
+        };
 
         let (namespace_tx, mut namespace_rx) =
           tokio::sync::mpsc::unbounded_channel::<ControlMessage>();
 
-        let result = message_handlers::subscribe_namespace_handler::handle_subscribe_namespace(
-          client.clone(),
-          &mut stream_handler,
-          sub_ns,
-          context.clone(),
-          namespace_tx,
-        )
-        .await;
+        let result = match first {
+          ControlMessage::SubscribeNamespace(sub_ns) => {
+            message_handlers::subscribe_namespace_handler::handle_subscribe_namespace(
+              client.clone(),
+              &mut stream_handler,
+              sub_ns,
+              context.clone(),
+              namespace_tx,
+            )
+            .await
+          }
+          ControlMessage::SubscribeTracks(sub_tracks) => {
+            message_handlers::subscribe_tracks_handler::handle_subscribe_tracks(
+              client.clone(),
+              &mut stream_handler,
+              sub_tracks,
+              context.clone(),
+              namespace_tx,
+            )
+            .await
+          }
+          _ => unreachable!("matched above"),
+        };
 
         if let Err(e) = result {
-          error!("handle_subscribe_namespace error: {:?}", e);
+          error!("prefix subscription handler error: {:?}", e);
           return;
         }
 
-        // Long-lived loop: forward NAMESPACE messages to bi-stream, or cancel on stream close
+        // Long-lived loop: forward NAMESPACE/PUBLISH messages to the bi-stream, or cancel on close.
         loop {
           tokio::select! {
             biased;

--- a/apps/relay/src/server/session_context.rs
+++ b/apps/relay/src/server/session_context.rs
@@ -48,6 +48,11 @@ pub enum PendingRequest {
     original_request_id: u64,
     message: moqtail::model::control::subscribe_namespace::SubscribeNamespace,
   },
+  SubscribeTracks {
+    client_connection_id: usize,
+    original_request_id: u64,
+    message: moqtail::model::control::subscribe_tracks::SubscribeTracks,
+  },
   Publish {
     publisher_connection_id: usize,
     original_request_id: u64,

--- a/apps/relay/src/server/track_manager.rs
+++ b/apps/relay/src/server/track_manager.rs
@@ -18,9 +18,10 @@ use moqtail::model::common::tuple::Tuple;
 use moqtail::model::control::control_message::ControlMessage;
 use moqtail::model::control::publish::Publish;
 use moqtail::model::control::publish_namespace::PublishNamespace;
-use moqtail::model::control::subscribe_namespace::SubscribeNamespace;
 use moqtail::model::data::full_track_name::FullTrackName;
-use moqtail::model::parameter::message_parameter::apply_message_parameter_update;
+use moqtail::model::parameter::message_parameter::{
+  MessageParameter, apply_message_parameter_update,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -29,9 +30,25 @@ use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, info, warn};
 
 pub type NamespacePrefix = Tuple;
+
+/// The two prefix-subscription request types. They share a wire shape but have
+/// independent overlap spaces: a Namespace and a Tracks subscription may share a
+/// prefix, but two of the same kind may not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscribeKind {
+  /// SUBSCRIBE_NAMESPACE (0x50): discovery — the relay sends NAMESPACE /
+  /// NAMESPACE_DONE for matching namespaces.
+  Namespace,
+  /// SUBSCRIBE_TRACKS (0x51): the relay sends a PUBLISH for every matching track.
+  Tracks,
+}
+
+/// A prefix subscription: which client, which kind, its parameters, and the
+/// channel that forwards messages onto its request stream.
 pub type NamespaceSubscriber = (
   Arc<MOQTClient>,
-  SubscribeNamespace,
+  SubscribeKind,
+  Vec<MessageParameter>,
   UnboundedSender<ControlMessage>,
 );
 pub type AnnouncementSubscriber = (Arc<MOQTClient>, PublishNamespace);
@@ -250,7 +267,8 @@ impl TrackManager {
     &self,
     prefix: Tuple,
     client: Arc<MOQTClient>,
-    message: SubscribeNamespace,
+    kind: SubscribeKind,
+    parameters: Vec<MessageParameter>,
     namespace_tx: UnboundedSender<ControlMessage>,
   ) {
     let mut subs = self.namespace_subscribers.write().await;
@@ -258,17 +276,22 @@ impl TrackManager {
     // Get or create the list for this prefix
     let clients = subs.entry(prefix.clone()).or_insert_with(Vec::new);
 
-    // Avoid duplicates
+    // Avoid duplicates of the same client and kind
     if !clients
       .iter()
-      .any(|(c, _, _)| c.connection_id == client.connection_id)
+      .any(|(c, k, _, _)| c.connection_id == client.connection_id && *k == kind)
     {
-      clients.push((client, message, namespace_tx));
+      clients.push((client, kind, parameters, namespace_tx));
     }
     info!("Added namespace subscriber for prefix {:?}", prefix);
   }
 
-  pub async fn get_namespace_subscribers(&self, target_namespace: &Tuple) -> Vec<Arc<MOQTClient>> {
+  /// Clients of the given kind whose prefix matches the target namespace.
+  pub async fn get_namespace_subscribers(
+    &self,
+    target_namespace: &Tuple,
+    kind: SubscribeKind,
+  ) -> Vec<Arc<MOQTClient>> {
     let subs = self.namespace_subscribers.read().await;
     let mut interested_clients = Vec::new();
 
@@ -276,8 +299,10 @@ impl TrackManager {
     // Example: Target "meet.room1", Prefix "meet" -> Match.
     for (prefix, clients) in subs.iter() {
       if target_namespace.starts_with(prefix) {
-        for (client, _message, _tx) in clients {
-          interested_clients.push(client.clone());
+        for (client, k, _params, _tx) in clients {
+          if *k == kind {
+            interested_clients.push(client.clone());
+          }
         }
       }
     }
@@ -330,15 +355,20 @@ impl TrackManager {
   pub async fn remove_namespace_subscriber(&self, connection_id: usize) {
     let mut subs = self.namespace_subscribers.write().await;
     for clients in subs.values_mut() {
-      clients.retain(|(c, _, _)| c.connection_id != connection_id);
+      clients.retain(|(c, _, _, _)| c.connection_id != connection_id);
     }
     subs.retain(|_, clients| !clients.is_empty());
   }
 
-  pub async fn remove_namespace_subscriber_by_prefix(&self, prefix: &Tuple, connection_id: usize) {
+  pub async fn remove_namespace_subscriber_by_prefix(
+    &self,
+    prefix: &Tuple,
+    connection_id: usize,
+    kind: SubscribeKind,
+  ) {
     let mut subs = self.namespace_subscribers.write().await;
     if let Some(clients) = subs.get_mut(prefix) {
-      clients.retain(|(c, _, _)| c.connection_id != connection_id);
+      clients.retain(|(c, k, _, _)| !(c.connection_id == connection_id && *k == kind));
     }
     subs.retain(|_, clients| !clients.is_empty());
   }
@@ -362,11 +392,11 @@ impl TrackManager {
   ) {
     let mut subs = self.namespace_subscribers.write().await;
     if let Some(clients) = subs.get_mut(prefix)
-      && let Some((_client, message, _tx)) = clients
+      && let Some((_client, _kind, params, _tx)) = clients
         .iter_mut()
-        .find(|(c, _, _)| c.connection_id == connection_id)
+        .find(|(c, _, _, _)| c.connection_id == connection_id)
     {
-      apply_message_parameter_update(&mut message.parameters, new_parameters);
+      apply_message_parameter_update(params, new_parameters);
     }
   }
 
@@ -418,16 +448,20 @@ impl TrackManager {
   /// Returns the first existing namespace subscription prefix for `connection_id`
   /// that overlaps with `new_prefix` (equal, or one is a prefix of the other).
   /// Returns `None` if no overlap is found.
+  /// A prefix already subscribed by this connection with the same kind that
+  /// overlaps the new prefix. Overlap spaces are independent per kind, so a
+  /// SUBSCRIBE_NAMESPACE never conflicts with a SUBSCRIBE_TRACKS.
   pub async fn find_overlapping_namespace_subscription(
     &self,
     connection_id: usize,
     new_prefix: &Tuple,
+    kind: SubscribeKind,
   ) -> Option<Tuple> {
     let subs = self.namespace_subscribers.read().await;
     for (existing_prefix, clients) in subs.iter() {
       if clients
         .iter()
-        .any(|(c, _, _)| c.connection_id == connection_id)
+        .any(|(c, k, _, _)| c.connection_id == connection_id && *k == kind)
         && namespace_prefixes_overlap(new_prefix, existing_prefix)
       {
         return Some(existing_prefix.clone());

--- a/libs/moqtail-rs/src/model/control.rs
+++ b/libs/moqtail-rs/src/model/control.rs
@@ -29,5 +29,6 @@ pub mod setup;
 pub mod subscribe;
 pub mod subscribe_namespace;
 pub mod subscribe_ok;
+pub mod subscribe_tracks;
 pub mod switch;
 pub mod track_status;

--- a/libs/moqtail-rs/src/model/control/control_message.rs
+++ b/libs/moqtail-rs/src/model/control/control_message.rs
@@ -21,8 +21,8 @@ use super::{
   namespace::Namespace, namespace_done::NamespaceDone, publish::Publish, publish_done::PublishDone,
   publish_namespace::PublishNamespace, request_error::RequestError, request_ok::RequestOk,
   request_update::RequestUpdate, setup::Setup, subscribe::Subscribe,
-  subscribe_namespace::SubscribeNamespace, subscribe_ok::SubscribeOk, switch::Switch,
-  track_status::TrackStatus,
+  subscribe_namespace::SubscribeNamespace, subscribe_ok::SubscribeOk,
+  subscribe_tracks::SubscribeTracks, switch::Switch, track_status::TrackStatus,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -42,6 +42,7 @@ pub enum ControlMessage {
   RequestUpdate(Box<RequestUpdate>),
   TrackStatus(Box<TrackStatus>),
   SubscribeNamespace(Box<SubscribeNamespace>),
+  SubscribeTracks(Box<SubscribeTracks>),
   RequestError(Box<RequestError>),
   Switch(Box<Switch>),
 }
@@ -125,16 +126,17 @@ impl ControlMessage {
       ControlMessageType::SubscribeNamespace => {
         SubscribeNamespace::parse_payload(&mut payload).map(ControlMessage::SubscribeNamespace)
       }
+      ControlMessageType::SubscribeTracks => {
+        SubscribeTracks::parse_payload(&mut payload).map(ControlMessage::SubscribeTracks)
+      }
       ControlMessageType::Switch => Switch::parse_payload(&mut payload).map(ControlMessage::Switch),
       // Draft-18 assigns these codepoints but their bodies are not built yet. Parsing
       // fails rather than the type being rejected outright, so the error says the type
       // was understood and the body was not.
-      ControlMessageType::SubscribeTracks | ControlMessageType::PublishBlocked => {
-        Err(ParseError::Other {
-          context: "ControlMessage::deserialize(payload)",
-          msg: format!("{msg_type:?} is a draft-18 message type with no body implemented yet"),
-        })
-      }
+      ControlMessageType::PublishBlocked => Err(ParseError::Other {
+        context: "ControlMessage::deserialize(payload)",
+        msg: format!("{msg_type:?} is a draft-18 message type with no body implemented yet"),
+      }),
     }
     .map_err(|err| ParseError::ProtocolViolation {
       context: "ControlMessage::deserialize(payload)",
@@ -171,6 +173,7 @@ impl ControlMessage {
       ControlMessage::RequestUpdate(msg) => msg.serialize(),
       ControlMessage::TrackStatus(msg) => msg.serialize(),
       ControlMessage::SubscribeNamespace(msg) => msg.serialize(),
+      ControlMessage::SubscribeTracks(msg) => msg.serialize(),
       ControlMessage::Switch(msg) => msg.serialize(),
     }
   }
@@ -194,6 +197,7 @@ impl ControlMessage {
       ControlMessage::RequestUpdate(_) => ControlMessageType::RequestUpdate,
       ControlMessage::TrackStatus(_) => ControlMessageType::TrackStatus,
       ControlMessage::SubscribeNamespace(_) => ControlMessageType::SubscribeNamespace,
+      ControlMessage::SubscribeTracks(_) => ControlMessageType::SubscribeTracks,
       ControlMessage::Switch(_) => ControlMessageType::Switch,
     }
   }

--- a/libs/moqtail-rs/src/model/control/subscribe_tracks.rs
+++ b/libs/moqtail-rs/src/model/control/subscribe_tracks.rs
@@ -22,14 +22,17 @@ use crate::model::parameter::message_parameter::{
 };
 use bytes::{BufMut, Bytes, BytesMut};
 
+/// SUBSCRIBE_TRACKS (0x51) requests a PUBLISH for every track under the matching
+/// namespace prefix, present and future. It shares SUBSCRIBE_NAMESPACE's wire
+/// shape but has an independent prefix-overlap space.
 #[derive(Debug, PartialEq, Clone)]
-pub struct SubscribeNamespace {
+pub struct SubscribeTracks {
   pub request_id: u64,
   pub track_namespace_prefix: Tuple,
   pub parameters: Vec<MessageParameter>,
 }
 
-impl SubscribeNamespace {
+impl SubscribeTracks {
   pub fn new(
     request_id: u64,
     track_namespace_prefix: Tuple,
@@ -43,10 +46,10 @@ impl SubscribeNamespace {
   }
 }
 
-impl ControlMessageTrait for SubscribeNamespace {
+impl ControlMessageTrait for SubscribeTracks {
   fn serialize(&self) -> Result<Bytes, ParseError> {
     let mut buf = BytesMut::new();
-    buf.put_vi(ControlMessageType::SubscribeNamespace)?;
+    buf.put_vi(ControlMessageType::SubscribeTracks)?;
 
     let mut payload = BytesMut::new();
     payload.put_vi(self.request_id)?;
@@ -59,7 +62,7 @@ impl ControlMessageTrait for SubscribeNamespace {
       .len()
       .try_into()
       .map_err(|e: std::num::TryFromIntError| ParseError::CastingError {
-        context: "Announce::serialize",
+        context: "SubscribeTracks::serialize",
         from_type: "usize",
         to_type: "u16",
         details: e.to_string(),
@@ -74,7 +77,7 @@ impl ControlMessageTrait for SubscribeNamespace {
     let track_namespace_prefix = Tuple::deserialize(payload)?;
     if track_namespace_prefix.fields.len() > 32 {
       return Err(ParseError::ProtocolViolation {
-        context: "SubscribeNamespace::parse_payload",
+        context: "SubscribeTracks::parse_payload",
         details: format!(
           "Track namespace prefix has {} fields, maximum is 32",
           track_namespace_prefix.fields.len()
@@ -83,9 +86,9 @@ impl ControlMessageTrait for SubscribeNamespace {
     }
     let param_count = payload.get_vi()?;
     let parameters =
-      deserialize_message_parameters(payload, param_count, ControlMessageType::SubscribeNamespace)?;
+      deserialize_message_parameters(payload, param_count, ControlMessageType::SubscribeTracks)?;
 
-    Ok(Box::new(SubscribeNamespace {
+    Ok(Box::new(SubscribeTracks {
       request_id,
       track_namespace_prefix,
       parameters,
@@ -93,103 +96,62 @@ impl ControlMessageTrait for SubscribeNamespace {
   }
 
   fn get_type(&self) -> ControlMessageType {
-    ControlMessageType::SubscribeNamespace
+    ControlMessageType::SubscribeTracks
   }
 }
 
 #[cfg(test)]
 mod tests {
-  use crate::model::parameter::authorization_token::AuthorizationToken;
-
   use super::*;
   use bytes::Buf;
 
+  fn sample() -> SubscribeTracks {
+    SubscribeTracks::new(
+      241421,
+      Tuple::from_utf8_path("pre/fix/me"),
+      vec![MessageParameter::new_forward(true)],
+    )
+  }
+
   #[test]
   fn test_roundtrip() {
-    let request_id = 241421;
-    let track_namespace_prefix = Tuple::from_utf8_path("pre/fix/me");
-    let parameters = vec![
-      MessageParameter::new_authorization_token(AuthorizationToken::new_use_value(
-        0,
-        Bytes::from_static(b"test-token"),
-      )),
-      MessageParameter::new_forward(true),
-    ];
-    let subscribe_namespace = SubscribeNamespace {
-      request_id,
-      track_namespace_prefix,
-      parameters,
-    };
-
-    let mut buf = subscribe_namespace.serialize().unwrap();
+    let subscribe_tracks = sample();
+    let mut buf = subscribe_tracks.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();
-    assert_eq!(msg_type, ControlMessageType::SubscribeNamespace as u64);
+    assert_eq!(msg_type, ControlMessageType::SubscribeTracks as u64);
     let msg_length = buf.get_u16();
     assert_eq!(msg_length as usize, buf.remaining());
-    let deserialized = SubscribeNamespace::parse_payload(&mut buf).unwrap();
-    assert_eq!(*deserialized, subscribe_namespace);
+    let deserialized = SubscribeTracks::parse_payload(&mut buf).unwrap();
+    assert_eq!(*deserialized, subscribe_tracks);
     assert!(!buf.has_remaining());
   }
 
   #[test]
   fn test_excess_roundtrip() {
-    let request_id = 241421;
-    let track_namespace_prefix = Tuple::from_utf8_path("pre/fix/me");
-    let parameters = vec![
-      MessageParameter::new_authorization_token(AuthorizationToken::new_use_value(
-        0,
-        Bytes::from_static(b"test-token"),
-      )),
-      MessageParameter::new_forward(true),
-    ];
-    let subscribe_namespace = SubscribeNamespace {
-      request_id,
-      track_namespace_prefix,
-      parameters,
-    };
-
-    let serialized = subscribe_namespace.serialize().unwrap();
+    let subscribe_tracks = sample();
+    let serialized = subscribe_tracks.serialize().unwrap();
     let mut excess = BytesMut::new();
     excess.extend_from_slice(&serialized);
     excess.extend_from_slice(&[9u8, 1u8, 1u8]);
     let mut buf = excess.freeze();
 
     let msg_type = buf.get_vi().unwrap();
-    assert_eq!(msg_type, ControlMessageType::SubscribeNamespace as u64);
+    assert_eq!(msg_type, ControlMessageType::SubscribeTracks as u64);
     let msg_length = buf.get_u16();
-
     assert_eq!(msg_length as usize, buf.remaining() - 3);
-    let deserialized = SubscribeNamespace::parse_payload(&mut buf).unwrap();
-    assert_eq!(*deserialized, subscribe_namespace);
+    let deserialized = SubscribeTracks::parse_payload(&mut buf).unwrap();
+    assert_eq!(*deserialized, subscribe_tracks);
     assert_eq!(buf.chunk(), &[9u8, 1u8, 1u8]);
   }
 
   #[test]
   fn test_partial_message() {
-    let request_id = 241421;
-    let track_namespace_prefix = Tuple::from_utf8_path("pre/fix/me");
-    let parameters = vec![
-      MessageParameter::new_authorization_token(AuthorizationToken::new_use_value(
-        0,
-        Bytes::from_static(b"test-token"),
-      )),
-      MessageParameter::new_forward(true),
-    ];
-    let subscribe_namespace = SubscribeNamespace {
-      request_id,
-      track_namespace_prefix,
-      parameters,
-    };
-
-    let mut buf = subscribe_namespace.serialize().unwrap();
-    let msg_type = buf.get_vi().unwrap();
-    assert_eq!(msg_type, ControlMessageType::SubscribeNamespace as u64);
-    let msg_length = buf.get_u16();
-    assert_eq!(msg_length as usize, buf.remaining());
-
+    let subscribe_tracks = sample();
+    let mut buf = subscribe_tracks.serialize().unwrap();
+    let _ = buf.get_vi().unwrap();
+    let _ = buf.get_u16();
     let upper = buf.remaining() / 2;
     let mut partial = buf.slice(..upper);
-    let deserialized = SubscribeNamespace::parse_payload(&mut partial);
-    assert!(deserialized.is_err());
+    assert!(SubscribeTracks::parse_payload(&mut partial).is_err());
   }
 }

--- a/libs/moqtail-rs/src/model/parameter/message_parameter.rs
+++ b/libs/moqtail-rs/src/model/parameter/message_parameter.rs
@@ -149,6 +149,7 @@ impl MessageParameter {
           | ControlMessageType::Subscribe
           | ControlMessageType::RequestUpdate
           | ControlMessageType::SubscribeNamespace
+          | ControlMessageType::SubscribeTracks
           | ControlMessageType::PublishNamespace
           | ControlMessageType::TrackStatus
           | ControlMessageType::Fetch
@@ -212,6 +213,7 @@ impl MessageParameter {
           | ControlMessageType::PublishOk
           | ControlMessageType::RequestOk
           | ControlMessageType::SubscribeNamespace
+          | ControlMessageType::SubscribeTracks
       ),
       Self::NewGroupRequest { .. } => matches!(
         msg_type,


### PR DESCRIPTION
Remove the Rust-only subscribe_options field from SUBSCRIBE_NAMESPACE and add a new SUBSCRIBE_TRACKS (0x51) message. SUBSCRIBE_NAMESPACE is now pure namespace discovery (the relay sends NAMESPACE for matching announced and published-track namespaces); SUBSCRIBE_TRACKS requests a PUBLISH for every matching track.

The two have independent prefix-overlap spaces: a SUBSCRIBE_NAMESPACE and a SUBSCRIBE_TRACKS may share a prefix, but two of the same kind conflict with PREFIX_OVERLAP. Subscribers are tagged by kind in the track manager, and the overlap check and PUBLISH_NAMESPACE/PUBLISH fan-out are kind-scoped.
