### PR TITLE
feat: allow zero-element track namespaces (#247)

### DIFF
--- a/libs/moqtail-rs/src/model/control/subscribe_namespace.rs
+++ b/libs/moqtail-rs/src/model/control/subscribe_namespace.rs
@@ -70,17 +70,10 @@ impl ControlMessageTrait for SubscribeNamespace {
   }
 
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
+    // The 0-32 field bound is a relay policy answered with NAMESPACE_TOO_LARGE, not
+    // a parse error, so it is enforced by the handler rather than here.
     let request_id = payload.get_vi()?;
     let track_namespace_prefix = Tuple::deserialize(payload)?;
-    if track_namespace_prefix.fields.len() > 32 {
-      return Err(ParseError::ProtocolViolation {
-        context: "SubscribeNamespace::parse_payload",
-        details: format!(
-          "Track namespace prefix has {} fields, maximum is 32",
-          track_namespace_prefix.fields.len()
-        ),
-      });
-    }
     let param_count = payload.get_vi()?;
     let parameters =
       deserialize_message_parameters(payload, param_count, ControlMessageType::SubscribeNamespace)?;

--- a/libs/moqtail-rs/src/model/control/subscribe_tracks.rs
+++ b/libs/moqtail-rs/src/model/control/subscribe_tracks.rs
@@ -73,17 +73,10 @@ impl ControlMessageTrait for SubscribeTracks {
   }
 
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
+    // The 0-32 field bound is a relay policy answered with NAMESPACE_TOO_LARGE, not
+    // a parse error, so it is enforced by the handler rather than here.
     let request_id = payload.get_vi()?;
     let track_namespace_prefix = Tuple::deserialize(payload)?;
-    if track_namespace_prefix.fields.len() > 32 {
-      return Err(ParseError::ProtocolViolation {
-        context: "SubscribeTracks::parse_payload",
-        details: format!(
-          "Track namespace prefix has {} fields, maximum is 32",
-          track_namespace_prefix.fields.len()
-        ),
-      });
-    }
     let param_count = payload.get_vi()?;
     let parameters =
       deserialize_message_parameters(payload, param_count, ControlMessageType::SubscribeTracks)?;

--- a/libs/moqtail-rs/src/model/data/full_track_name.rs
+++ b/libs/moqtail-rs/src/model/data/full_track_name.rs
@@ -53,12 +53,10 @@ impl Display for FullTrackName {
 impl FullTrackName {
   pub fn new(namespace: Tuple, name: TupleField) -> Result<Self, ParseError> {
     let ns_count = namespace.fields.len();
-    if ns_count == 0 || ns_count > MAX_NAMESPACE_TUPLE_COUNT {
+    if ns_count > MAX_NAMESPACE_TUPLE_COUNT {
       return Err(ParseError::TrackNameError {
         context: "FullTrackName::new(ns_count)",
-        details: format!(
-          "Namespace cannot be empty or cannot exceed {MAX_NAMESPACE_TUPLE_COUNT} fields"
-        ),
+        details: format!("Namespace cannot exceed {MAX_NAMESPACE_TUPLE_COUNT} fields"),
       });
     }
 
@@ -94,12 +92,10 @@ impl FullTrackName {
   pub fn deserialize(buf: &mut Bytes) -> Result<Self, ParseError> {
     let namespace = Tuple::deserialize(buf)?;
     let ns_count = namespace.fields.len();
-    if ns_count == 0 || ns_count > MAX_NAMESPACE_TUPLE_COUNT {
+    if ns_count > MAX_NAMESPACE_TUPLE_COUNT {
       return Err(ParseError::TrackNameError {
         context: "FullTrackName::deserialize(ns_count)",
-        details: format!(
-          "Namespace cannot be empty or cannot exceed {MAX_NAMESPACE_TUPLE_COUNT} fields"
-        ),
+        details: format!("Namespace cannot exceed {MAX_NAMESPACE_TUPLE_COUNT} fields"),
       });
     }
     let name_len = buf.get_vi()? as usize;
@@ -125,5 +121,44 @@ impl FullTrackName {
       namespace,
       name: TupleField::new(name),
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn ns(field_count: usize) -> Tuple {
+    Tuple {
+      fields: (0..field_count)
+        .map(|i| TupleField::from_utf8(&i.to_string()))
+        .collect(),
+    }
+  }
+
+  #[test]
+  fn zero_element_namespace_round_trips() {
+    let ftn = FullTrackName::new(Tuple::new(), TupleField::from_utf8("track")).unwrap();
+    assert_eq!(ftn.namespace.fields.len(), 0);
+
+    let mut bytes = ftn.serialize().unwrap();
+    let parsed = FullTrackName::deserialize(&mut bytes).unwrap();
+    assert_eq!(parsed, ftn);
+  }
+
+  #[test]
+  fn thirty_two_field_namespace_is_allowed() {
+    assert!(FullTrackName::new(ns(MAX_NAMESPACE_TUPLE_COUNT), TupleField::from_utf8("t")).is_ok());
+  }
+
+  #[test]
+  fn thirty_three_field_namespace_is_rejected() {
+    assert!(
+      FullTrackName::new(
+        ns(MAX_NAMESPACE_TUPLE_COUNT + 1),
+        TupleField::from_utf8("t")
+      )
+      .is_err()
+    );
   }
 }


### PR DESCRIPTION
Draft-18 defines a Track Namespace as 0 to 32 fields, so drop the empty-namespace rejection in FullTrackName::new and ::deserialize; the upper bound of 32 stays.

Reconcile the two namespace validators: remove the parse-time >32 rejection from SUBSCRIBE_NAMESPACE and SUBSCRIBE_TRACKS so an oversized prefix reaches the relay handler and is answered with NAMESPACE_TOO_LARGE rather than a parse-time protocol violation. Both validators now accept 0-32 fields.
