### PR TITLE
feat: add the PUBLISH_BLOCKED message (#248)

### DIFF
--- a/libs/moqtail-rs/src/model/control.rs
+++ b/libs/moqtail-rs/src/model/control.rs
@@ -20,6 +20,7 @@ pub mod goaway;
 pub mod namespace;
 pub mod namespace_done;
 pub mod publish;
+pub mod publish_blocked;
 pub mod publish_done;
 pub mod publish_namespace;
 pub mod request_error;

--- a/libs/moqtail-rs/src/model/control/control_message.rs
+++ b/libs/moqtail-rs/src/model/control/control_message.rs
@@ -18,10 +18,10 @@ use bytes::{Buf, Bytes};
 
 use super::{
   constant::ControlMessageType, fetch::Fetch, fetch_ok::FetchOk, goaway::GoAway,
-  namespace::Namespace, namespace_done::NamespaceDone, publish::Publish, publish_done::PublishDone,
-  publish_namespace::PublishNamespace, request_error::RequestError, request_ok::RequestOk,
-  request_update::RequestUpdate, setup::Setup, subscribe::Subscribe,
-  subscribe_namespace::SubscribeNamespace, subscribe_ok::SubscribeOk,
+  namespace::Namespace, namespace_done::NamespaceDone, publish::Publish,
+  publish_blocked::PublishBlocked, publish_done::PublishDone, publish_namespace::PublishNamespace,
+  request_error::RequestError, request_ok::RequestOk, request_update::RequestUpdate, setup::Setup,
+  subscribe::Subscribe, subscribe_namespace::SubscribeNamespace, subscribe_ok::SubscribeOk,
   subscribe_tracks::SubscribeTracks, switch::Switch, track_status::TrackStatus,
 };
 
@@ -44,6 +44,7 @@ pub enum ControlMessage {
   SubscribeNamespace(Box<SubscribeNamespace>),
   SubscribeTracks(Box<SubscribeTracks>),
   RequestError(Box<RequestError>),
+  PublishBlocked(Box<PublishBlocked>),
   Switch(Box<Switch>),
 }
 
@@ -129,14 +130,10 @@ impl ControlMessage {
       ControlMessageType::SubscribeTracks => {
         SubscribeTracks::parse_payload(&mut payload).map(ControlMessage::SubscribeTracks)
       }
+      ControlMessageType::PublishBlocked => {
+        PublishBlocked::parse_payload(&mut payload).map(ControlMessage::PublishBlocked)
+      }
       ControlMessageType::Switch => Switch::parse_payload(&mut payload).map(ControlMessage::Switch),
-      // Draft-18 assigns these codepoints but their bodies are not built yet. Parsing
-      // fails rather than the type being rejected outright, so the error says the type
-      // was understood and the body was not.
-      ControlMessageType::PublishBlocked => Err(ParseError::Other {
-        context: "ControlMessage::deserialize(payload)",
-        msg: format!("{msg_type:?} is a draft-18 message type with no body implemented yet"),
-      }),
     }
     .map_err(|err| ParseError::ProtocolViolation {
       context: "ControlMessage::deserialize(payload)",
@@ -174,6 +171,7 @@ impl ControlMessage {
       ControlMessage::TrackStatus(msg) => msg.serialize(),
       ControlMessage::SubscribeNamespace(msg) => msg.serialize(),
       ControlMessage::SubscribeTracks(msg) => msg.serialize(),
+      ControlMessage::PublishBlocked(msg) => msg.serialize(),
       ControlMessage::Switch(msg) => msg.serialize(),
     }
   }
@@ -198,6 +196,7 @@ impl ControlMessage {
       ControlMessage::TrackStatus(_) => ControlMessageType::TrackStatus,
       ControlMessage::SubscribeNamespace(_) => ControlMessageType::SubscribeNamespace,
       ControlMessage::SubscribeTracks(_) => ControlMessageType::SubscribeTracks,
+      ControlMessage::PublishBlocked(_) => ControlMessageType::PublishBlocked,
       ControlMessage::Switch(_) => ControlMessageType::Switch,
     }
   }

--- a/libs/moqtail-rs/src/model/control/publish_blocked.rs
+++ b/libs/moqtail-rs/src/model/control/publish_blocked.rs
@@ -1,0 +1,140 @@
+// Copyright 2026 The MOQtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::constant::ControlMessageType;
+use super::control_message::ControlMessageTrait;
+use crate::model::common::tuple::{Tuple, TupleField};
+use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
+use crate::model::error::ParseError;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+
+/// PUBLISH_BLOCKED (0xF): a publisher tells the peer it cannot send a PUBLISH to
+/// start a subscription for a track under a SUBSCRIBE_TRACKS namespace because it
+/// is blocked by the peer's bidirectional stream limit. Since it always answers a
+/// SUBSCRIBE_TRACKS, only the namespace suffix after the prefix is carried.
+#[derive(Debug, PartialEq, Clone)]
+pub struct PublishBlocked {
+  pub track_namespace_suffix: Tuple,
+  pub track_name: TupleField,
+}
+
+impl PublishBlocked {
+  pub fn new(track_namespace_suffix: Tuple, track_name: TupleField) -> Self {
+    Self {
+      track_namespace_suffix,
+      track_name,
+    }
+  }
+}
+
+impl ControlMessageTrait for PublishBlocked {
+  fn serialize(&self) -> Result<Bytes, ParseError> {
+    let mut buf = BytesMut::new();
+    buf.put_vi(ControlMessageType::PublishBlocked)?;
+
+    let mut payload = BytesMut::new();
+    payload.extend_from_slice(&self.track_namespace_suffix.serialize()?);
+    payload.put_vi(self.track_name.len())?;
+    payload.extend_from_slice(self.track_name.as_bytes());
+
+    let payload_len: u16 = payload
+      .len()
+      .try_into()
+      .map_err(|e: std::num::TryFromIntError| ParseError::CastingError {
+        context: "PublishBlocked::serialize(payload_length)",
+        from_type: "usize",
+        to_type: "u16",
+        details: e.to_string(),
+      })?;
+    buf.put_u16(payload_len);
+    buf.extend_from_slice(&payload);
+
+    Ok(buf.freeze())
+  }
+
+  fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
+    let track_namespace_suffix = Tuple::deserialize(payload)?;
+    let name_len = payload.get_vi()? as usize;
+    if payload.remaining() < name_len {
+      return Err(ParseError::NotEnoughBytes {
+        context: "PublishBlocked::parse_payload(track_name)",
+        needed: name_len,
+        available: payload.remaining(),
+      });
+    }
+    let track_name = TupleField::new(payload.copy_to_bytes(name_len));
+
+    Ok(Box::new(PublishBlocked {
+      track_namespace_suffix,
+      track_name,
+    }))
+  }
+
+  fn get_type(&self) -> ControlMessageType {
+    ControlMessageType::PublishBlocked
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn sample() -> PublishBlocked {
+    PublishBlocked::new(
+      Tuple::from_utf8_path("room1/audio"),
+      TupleField::from_utf8("track-42"),
+    )
+  }
+
+  #[test]
+  fn test_roundtrip() {
+    let msg = sample();
+    let mut buf = msg.serialize().unwrap();
+    let msg_type = buf.get_vi().unwrap();
+    assert_eq!(msg_type, ControlMessageType::PublishBlocked as u64);
+    let msg_length = buf.get_u16();
+    assert_eq!(msg_length as usize, buf.remaining());
+    let deserialized = PublishBlocked::parse_payload(&mut buf).unwrap();
+    assert_eq!(*deserialized, msg);
+    assert!(!buf.has_remaining());
+  }
+
+  #[test]
+  fn test_excess_roundtrip() {
+    let msg = sample();
+    let serialized = msg.serialize().unwrap();
+    let mut excess = BytesMut::new();
+    excess.extend_from_slice(&serialized);
+    excess.extend_from_slice(&[9u8, 1u8, 1u8]);
+    let mut buf = excess.freeze();
+    let msg_type = buf.get_vi().unwrap();
+    assert_eq!(msg_type, ControlMessageType::PublishBlocked as u64);
+    let msg_length = buf.get_u16();
+    assert_eq!(msg_length as usize, buf.remaining() - 3);
+    let deserialized = PublishBlocked::parse_payload(&mut buf).unwrap();
+    assert_eq!(*deserialized, msg);
+    assert_eq!(buf.chunk(), &[9u8, 1u8, 1u8]);
+  }
+
+  #[test]
+  fn test_partial_message() {
+    let msg = sample();
+    let mut buf = msg.serialize().unwrap();
+    let _ = buf.get_vi().unwrap();
+    let _ = buf.get_u16();
+    let upper = buf.remaining() / 2;
+    let mut partial = buf.slice(..upper);
+    assert!(PublishBlocked::parse_payload(&mut partial).is_err());
+  }
+}


### PR DESCRIPTION
Add the net-new PUBLISH_BLOCKED (0xF) control message: a namespace suffix tuple plus a track name, sent on a SUBSCRIBE_TRACKS response stream when the publisher is blocked by the peer's bidirectional stream limit. Wire it into ControlMessage (parse/serialize/get_type) and drop the placeholder that rejected the codepoint.

Emitting it when the relay hits the stream limit is tracked separately (#307), since that needs the flow-controlled SUBSCRIBE_TRACKS publish loop.
