### PR TITLE
feat: add GOAWAY Request ID and Timeout, and the REDIRECT structure

### DIFF
--- a/dev/conformance/draft18/request_error_codes.json
+++ b/dev/conformance/draft18/request_error_codes.json
@@ -51,7 +51,7 @@
       "value": "0x34",
       "spec": "Section 10.6",
       "notes": "Used by GOAWAY-driven request migration.",
-      "pending": { "rs": 244, "ts": 268 }
+      "pending": { "ts": 268 }
     }
   ]
 }

--- a/libs/moqtail-rs/src/model/common.rs
+++ b/libs/moqtail-rs/src/model/common.rs
@@ -16,5 +16,6 @@ pub mod grease;
 pub mod location;
 pub mod pair;
 pub mod reason_phrase;
+pub mod redirect;
 pub mod tuple;
 pub mod varint;

--- a/libs/moqtail-rs/src/model/common/redirect.rs
+++ b/libs/moqtail-rs/src/model/common/redirect.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 The MOQtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::common::tuple::{Tuple, TupleField};
+use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
+use crate::model::error::ParseError;
+use bytes::{Buf, Bytes, BytesMut};
+
+/// Directs the peer to retry a request at a different URI and/or Full Track Name
+/// (draft §10.6.1). Carried by a REQUEST_ERROR whose code is REDIRECT.
+#[derive(Debug, PartialEq, Clone)]
+pub struct Redirect {
+  /// The URI to connect to. Empty means reuse the current session's URI.
+  pub connect_uri: Option<String>,
+  /// Track Namespace for the redirected request; empty (with an empty name)
+  /// means reuse the original request's values.
+  pub track_namespace: Tuple,
+  /// Track Name for the redirected request; empty for namespace-scoped requests.
+  pub track_name: TupleField,
+}
+
+impl Redirect {
+  pub fn new(connect_uri: Option<String>, track_namespace: Tuple, track_name: TupleField) -> Self {
+    let connect_uri = connect_uri.filter(|uri| !uri.is_empty());
+    Self {
+      connect_uri,
+      track_namespace,
+      track_name,
+    }
+  }
+
+  pub fn serialize(&self) -> Result<Bytes, ParseError> {
+    let mut buf = BytesMut::new();
+    match &self.connect_uri {
+      Some(uri) => {
+        buf.put_vi(uri.len())?;
+        buf.extend_from_slice(uri.as_bytes());
+      }
+      None => buf.put_vi(0)?,
+    }
+    buf.extend_from_slice(&self.track_namespace.serialize()?);
+    buf.put_vi(self.track_name.len())?;
+    buf.extend_from_slice(self.track_name.as_bytes());
+    Ok(buf.freeze())
+  }
+
+  pub fn deserialize(payload: &mut Bytes) -> Result<Self, ParseError> {
+    let uri_len: usize = payload
+      .get_vi()?
+      .try_into()
+      .map_err(|e: std::num::TryFromIntError| ParseError::CastingError {
+        context: "Redirect::deserialize(uri_len)",
+        from_type: "u64",
+        to_type: "usize",
+        details: e.to_string(),
+      })?;
+
+    let connect_uri = if uri_len == 0 {
+      None
+    } else {
+      if payload.remaining() < uri_len {
+        return Err(ParseError::NotEnoughBytes {
+          context: "Redirect::deserialize(connect_uri)",
+          needed: uri_len,
+          available: payload.remaining(),
+        });
+      }
+      let bytes = payload.copy_to_bytes(uri_len);
+      Some(
+        String::from_utf8(bytes.to_vec()).map_err(|e| ParseError::InvalidUTF8 {
+          context: "Redirect::deserialize(connect_uri)",
+          details: e.to_string(),
+        })?,
+      )
+    };
+
+    let track_namespace = Tuple::deserialize(payload)?;
+
+    let name_len: usize =
+      payload
+        .get_vi()?
+        .try_into()
+        .map_err(|e: std::num::TryFromIntError| ParseError::CastingError {
+          context: "Redirect::deserialize(name_len)",
+          from_type: "u64",
+          to_type: "usize",
+          details: e.to_string(),
+        })?;
+    if payload.remaining() < name_len {
+      return Err(ParseError::NotEnoughBytes {
+        context: "Redirect::deserialize(track_name)",
+        needed: name_len,
+        available: payload.remaining(),
+      });
+    }
+    let track_name = TupleField::new(payload.copy_to_bytes(name_len));
+
+    Ok(Self {
+      connect_uri,
+      track_namespace,
+      track_name,
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn round_trips_with_uri_and_track() {
+    let r = Redirect::new(
+      Some("moqt://other.example".to_string()),
+      Tuple::from_utf8_path("room1/audio"),
+      TupleField::from_utf8("track-9"),
+    );
+    let mut bytes = r.serialize().unwrap();
+    assert_eq!(Redirect::deserialize(&mut bytes).unwrap(), r);
+    assert!(!bytes.has_remaining());
+  }
+
+  #[test]
+  fn round_trips_empty_uri_and_empty_track() {
+    let r = Redirect::new(None, Tuple::new(), TupleField::from_utf8(""));
+    assert_eq!(r.connect_uri, None);
+    let mut bytes = r.serialize().unwrap();
+    assert_eq!(Redirect::deserialize(&mut bytes).unwrap(), r);
+    assert!(!bytes.has_remaining());
+  }
+}

--- a/libs/moqtail-rs/src/model/control/goaway.rs
+++ b/libs/moqtail-rs/src/model/control/goaway.rs
@@ -18,15 +18,29 @@ use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::error::ParseError;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
+/// The New Session URI is bounded at 8,192 bytes; a longer one is a protocol
+/// violation.
+const MAX_NEW_SESSION_URI_LEN: usize = 8192;
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct GoAway {
+  /// Empty means the current URI is reused.
   pub new_session_uri: Option<String>,
+  /// Milliseconds the sender waits for graceful closure (0 = no specific timeout).
+  pub timeout: u64,
+  /// The smallest peer Request ID not necessarily processed. Present only when
+  /// the GOAWAY is sent on the control stream.
+  pub request_id: Option<u64>,
 }
 
 impl GoAway {
-  pub fn new(new_session_uri: Option<String>) -> Self {
+  pub fn new(new_session_uri: Option<String>, timeout: u64, request_id: Option<u64>) -> Self {
     let new_session_uri = new_session_uri.filter(|uri| !uri.is_empty());
-    Self { new_session_uri }
+    Self {
+      new_session_uri,
+      timeout,
+      request_id,
+    }
   }
 }
 
@@ -45,6 +59,10 @@ impl ControlMessageTrait for GoAway {
         payload.put_vi(0)?;
       }
     }
+    payload.put_vi(self.timeout)?;
+    if let Some(request_id) = self.request_id {
+      payload.put_vi(request_id)?;
+    }
 
     let payload_len: u16 = payload
       .len()
@@ -61,46 +79,58 @@ impl ControlMessageTrait for GoAway {
     Ok(buf.freeze())
   }
 
-  // TODO: If the URI is zero bytes long, the current URI is reused instead.
-  // The new session URI SHOULD use the same scheme as the current URL to ensure compatibility.
-  // The maximum length of the New Session URI is 8,192 bytes.
-  // If an endpoint receives a length exceeding the maximum, it MUST close the session with a Protocol Violation.
-  // If a server receives a GOAWAY with a non-zero New Session URI Length it MUST terminate the session with a Protocol Violation.
-
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
-    let uri_length = payload.get_vi()?;
-    let uri_length: usize = uri_length
-      .try_into()
-      .map_err(|e: std::num::TryFromIntError| ParseError::CastingError {
-        context: "GoAway::parse_payload(uri_length)",
-        from_type: "u64",
-        to_type: "usize",
-        details: e.to_string(),
-      })?;
+    let uri_length: usize =
+      payload
+        .get_vi()?
+        .try_into()
+        .map_err(|e: std::num::TryFromIntError| ParseError::CastingError {
+          context: "GoAway::parse_payload(uri_length)",
+          from_type: "u64",
+          to_type: "usize",
+          details: e.to_string(),
+        })?;
 
-    if uri_length == 0 {
-      return Ok(Box::new(GoAway {
-        new_session_uri: None,
-      }));
-    }
-
-    if payload.remaining() < uri_length {
-      return Err(ParseError::NotEnoughBytes {
+    if uri_length > MAX_NEW_SESSION_URI_LEN {
+      return Err(ParseError::ProtocolViolation {
         context: "GoAway::parse_payload(uri_length)",
-        needed: uri_length,
-        available: payload.remaining(),
+        details: format!("New Session URI length {uri_length} exceeds {MAX_NEW_SESSION_URI_LEN}"),
       });
     }
 
-    let new_session_uri = payload.copy_to_bytes(uri_length);
-    let new_session_uri =
-      String::from_utf8(new_session_uri.to_vec()).map_err(|e| ParseError::InvalidUTF8 {
-        context: "GoAway::parse_payload(new_session_uri)",
-        details: e.to_string(),
-      })?;
+    let new_session_uri = if uri_length == 0 {
+      None
+    } else {
+      if payload.remaining() < uri_length {
+        return Err(ParseError::NotEnoughBytes {
+          context: "GoAway::parse_payload(uri_length)",
+          needed: uri_length,
+          available: payload.remaining(),
+        });
+      }
+      let bytes = payload.copy_to_bytes(uri_length);
+      Some(
+        String::from_utf8(bytes.to_vec()).map_err(|e| ParseError::InvalidUTF8 {
+          context: "GoAway::parse_payload(new_session_uri)",
+          details: e.to_string(),
+        })?,
+      )
+    };
+
+    let timeout = payload.get_vi()?;
+
+    // Request ID is present only when the GOAWAY is sent on the control stream,
+    // so it is optional and trailing (bounded by the outer Length field).
+    let request_id = if payload.has_remaining() {
+      Some(payload.get_vi()?)
+    } else {
+      None
+    };
 
     Ok(Box::new(GoAway {
-      new_session_uri: Some(new_session_uri),
+      new_session_uri,
+      timeout,
+      request_id,
     }))
   }
   fn get_type(&self) -> ControlMessageType {
@@ -113,10 +143,7 @@ mod tests {
   use super::*;
   use bytes::Buf;
 
-  #[test]
-  fn test_roundtrip() {
-    let new_session_uri = Some("Begone wreched monster".to_string());
-    let go_away = GoAway { new_session_uri };
+  fn roundtrip(go_away: GoAway) {
     let mut buf = go_away.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();
     assert_eq!(msg_type, ControlMessageType::GoAway as u64);
@@ -128,9 +155,33 @@ mod tests {
   }
 
   #[test]
+  fn roundtrip_without_request_id() {
+    roundtrip(GoAway::new(
+      Some("moqt://new.example".to_string()),
+      5000,
+      None,
+    ));
+  }
+
+  #[test]
+  fn roundtrip_with_request_id() {
+    roundtrip(GoAway::new(
+      Some("moqt://new.example".to_string()),
+      5000,
+      Some(42),
+    ));
+  }
+
+  #[test]
+  fn roundtrip_empty_uri_reuses_current() {
+    let go_away = GoAway::new(Some(String::new()), 0, Some(7));
+    assert_eq!(go_away.new_session_uri, None);
+    roundtrip(go_away);
+  }
+
+  #[test]
   fn test_excess_roundtrip() {
-    let new_session_uri = Some("Begone wreched monster".to_string());
-    let go_away = GoAway { new_session_uri };
+    let go_away = GoAway::new(Some("moqt://new.example".to_string()), 5000, Some(42));
 
     let serialized = go_away.serialize().unwrap();
     let mut excess = BytesMut::new();
@@ -141,26 +192,23 @@ mod tests {
     let msg_type = buf.get_vi().unwrap();
     assert_eq!(msg_type, ControlMessageType::GoAway as u64);
     let msg_length = buf.get_u16();
-
-    assert_eq!(msg_length as usize, buf.remaining() - 3);
-    let deserialized = GoAway::parse_payload(&mut buf).unwrap();
+    // The trailing request_id is bounded by Length, so slice the payload first.
+    let mut payload = buf.copy_to_bytes(msg_length as usize);
+    let deserialized = GoAway::parse_payload(&mut payload).unwrap();
     assert_eq!(*deserialized, go_away);
     assert_eq!(buf.chunk(), &[9u8, 1u8, 1u8]);
   }
 
   #[test]
   fn test_partial_message() {
-    let new_session_uri = Some("Begone wreched monster".to_string());
-    let go_away = GoAway { new_session_uri };
+    let go_away = GoAway::new(Some("moqt://new.example".to_string()), 5000, Some(42));
     let mut buf = go_away.serialize().unwrap();
-    let msg_type = buf.get_vi().unwrap();
-    assert_eq!(msg_type, ControlMessageType::GoAway as u64);
+    let _ = buf.get_vi().unwrap();
     let msg_length = buf.get_u16();
     assert_eq!(msg_length as usize, buf.remaining());
 
     let upper = buf.remaining() / 2;
     let mut partial = buf.slice(..upper);
-    let deserialized = GoAway::parse_payload(&mut partial);
-    assert!(deserialized.is_err());
+    assert!(GoAway::parse_payload(&mut partial).is_err());
   }
 }

--- a/libs/moqtail-rs/src/model/control/request_error.rs
+++ b/libs/moqtail-rs/src/model/control/request_error.rs
@@ -15,6 +15,7 @@
 use super::constant::ControlMessageType;
 use super::control_message::ControlMessageTrait;
 use crate::model::common::reason_phrase::ReasonPhrase;
+use crate::model::common::redirect::Redirect;
 use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::error::{ParseError, RequestErrorCode};
 use bytes::{BufMut, Bytes, BytesMut};
@@ -24,6 +25,8 @@ pub struct RequestError {
   pub error_code: RequestErrorCode,
   pub retry_interval: u64,
   pub reason_phrase: ReasonPhrase,
+  /// Present only when `error_code` is `Redirect`.
+  pub redirect: Option<Redirect>,
 }
 
 impl RequestError {
@@ -36,6 +39,21 @@ impl RequestError {
       error_code,
       retry_interval,
       reason_phrase,
+      redirect: None,
+    }
+  }
+
+  /// A REDIRECT error carrying the retry target.
+  pub fn new_redirect(
+    retry_interval: u64,
+    reason_phrase: ReasonPhrase,
+    redirect: Redirect,
+  ) -> Self {
+    Self {
+      error_code: RequestErrorCode::Redirect,
+      retry_interval,
+      reason_phrase,
+      redirect: Some(redirect),
     }
   }
 }
@@ -49,6 +67,9 @@ impl ControlMessageTrait for RequestError {
     payload.put_vi(self.error_code as u64)?;
     payload.put_vi(self.retry_interval)?;
     payload.extend_from_slice(&self.reason_phrase.serialize()?);
+    if let Some(redirect) = &self.redirect {
+      payload.extend_from_slice(&redirect.serialize()?);
+    }
 
     let payload_len: u16 = payload
       .len()
@@ -75,10 +96,18 @@ impl ControlMessageTrait for RequestError {
 
     let reason_phrase = ReasonPhrase::deserialize(payload)?;
 
+    // A Redirect is present only for a REDIRECT error.
+    let redirect = if error_code == RequestErrorCode::Redirect {
+      Some(Redirect::deserialize(payload)?)
+    } else {
+      None
+    };
+
     Ok(Box::new(RequestError {
       error_code,
       retry_interval,
       reason_phrase,
+      redirect,
     }))
   }
 
@@ -118,11 +147,7 @@ mod tests {
     let error_code = RequestErrorCode::InternalError; // Update to match your new constant
     let retry_interval = 0; // As requested, set to 0 to state no retries for now
     let reason_phrase = ReasonPhrase::try_new("They see me rollin'".to_string()).unwrap();
-    let request_error = RequestError {
-      error_code,
-      retry_interval,
-      reason_phrase,
-    };
+    let request_error = RequestError::new(error_code, retry_interval, reason_phrase);
     let mut buf = request_error.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();
     assert_eq!(msg_type, ControlMessageType::RequestError as u64);
@@ -138,11 +163,7 @@ mod tests {
     let error_code = RequestErrorCode::InternalError;
     let retry_interval = 0;
     let reason_phrase = ReasonPhrase::try_new("They see me rollin'".to_string()).unwrap();
-    let request_error = RequestError {
-      error_code,
-      retry_interval,
-      reason_phrase,
-    };
+    let request_error = RequestError::new(error_code, retry_interval, reason_phrase);
     let serialized = request_error.serialize().unwrap();
     let mut excess = BytesMut::new();
     excess.extend_from_slice(&serialized);
@@ -164,11 +185,7 @@ mod tests {
     let error_code = RequestErrorCode::InternalError;
     let retry_interval = 0;
     let reason_phrase = ReasonPhrase::try_new("They see me rollin'".to_string()).unwrap();
-    let request_error = RequestError {
-      error_code,
-      retry_interval,
-      reason_phrase,
-    };
+    let request_error = RequestError::new(error_code, retry_interval, reason_phrase);
     let mut buf = request_error.serialize().unwrap();
     let msg_type = buf.get_vi().unwrap();
     assert_eq!(msg_type, ControlMessageType::RequestError as u64);
@@ -179,5 +196,30 @@ mod tests {
     let mut partial = buf.slice(..upper);
     let deserialized = RequestError::parse_payload(&mut partial);
     assert!(deserialized.is_err());
+  }
+
+  #[test]
+  fn redirect_error_round_trips() {
+    use crate::model::common::redirect::Redirect;
+    use crate::model::common::tuple::{Tuple, TupleField};
+
+    let request_error = RequestError::new_redirect(
+      0,
+      ReasonPhrase::try_new("try elsewhere".to_string()).unwrap(),
+      Redirect::new(
+        Some("moqt://other.example".to_string()),
+        Tuple::from_utf8_path("room1/audio"),
+        TupleField::from_utf8("track-9"),
+      ),
+    );
+    assert_eq!(request_error.error_code, RequestErrorCode::Redirect);
+
+    let mut buf = request_error.serialize().unwrap();
+    let _ = buf.get_vi().unwrap();
+    let msg_length = buf.get_u16();
+    let mut payload = buf.copy_to_bytes(msg_length as usize);
+    let deserialized = RequestError::parse_payload(&mut payload).unwrap();
+    assert_eq!(*deserialized, request_error);
+    assert!(deserialized.redirect.is_some());
   }
 }

--- a/libs/moqtail-rs/src/model/error/request_error.rs
+++ b/libs/moqtail-rs/src/model/error/request_error.rs
@@ -39,6 +39,7 @@ pub enum RequestErrorCode {
   NamespaceTooLarge = 0x31,
   InvalidJoiningRequestId = 0x32,
   UnsupportedExtension = 0x33,
+  Redirect = 0x34,
 }
 
 impl TryFrom<u64> for RequestErrorCode {
@@ -63,6 +64,7 @@ impl TryFrom<u64> for RequestErrorCode {
       0x31 => Ok(RequestErrorCode::NamespaceTooLarge),
       0x32 => Ok(RequestErrorCode::InvalidJoiningRequestId),
       0x33 => Ok(RequestErrorCode::UnsupportedExtension),
+      0x34 => Ok(RequestErrorCode::Redirect),
       _ => Err(ParseError::InvalidType {
         context: "RequestErrorCode::try_from(u64)",
         details: format!("Invalid type, got {value}"),


### PR DESCRIPTION
closes #244 

GOAWAY gains a Timeout field and an optional trailing Request ID that is present only on the control stream, with the New Session URI bounded at 8192 bytes. Add the Redirect structure (Connect URI + Track Namespace + Track Name) and carry it on a REQUEST_ERROR whose code is the new REDIRECT (0x34); the redirect is parsed only for that code.

This is the wire model only. GOAWAY per-request migration and REDIRECT retry behavior are tracked in #309.
