### PR TITLE
feat: shed load on request streams with EXCESSIVE_LOAD (#250)

### DIFF
--- a/apps/relay/src/server.rs
+++ b/apps/relay/src/server.rs
@@ -53,6 +53,8 @@ pub(crate) struct Server {
   pub app_config: &'static AppConfig,
   pub relay_next_request_id: Arc<AtomicU64>,
   pub upstream_fetch_senders: Arc<RwLock<BTreeMap<u64, mpsc::Sender<UpstreamFetchEvent>>>>,
+  /// Request streams currently being served across the relay (for load shedding).
+  pub active_request_streams: Arc<AtomicU64>,
 }
 
 impl Server {
@@ -70,6 +72,7 @@ impl Server {
       app_config: config,
       relay_next_request_id: Arc::new(AtomicU64::new(1u64)), // relay's request id starts at 1 and are odd
       upstream_fetch_senders: Arc::new(RwLock::new(BTreeMap::new())),
+      active_request_streams: Arc::new(AtomicU64::new(0)),
     }
   }
 

--- a/apps/relay/src/server/config.rs
+++ b/apps/relay/src/server/config.rs
@@ -78,6 +78,12 @@ pub struct Cli {
   #[arg(long, default_value_t = 10_000)]
   pub max_request_streams: u64,
 
+  /// Application-level load-shedding limit: once this many request streams are
+  /// being served across the relay, new ones are reset with EXCESSIVE_LOAD.
+  /// 0 disables load shedding.
+  #[arg(long, default_value_t = 0)]
+  pub max_active_requests: u64,
+
   /// Simulate a bandwidth cap per subscriber connection (kbps). 0 = unlimited.
   /// Useful for testing QUIC stream priority scheduling without OS-level throttling.
   #[arg(long, default_value_t = 0)]
@@ -106,6 +112,7 @@ pub struct AppConfig {
   pub enable_token_logging: bool,
   pub token_log_path: String,
   pub max_request_streams: u64,
+  pub max_active_requests: u64,
   /// 0 = unlimited. Non-zero caps relay writes to this many kbps per subscriber connection.
   pub write_kbps_limit: u64,
   pub max_upstream_fetch_gaps: u64,
@@ -132,6 +139,7 @@ impl AppConfig {
         enable_token_logging: cli.enable_token_logging,
         token_log_path: cli.token_log_path,
         max_request_streams: cli.max_request_streams,
+        max_active_requests: cli.max_active_requests,
         write_kbps_limit: cli.write_kbps_limit,
         max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
         upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
@@ -248,6 +256,7 @@ mod tests {
       enable_token_logging: false,
       token_log_path: "/tmp/moqtail_relay_tokens.csv".to_string(),
       max_request_streams,
+      max_active_requests: 0,
       write_kbps_limit: 0,
       max_upstream_fetch_gaps: 10,
       upstream_fetch_timeout: Duration::from_secs(10),

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -20,7 +20,7 @@ use moqtail::model::{
     setup::{Setup, SetupSender},
   },
   data::datagram::Datagram,
-  error::TerminationCode,
+  error::{StreamResetCode, TerminationCode},
 };
 use moqtail::transport::{
   connection::{
@@ -147,6 +147,7 @@ impl Session {
       request_maps,
       connection,
       relay_next_request_id,
+      server.active_request_streams.clone(),
     ));
 
     info!(
@@ -476,7 +477,28 @@ impl Session {
       return;
     }
 
-    Self::dispatch_request_stream_message(client, stream_handler, msg, context).await;
+    // Load shedding: once the relay is serving its configured maximum of request
+    // streams, reset new ones with EXCESSIVE_LOAD instead of serving them.
+    use std::sync::atomic::Ordering;
+    let max_active = context.server_config.max_active_requests;
+    if max_active > 0 && context.active_request_streams.load(Ordering::Relaxed) >= max_active {
+      warn!(
+        "Load shedding request stream {:?}: {} active >= max {}",
+        msg.get_type(),
+        context.active_request_streams.load(Ordering::Relaxed),
+        max_active
+      );
+      stream_handler.reset(StreamResetCode::ExcessiveLoad.to_u64());
+      return;
+    }
+
+    context
+      .active_request_streams
+      .fetch_add(1, Ordering::Relaxed);
+    Self::dispatch_request_stream_message(client, stream_handler, msg, context.clone()).await;
+    context
+      .active_request_streams
+      .fetch_sub(1, Ordering::Relaxed);
   }
 
   async fn dispatch_request_stream_message(

--- a/apps/relay/src/server/session_context.rs
+++ b/apps/relay/src/server/session_context.rs
@@ -97,6 +97,7 @@ pub struct SessionContext {
   pub(crate) is_connection_closed: Arc<AtomicBool>,
   pub(crate) relay_next_request_id: Arc<AtomicU64>,
   pub(crate) upstream_fetch_senders: Arc<RwLock<BTreeMap<u64, mpsc::Sender<UpstreamFetchEvent>>>>,
+  pub(crate) active_request_streams: Arc<AtomicU64>,
 }
 
 impl SessionContext {
@@ -107,6 +108,7 @@ impl SessionContext {
     request_maps: RequestMaps,
     connection: TransportConnection,
     relay_next_request_id: Arc<AtomicU64>,
+    active_request_streams: Arc<AtomicU64>,
   ) -> Self {
     Self {
       client_manager,
@@ -120,6 +122,7 @@ impl SessionContext {
       is_connection_closed: Arc::new(AtomicBool::new(false)),
       relay_next_request_id,
       upstream_fetch_senders: request_maps.upstream_fetch_senders,
+      active_request_streams,
     }
   }
 


### PR DESCRIPTION
Add a relay-wide active-request-stream counter and a max_active_requests config (0 = disabled). When the relay is already serving that many request streams, a newly opened request stream is reset with EXCESSIVE_LOAD instead of being served.

First of three abort-path changes for RL-5; slow-subscriber and drain land separately.
