### PR TITLE
feat(relay): drain on SIGTERM with GOAWAY and reject new requests (RL-5)

### DIFF
--- a/apps/relay/src/server.rs
+++ b/apps/relay/src/server.rs
@@ -29,13 +29,17 @@ mod track_cache;
 mod track_manager;
 mod utils;
 
+use crate::server::client::MOQTClient;
 use crate::server::session_context::{PendingRequest, UpstreamFetchEvent};
 use crate::server::{config::AppConfig, session::Session};
 use anyhow::Result;
 use client_manager::ClientManager;
+use moqtail::model::control::control_message::ControlMessage;
+use moqtail::model::control::goaway::GoAway;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
 use tokio::signal;
 use tokio::sync::{Notify, RwLock, mpsc};
 use tracing::{debug, error, info, warn};
@@ -55,6 +59,11 @@ pub(crate) struct Server {
   pub upstream_fetch_senders: Arc<RwLock<BTreeMap<u64, mpsc::Sender<UpstreamFetchEvent>>>>,
   /// Request streams currently being served across the relay (for load shedding).
   pub active_request_streams: Arc<AtomicU64>,
+  /// Set once the relay is draining (GOAWAY broadcast); new requests are rejected.
+  pub draining: Arc<AtomicBool>,
+  /// GOAWAY redirect URI clients should migrate to. Seeded from config; a future
+  /// admin API mutates this at runtime.
+  pub redirect_uri: Arc<RwLock<Option<String>>>,
 }
 
 impl Server {
@@ -73,7 +82,15 @@ impl Server {
       relay_next_request_id: Arc::new(AtomicU64::new(1u64)), // relay's request id starts at 1 and are odd
       upstream_fetch_senders: Arc::new(RwLock::new(BTreeMap::new())),
       active_request_streams: Arc::new(AtomicU64::new(0)),
+      draining: Arc::new(AtomicBool::new(false)),
+      redirect_uri: Arc::new(RwLock::new(config.redirect_uri.clone())),
     }
+  }
+
+  /// The redirect URI advertised in GOAWAY. Reads the runtime value; the config
+  /// default seeds it at startup.
+  async fn redirect_uri(&self) -> Option<String> {
+    self.redirect_uri.read().await.clone()
   }
 
   pub async fn start(&mut self) -> Result<()> {
@@ -100,6 +117,12 @@ impl Server {
 
     let notify_clone = shutdown_notify.clone();
 
+    // SIGTERM drains the relay: broadcast GOAWAY, reject new requests, then exit
+    // after the drain timeout.
+    let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
+      .expect("Failed to install SIGTERM handler");
+    const DRAIN_TIMEOUT_MS: u64 = 10_000;
+
     let mut session_id_counter: u64 = 0;
 
     loop {
@@ -108,6 +131,16 @@ impl Server {
         _ = notify_clone.notified() => {
           info!("Ctrl-C received, exiting...");
           break;
+        },
+        _ = sigterm.recv() => {
+          info!("SIGTERM received, draining (GOAWAY, timeout {}ms)...", DRAIN_TIMEOUT_MS);
+          self.draining.store(true, Ordering::Relaxed);
+          self.broadcast_goaway(DRAIN_TIMEOUT_MS).await;
+          let notify = shutdown_notify.clone();
+          tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(DRAIN_TIMEOUT_MS)).await;
+            notify.notify_waiters();
+          });
         },
         incoming = endpoint.accept() => {
           let Some(incoming) = incoming else {
@@ -134,6 +167,27 @@ impl Server {
       }
     }
     Ok(())
+  }
+
+  /// Sends GOAWAY to every connected client so they can migrate before the relay exits.
+  async fn broadcast_goaway(&self, timeout_ms: u64) {
+    let redirect_uri = self.redirect_uri().await;
+    let clients: Vec<Arc<MOQTClient>> = {
+      let client_manager = self.client_manager.read().await;
+      let clients = client_manager.clients.read().await;
+      clients.values().cloned().collect()
+    };
+    info!(
+      "Broadcasting GOAWAY (uri: {:?}) to {} client(s)",
+      redirect_uri,
+      clients.len()
+    );
+    for client in clients {
+      let goaway = GoAway::new(redirect_uri.clone(), timeout_ms, Some(0));
+      client
+        .queue_message(ControlMessage::Goaway(Box::new(goaway)))
+        .await;
+    }
   }
 
   /// Demultiplexes one incoming QUIC connection by its negotiated ALPN protocol —

--- a/apps/relay/src/server/config.rs
+++ b/apps/relay/src/server/config.rs
@@ -89,6 +89,11 @@ pub struct Cli {
   #[arg(long, default_value_t = 0)]
   pub write_kbps_limit: u64,
 
+  /// URI advertised to clients in GOAWAY so they can migrate to another relay.
+  /// Empty reuses the current URI. Future admin API overrides this at runtime.
+  #[arg(long)]
+  pub redirect_uri: Option<String>,
+
   /// Maximum number of upstream fetch gaps before skipping
   #[arg(long, default_value_t = 10)]
   pub max_upstream_fetch_gaps: u64,
@@ -115,6 +120,8 @@ pub struct AppConfig {
   pub max_active_requests: u64,
   /// 0 = unlimited. Non-zero caps relay writes to this many kbps per subscriber connection.
   pub write_kbps_limit: u64,
+  /// Default GOAWAY redirect URI; the runtime value lives on `Server`.
+  pub redirect_uri: Option<String>,
   pub max_upstream_fetch_gaps: u64,
   pub upstream_fetch_timeout: Duration,
 }
@@ -141,6 +148,7 @@ impl AppConfig {
         max_request_streams: cli.max_request_streams,
         max_active_requests: cli.max_active_requests,
         write_kbps_limit: cli.write_kbps_limit,
+        redirect_uri: cli.redirect_uri,
         max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
         upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
       }
@@ -258,6 +266,7 @@ mod tests {
       max_request_streams,
       max_active_requests: 0,
       write_kbps_limit: 0,
+      redirect_uri: None,
       max_upstream_fetch_gaps: 10,
       upstream_fetch_timeout: Duration::from_secs(10),
     }

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -14,13 +14,15 @@
 
 use anyhow::Result;
 use moqtail::model::{
+  common::reason_phrase::ReasonPhrase,
   control::{
     constant::SUPPORTED_VERSIONS,
     control_message::ControlMessage,
+    request_error::RequestError,
     setup::{Setup, SetupSender},
   },
   data::datagram::Datagram,
-  error::{StreamResetCode, TerminationCode},
+  error::{RequestErrorCode, StreamResetCode, TerminationCode},
 };
 use moqtail::transport::{
   connection::{
@@ -134,6 +136,7 @@ impl Session {
     let relay_pending_requests = server.relay_pending_requests.clone();
     let upstream_fetch_senders = server.upstream_fetch_senders.clone();
     let relay_next_request_id = server.relay_next_request_id.clone();
+    let draining = server.draining.clone();
 
     let request_maps = RequestMaps {
       relay_pending_requests,
@@ -148,6 +151,7 @@ impl Session {
       connection,
       relay_next_request_id,
       server.active_request_streams.clone(),
+      draining,
     ));
 
     info!(
@@ -477,9 +481,27 @@ impl Session {
       return;
     }
 
+    use std::sync::atomic::Ordering;
+
+    // While draining, reject new requests with GOING_AWAY per draft-18 10.4.
+    if context.draining.load(Ordering::Relaxed) {
+      warn!(
+        "Rejecting new request {:?} while draining (GOING_AWAY)",
+        msg.get_type()
+      );
+      let err = RequestError::new(
+        RequestErrorCode::GoingAway,
+        0,
+        ReasonPhrase::try_new("Relay is draining".to_string()).unwrap(),
+      );
+      let _ = stream_handler
+        .send(&ControlMessage::RequestError(Box::new(err)))
+        .await;
+      return;
+    }
+
     // Load shedding: once the relay is serving its configured maximum of request
     // streams, reset new ones with EXCESSIVE_LOAD instead of serving them.
-    use std::sync::atomic::Ordering;
     let max_active = context.server_config.max_active_requests;
     if max_active > 0 && context.active_request_streams.load(Ordering::Relaxed) >= max_active {
       warn!(

--- a/apps/relay/src/server/session_context.rs
+++ b/apps/relay/src/server/session_context.rs
@@ -98,9 +98,12 @@ pub struct SessionContext {
   pub(crate) relay_next_request_id: Arc<AtomicU64>,
   pub(crate) upstream_fetch_senders: Arc<RwLock<BTreeMap<u64, mpsc::Sender<UpstreamFetchEvent>>>>,
   pub(crate) active_request_streams: Arc<AtomicU64>,
+  /// Set once the relay is draining (GOAWAY sent); new requests are rejected.
+  pub(crate) draining: Arc<AtomicBool>,
 }
 
 impl SessionContext {
+  #[allow(clippy::too_many_arguments)]
   pub fn new(
     server_config: &'static AppConfig,
     client_manager: Arc<RwLock<ClientManager>>,
@@ -109,6 +112,7 @@ impl SessionContext {
     connection: TransportConnection,
     relay_next_request_id: Arc<AtomicU64>,
     active_request_streams: Arc<AtomicU64>,
+    draining: Arc<AtomicBool>,
   ) -> Self {
     Self {
       client_manager,
@@ -123,6 +127,7 @@ impl SessionContext {
       relay_next_request_id,
       upstream_fetch_senders: request_maps.upstream_fetch_senders,
       active_request_streams,
+      draining,
     }
   }
 


### PR DESCRIPTION
SIGTERM now drains the relay: it sets a draining flag, broadcasts GOAWAY to every connected client, and exits after a 10s drain window. Ctrl-C still exits immediately.

The GOAWAY carries a redirect URI so clients can migrate. The URI is a runtime value on Server (Arc<RwLock<Option<String>>>) seeded from the new --redirect-uri config option; a future admin API can overwrite it without touching the drain path. Server::redirect_uri() exposes it.

While draining, handle_request_stream rejects any new request stream with REQUEST_ERROR / GOING_AWAY per draft-18 10.4.
