### PR TITLE
feat: reset slow subscribers with TOO_FAR_BEHIND (#250)

### DIFF
--- a/apps/relay/src/server/client.rs
+++ b/apps/relay/src/server/client.rs
@@ -433,6 +433,16 @@ impl MOQTClient {
     send_streams.remove(stream_id.get_stream_id().as_str())
   }
 
+  /// Reset a data stream with an application error code (QUIC RESET_STREAM) and
+  /// drop it from the send-stream map.
+  pub async fn reset_stream(&self, stream_id: &StreamId, code: u64) {
+    if let Some(stream) = self.remove_stream_by_stream_id(stream_id).await
+      && let Err(e) = stream.lock().await.reset(code)
+    {
+      warn!("Error resetting data stream {}: {:?}", stream_id, e);
+    }
+  }
+
   pub async fn write_stream_object(
     &self,
     stream_id: &StreamId,

--- a/apps/relay/src/server/config.rs
+++ b/apps/relay/src/server/config.rs
@@ -84,6 +84,11 @@ pub struct Cli {
   #[arg(long, default_value_t = 0)]
   pub max_active_requests: u64,
 
+  /// Max objects queued for a subscriber before its data streams are reset with
+  /// TOO_FAR_BEHIND. 0 disables the check.
+  #[arg(long, default_value_t = 0)]
+  pub max_subscriber_lag: u64,
+
   /// Simulate a bandwidth cap per subscriber connection (kbps). 0 = unlimited.
   /// Useful for testing QUIC stream priority scheduling without OS-level throttling.
   #[arg(long, default_value_t = 0)]
@@ -113,6 +118,7 @@ pub struct AppConfig {
   pub token_log_path: String,
   pub max_request_streams: u64,
   pub max_active_requests: u64,
+  pub max_subscriber_lag: u64,
   /// 0 = unlimited. Non-zero caps relay writes to this many kbps per subscriber connection.
   pub write_kbps_limit: u64,
   pub max_upstream_fetch_gaps: u64,
@@ -140,6 +146,7 @@ impl AppConfig {
         token_log_path: cli.token_log_path,
         max_request_streams: cli.max_request_streams,
         max_active_requests: cli.max_active_requests,
+        max_subscriber_lag: cli.max_subscriber_lag,
         write_kbps_limit: cli.write_kbps_limit,
         max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
         upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
@@ -257,6 +264,7 @@ mod tests {
       token_log_path: "/tmp/moqtail_relay_tokens.csv".to_string(),
       max_request_streams,
       max_active_requests: 0,
+      max_subscriber_lag: 0,
       write_kbps_limit: 0,
       max_upstream_fetch_gaps: 10,
       upstream_fetch_timeout: Duration::from_secs(10),

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -37,6 +37,7 @@ use moqtail::model::control::subscribe::Subscribe;
 use moqtail::model::data::full_track_name::FullTrackName;
 use moqtail::model::data::object::Object;
 use moqtail::model::data::subgroup_header::SubgroupHeader;
+use moqtail::model::error::StreamResetCode;
 use moqtail::model::parameter::message_parameter::{
   MessageParameter, apply_message_parameter_update,
 };
@@ -837,17 +838,36 @@ impl Subscription {
     );
 
     let mut event_rx_guard = self.event_rx.lock().await;
-    let recv_result = {
+    let (recv_result, backlog) = {
       let Some(ref mut rx) = *event_rx_guard else {
         return;
       };
-      rx.recv().await
+      let event = rx.recv().await;
+      let backlog = rx.len();
+      (event, backlog)
     };
 
     trace!(
       "Received event for subscriber={} relay_track_id={}: {:?}",
       self.client_connection_id, self.relay_track_id, recv_result
     );
+
+    // Slow-subscriber shedding: once the queued backlog exceeds the limit, the
+    // subscriber can't keep up, so reset its data streams with TOO_FAR_BEHIND.
+    let max_lag = self.config.max_subscriber_lag;
+    if max_lag > 0 && backlog as u64 > max_lag && !self.finished.load(Ordering::Relaxed) {
+      warn!(
+        "Subscriber {} too far behind on relay_track_id={} ({} queued > {}); resetting data streams (TOO_FAR_BEHIND)",
+        self.client_connection_id, self.relay_track_id, backlog, max_lag
+      );
+      event_rx_guard.take();
+      drop(event_rx_guard);
+      self
+        .reset_data_streams(StreamResetCode::TooFarBehind.to_u64())
+        .await;
+      self.finish().await;
+      return;
+    }
 
     match recv_result {
       Some(event) if !self.finished.load(Ordering::Relaxed) => {
@@ -866,6 +886,17 @@ impl Subscription {
         event_rx_guard.take();
         drop(event_rx_guard);
       }
+    }
+  }
+
+  /// Reset every data stream this subscription has opened with the given code.
+  async fn reset_data_streams(&self, code: u64) {
+    let stream_ids: Vec<StreamId> = {
+      let map = self.send_stream_last_object_ids.read().await;
+      map.keys().cloned().collect()
+    };
+    for stream_id in stream_ids {
+      self.subscriber.reset_stream(&stream_id, code).await;
     }
   }
 


### PR DESCRIPTION
Add a max_subscriber_lag config (0 = disabled). When a subscriber's queued object backlog exceeds it, the subscriber can't keep up, so the relay resets that subscription's data streams with TOO_FAR_BEHIND and finishes it.

Second of three abort-path changes for RL-5.
