### PR TITLE
feat(relay): SUBSCRIBE precedence over SUBSCRIBE_TRACKS; 

### DIFF
--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -180,6 +180,19 @@ pub async fn handle(
         }
 
         for subscriber in subscribers {
+          // Never push a track back to its own publisher, and let an explicit
+          // SUBSCRIBE take precedence over SUBSCRIBE_TRACKS for the same track.
+          if subscriber.connection_id == context.connection_id
+            || track_arc
+              .read()
+              .await
+              .get_subscription(subscriber.connection_id)
+              .await
+              .is_some()
+          {
+            continue;
+          }
+
           info!(
             "Forwarding Publish to interested client: {}",
             subscriber.connection_id

--- a/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
@@ -119,6 +119,17 @@ pub async fn handle_subscribe_tracks(
     .await;
 
   for (full_track_name, track_arc, original_publish_message_opt) in matched_tracks {
+    // Exclude the subscriber's own published tracks, and let an explicit
+    // SUBSCRIBE take precedence over SUBSCRIBE_TRACKS for the same track.
+    let already_served = {
+      let track = track_arc.read().await;
+      track.is_published_by(client.connection_id).await
+        || track.get_subscription(client.connection_id).await.is_some()
+    };
+    if already_served {
+      continue;
+    }
+
     if let Some(mut original_publish_message) = original_publish_message_opt {
       info!("Forwarding existing track to SUBSCRIBE_TRACKS subscriber: {full_track_name:?}");
 

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -180,6 +180,15 @@ impl Track {
     !self.publisher_aliases.read().await.is_empty()
   }
 
+  /// Whether the given connection is one of this track's publishers.
+  pub async fn is_published_by(&self, connection_id: usize) -> bool {
+    self
+      .publisher_aliases
+      .read()
+      .await
+      .contains_key(&connection_id)
+  }
+
   /// Transition from Pending to Confirmed. Adds publisher alias and notifies waiters.
   pub async fn confirm(
     &mut self,


### PR DESCRIPTION
Closes #249
 
Exclude own tracks (RL-3).

When the relay pushes a PUBLISH to SUBSCRIBE_TRACKS subscribers, skip a subscriber that already holds an explicit SUBSCRIBE for the track (the SUBSCRIBE path serves it) and never push a track back to its own publisher.

Guards both fan-out points: the live PUBLISH fan-out in publish_handler and the retroactive forwarding of already-published tracks in subscribe_tracks_handler. Adds Track::is_published_by for the own-tracks check
