### PR TITLE
feat(relay): joining-fetch forward-state semantics (RL-7a, #315)

### DIFF
--- a/apps/client/README.md
+++ b/apps/client/README.md
@@ -1,6 +1,6 @@
 # MOQtail Test Client
 
-A unified test client for the MOQtail relay, supporting publish, subscribe, and fetch operations over MoQ Transport (draft-16). Supports both subgroup (unidirectional streams) and datagram object forwarding preferences.
+A unified test client for the MOQtail relay, supporting publish, subscribe, and fetch operations over MoQ Transport (draft-18). Supports both subgroup (unidirectional streams) and datagram object forwarding preferences.
 
 ## Usage
 
@@ -19,14 +19,15 @@ cargo run --bin client -- --command <COMMAND> [OPTIONS]
 
 ## Global Options
 
-| Option                    | Short | Default                  | Description                                                         |
-| ------------------------- | ----- | ------------------------ | ------------------------------------------------------------------- |
-| `--command`               | `-c`  | _(required)_             | Command to run                                                      |
-| `--server`                | `-s`  | `https://127.0.0.1:4433` | Server address. `https://` for WebTransport, `moqt://` for raw QUIC |
-| `--namespace`             | `-n`  | `moqtail`                | Track namespace                                                     |
-| `--track-name`            | `-T`  | `demo`                   | Track name                                                          |
-| `--no-cert-validation`    |       | `false`                  | Skip certificate validation                                         |
-| `--forwarding-preference` |       | `subgroup`               | Object forwarding preference (`subgroup` or `datagram`)             |
+| Option                 | Short | Default                 | Description                                     |
+| ---------------------- | ----- | ----------------------- | ----------------------------------------------- |
+| `--command`            | `-c`  | _(required)_            | Command to run                                  |
+| `--server`             | `-s`  | `moqt://127.0.0.1:4433` | Server address as a `moqt://` URI               |
+| `--transport`          |       | `web-transport`         | Session transport (`web-transport` or `quic`)   |
+| `--namespace`          | `-n`  | `moqtail`               | Track namespace                                 |
+| `--track-name`         | `-T`  | `demo`                  | Track name                                      |
+| `--no-cert-validation` |       | `false`                 | Skip certificate validation                     |
+| `--delivery-mode`      |       | `subgroup`              | Object delivery mode (`subgroup` or `datagram`) |
 
 ## Publish Options
 
@@ -41,12 +42,16 @@ cargo run --bin client -- --command <COMMAND> [OPTIONS]
 
 ## Subscribe Options
 
-| Option                  | Short | Default     | Description                                                     |
-| ----------------------- | ----- | ----------- | --------------------------------------------------------------- |
-| `--duration`            | `-d`  | `0`         | Duration to listen in seconds (0 = indefinite)                  |
-| `--subscriber-priority` |       | `128`       | Subscriber priority 0 (highest) – 255 (lowest)                  |
-| `--group-order`         |       | `ascending` | Group delivery order (`original`, `ascending`, `descending`)    |
-| `--extra-track`         |       | _(none)_    | Second track subscription for priority testing: `name:priority` |
+| Option                  | Short | Default     | Description                                                         |
+| ----------------------- | ----- | ----------- | ------------------------------------------------------------------- |
+| `--duration`            | `-d`  | `0`         | Duration to listen in seconds (0 = indefinite)                      |
+| `--subscriber-priority` |       | `128`       | Subscriber priority 0 (highest) – 255 (lowest)                      |
+| `--group-order`         |       | `ascending` | Group delivery order (`original`, `ascending`, `descending`)        |
+| `--extra-track`         |       | _(none)_    | Second track subscription for priority testing: `name:priority`     |
+| `--forward`             |       | `true`      | Subscription Forward State; set `false` to suppress object delivery |
+| `--joining-fetch`       |       | `false`     | After subscribing, issue a Joining FETCH against the subscription   |
+| `--joining-start`       |       | `0`         | Joining FETCH start group (with `--joining-fetch`)                  |
+| `--joining-type`        |       | `relative`  | Joining FETCH type (`relative` or `absolute`)                       |
 
 ## Fetch Options
 
@@ -63,13 +68,13 @@ cargo run --bin client -- --command <COMMAND> [OPTIONS]
 Publish 50 groups of datagrams at 500ms intervals:
 
 ```
-cargo run --bin client -- -c publish --forwarding-preference datagram --group-count 50 --interval 500
+cargo run --bin client -- -c publish --delivery-mode datagram --group-count 50 --interval 500
 ```
 
 Subscribe to datagrams for 30 seconds:
 
 ```
-cargo run --bin client -- -c subscribe --forwarding-preference datagram --duration 30
+cargo run --bin client -- -c subscribe --delivery-mode datagram --duration 30
 ```
 
 Subscribe to subgroup streams indefinitely:
@@ -84,16 +89,30 @@ Fetch objects from groups 0-10:
 cargo run --bin client -- -c fetch --start-group 0 --end-group 10
 ```
 
+Subscribe, then issue a Joining FETCH for the last 2 groups (a Joining FETCH is
+only accepted when the subscription is forwarding):
+
+```
+cargo run --bin client -- -c subscribe --joining-fetch --joining-start 2
+```
+
+Same, but with a non-forwarding subscription — the relay rejects the Joining
+FETCH with `REQUEST_ERROR` / `INVALID_RANGE`:
+
+```
+cargo run --bin client -- -c subscribe --forward false --joining-fetch --joining-start 2
+```
+
 Connect to a remote server with certificate validation disabled:
 
 ```
-cargo run --bin client -- -c publish --server https://relay.example.com:4433 --no-cert-validation
+cargo run --bin client -- -c publish --server moqt://relay.example.com:4433 --no-cert-validation
 ```
 
 Connect over raw QUIC instead of WebTransport:
 
 ```
-cargo run --bin client -- -c subscribe --server moqt://relay.example.com:4433
+cargo run --bin client -- -c subscribe --server moqt://relay.example.com:4433 --transport quic
 ```
 
 ## Testing QUIC Stream Priority Scheduling

--- a/apps/client/src/cli.rs
+++ b/apps/client/src/cli.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use clap::{Parser, ValueEnum};
-use moqtail::model::control::constant::GroupOrder;
+use moqtail::model::control::constant::{FetchType, GroupOrder};
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum CliGroupOrder {
@@ -28,6 +28,23 @@ impl From<CliGroupOrder> for GroupOrder {
       CliGroupOrder::Original => GroupOrder::Original,
       CliGroupOrder::Ascending => GroupOrder::Ascending,
       CliGroupOrder::Descending => GroupOrder::Descending,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum CliJoiningType {
+  /// Joining Fetch relative to the Largest group (start = largest - joining_start)
+  Relative,
+  /// Absolute Joining Fetch (start = joining_start)
+  Absolute,
+}
+
+impl From<CliJoiningType> for FetchType {
+  fn from(t: CliJoiningType) -> Self {
+    match t {
+      CliJoiningType::Relative => FetchType::RelativeFetch,
+      CliJoiningType::Absolute => FetchType::AbsoluteFetch,
     }
   }
 }
@@ -156,4 +173,22 @@ pub struct Cli {
   /// e.g. --extra-track demo2:200
   #[arg(long)]
   pub extra_track: Option<String>,
+
+  /// Subscription Forward State (subscribe only). Set false to test that a
+  /// joining FETCH against a non-forwarding subscription is rejected.
+  #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+  pub forward: bool,
+
+  /// After subscribing, issue a Joining FETCH referencing the subscription
+  /// (subscribe only).
+  #[arg(long, default_value_t = false)]
+  pub joining_fetch: bool,
+
+  /// Joining FETCH start group (subscribe + --joining-fetch only)
+  #[arg(long, default_value_t = 0)]
+  pub joining_start: u64,
+
+  /// Joining FETCH type (subscribe + --joining-fetch only)
+  #[arg(long, value_enum, default_value = "relative")]
+  pub joining_type: CliJoiningType,
 }

--- a/apps/client/src/main.rs
+++ b/apps/client/src/main.rs
@@ -83,6 +83,10 @@ async fn main() -> Result<(), anyhow::Error> {
           let priority: u8 = prio.parse().ok()?;
           Some((name.to_string(), priority))
         }),
+        forward: cli.forward,
+        joining_fetch: cli.joining_fetch,
+        joining_start: cli.joining_start,
+        joining_type: cli.joining_type.into(),
       };
       subscriber::run(moq_conn, config).await
     }

--- a/apps/client/src/subscriber.rs
+++ b/apps/client/src/subscriber.rs
@@ -18,8 +18,9 @@ use crate::stats::ReceptionStats;
 use crate::utils::should_log;
 use anyhow::Result;
 use moqtail::model::common::tuple::{Tuple, TupleField};
-use moqtail::model::control::constant::GroupOrder;
+use moqtail::model::control::constant::{FetchType, GroupOrder};
 use moqtail::model::control::control_message::ControlMessage;
+use moqtail::model::control::fetch::Fetch;
 use moqtail::model::control::subscribe::Subscribe;
 use moqtail::model::data::datagram::Datagram;
 use moqtail::model::parameter::message_parameter::MessageParameter;
@@ -41,11 +42,12 @@ async fn subscribe_track(
   request_id: u64,
   subscriber_priority: u8,
   group_order: GroupOrder,
+  forward: bool,
 ) -> Result<(u64, ControlStreamHandler)> {
   let ns = Tuple::from_utf8_path(namespace);
   info!(
-    "Subscribing to track: {}/{} (request_id={}, priority={})",
-    namespace, track_name, request_id, subscriber_priority
+    "Subscribing to track: {}/{} (request_id={}, priority={}, forward={})",
+    namespace, track_name, request_id, subscriber_priority, forward
   );
   let subscribe = Subscribe::new_latest_object(
     request_id,
@@ -54,7 +56,7 @@ async fn subscribe_track(
     vec![
       MessageParameter::new_subscriber_priority(subscriber_priority),
       MessageParameter::new_group_order(group_order),
-      MessageParameter::new_forward(true),
+      MessageParameter::new_forward(forward),
     ],
   );
 
@@ -88,6 +90,58 @@ pub struct SubscribeConfig {
   pub subscriber_priority: u8,
   pub group_order: GroupOrder,
   pub extra_track: Option<(String, u8)>,
+  pub forward: bool,
+  pub joining_fetch: bool,
+  pub joining_start: u64,
+  pub joining_type: FetchType,
+}
+
+/// Issue a Joining FETCH referencing an existing subscription and log the
+/// response (FETCH_OK when accepted, REQUEST_ERROR — e.g. INVALID_RANGE for a
+/// non-forwarding subscription — when rejected).
+async fn send_joining_fetch(
+  connection: &Arc<TransportConnection>,
+  joining_request_id: u64,
+  joining_start: u64,
+  fetch_type: FetchType,
+) -> Result<()> {
+  let request_id = 2u64;
+  let parameters = vec![MessageParameter::new_subscriber_priority(200)];
+  let fetch = Fetch::new_joining(
+    request_id,
+    fetch_type,
+    joining_request_id,
+    joining_start,
+    parameters,
+  )
+  .map_err(|e| anyhow::anyhow!("Failed to build joining FETCH: {}", e))?;
+
+  info!(
+    "Sending Joining FETCH: type={:?} joining_request_id={} joining_start={}",
+    fetch_type, joining_request_id, joining_start
+  );
+
+  let (send, recv) = connection.open_bi().await?;
+  let mut request_stream = ControlStreamHandler::new(send, recv);
+  request_stream
+    .send(&ControlMessage::Fetch(Box::new(fetch)))
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to send joining FETCH: {:?}", e))?;
+
+  match request_stream.next_message().await {
+    Ok(ControlMessage::FetchOk(m)) => {
+      info!(
+        "Joining FETCH accepted: FetchOk end_location={:?}",
+        m.end_location
+      );
+    }
+    Ok(ControlMessage::RequestError(m)) => {
+      error!("Joining FETCH rejected: RequestError {:?}", m);
+    }
+    Ok(m) => info!("Joining FETCH response: {:?}", m),
+    Err(e) => error!("Joining FETCH: error reading response: {:?}", e),
+  }
+  Ok(())
 }
 
 pub async fn run(moq: MoqConnection, config: SubscribeConfig) -> Result<()> {
@@ -106,9 +160,18 @@ pub async fn run(moq: MoqConnection, config: SubscribeConfig) -> Result<()> {
     0,
     config.subscriber_priority,
     config.group_order,
+    config.forward,
   )
   .await?;
   request_streams.push(primary_stream);
+
+  // Issue a Joining FETCH against the primary subscription (request_id 0). Kept
+  // before the receive loop so its response is observed directly.
+  if config.joining_fetch {
+    send_joining_fetch(&connection, 0, config.joining_start, config.joining_type).await?;
+    drop(request_streams);
+    return Ok(());
+  }
 
   let extra_alias = if let Some((ref extra_name, extra_priority)) = config.extra_track {
     let (alias, extra_stream) = subscribe_track(
@@ -118,6 +181,7 @@ pub async fn run(moq: MoqConnection, config: SubscribeConfig) -> Result<()> {
       1,
       extra_priority,
       config.group_order,
+      config.forward,
     )
     .await?;
     request_streams.push(extra_stream);

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -129,64 +129,80 @@ pub async fn handle(
           .insert(request_id, PendingRequest::Fetch(req));
       }
 
+      // Resolves the fetch target. The bool is `rejected`: true when a
+      // REQUEST_ERROR was already sent, so the caller must stop without also
+      // sending DoesNotExist.
       let fn_ = async {
         if let Some(joining_fetch_props) = fetch.clone().joining_fetch_props {
           let sub_request_id = joining_fetch_props.joining_request_id;
-          let sub_requests = client.subscribe_requests.read().await;
-          // the original request id is the request id of the subscribe request that created the subscription
-          let existing_sub = sub_requests
-            .iter()
-            .find(|e| e.1.original_request_id == sub_request_id);
-          if existing_sub.is_none() {
+
+          // Resolve the associated subscription regardless of how it was created
+          // (SUBSCRIBE, PUBLISH/PUBLISH_OK or REQUEST_UPDATE).
+          let Some((track_lock, subscription)) = context
+            .track_manager
+            .find_subscription_by_request_id(client.connection_id, sub_request_id)
+            .await
+          else {
             error!(
-              "handle_fetch_messages | Joining fetch request id not found: {:?} {:?}",
-              sub_request_id, sub_requests
+              "handle_fetch_messages | Joining fetch subscription not found: request_id={}",
+              sub_request_id
             );
-            return (None, None, None);
-          }
-          let existing_sub = existing_sub.unwrap().1;
+            return (None, None, None, false);
+          };
 
-          let full_track_name = existing_sub
-            .original_subscribe_request
-            .get_full_track_name();
-          let track_lock = context.track_manager.get_track(&full_track_name).await;
-
-          if let Some(track_lock) = track_lock {
-            let track = track_lock.read().await;
-            let largest_location = track.largest_location.read().await;
-
-            // TODO: validate the range
-            if largest_location.group < joining_fetch_props.joining_start {
-              error!(
-                "handle_fetch_messages | Joining fetch start location is larger than the track's largest location: {:?} {:?}",
-                largest_location, joining_fetch_props.joining_start
-              );
-              send_request_error(
-                client.clone(),
-                request_id,
-                RequestErrorCode::InvalidRange,
-                ReasonPhrase::try_new(String::from("Invalid range")).unwrap(),
-              )
-              .await;
-              return (None, None, None);
-            }
-
-            let start_group = if fetch.fetch_type == FetchType::RelativeFetch {
-              largest_location.group - joining_fetch_props.joining_start
-            } else {
-              joining_fetch_props.joining_start
-            };
-
-            let start_location = Location::new(start_group, 0);
-            let end_location = Location::new(largest_location.group, largest_location.object + 1);
-            (
-              Some(track_lock.clone()),
-              Some(start_location),
-              Some(end_location),
+          // A Joining Fetch is only permitted when the associated subscription
+          // has Forward State 1. REQUEST_UPDATE keeps this state current, so
+          // reading it here already reflects any processed update.
+          if !subscription.read().await.is_forwarding().await {
+            warn!(
+              "handle_fetch_messages | Joining fetch on non-forwarding subscription {}; INVALID_RANGE",
+              sub_request_id
+            );
+            send_request_error(
+              client.clone(),
+              request_id,
+              RequestErrorCode::InvalidRange,
+              ReasonPhrase::try_new(String::from(
+                "Joining fetch requires a forwarding subscription",
+              ))
+              .unwrap(),
             )
-          } else {
-            (None, None, None)
+            .await;
+            return (None, None, None, true);
           }
+
+          let track = track_lock.read().await;
+          let largest_location = track.largest_location.read().await;
+
+          if largest_location.group < joining_fetch_props.joining_start {
+            error!(
+              "handle_fetch_messages | Joining fetch start location is larger than the track's largest location: {:?} {:?}",
+              largest_location, joining_fetch_props.joining_start
+            );
+            send_request_error(
+              client.clone(),
+              request_id,
+              RequestErrorCode::InvalidRange,
+              ReasonPhrase::try_new(String::from("Invalid range")).unwrap(),
+            )
+            .await;
+            return (None, None, None, true);
+          }
+
+          let start_group = if fetch.fetch_type == FetchType::RelativeFetch {
+            largest_location.group - joining_fetch_props.joining_start
+          } else {
+            joining_fetch_props.joining_start
+          };
+
+          let start_location = Location::new(start_group, 0);
+          let end_location = Location::new(largest_location.group, largest_location.object + 1);
+          (
+            Some(track_lock.clone()),
+            Some(start_location),
+            Some(end_location),
+            false,
+          )
         } else {
           // standalone fetch
           let props = fetch.standalone_fetch_props.clone().unwrap();
@@ -203,14 +219,20 @@ pub async fn handle(
               Some(track),
               Some(props.start_location.clone()),
               Some(props.end_location.clone()),
+              false,
             )
           } else {
-            (None, None, None)
+            (None, None, None, false)
           }
         }
       };
 
-      let (track, start_location, end_location) = fn_.await;
+      let (track, start_location, end_location, rejected) = fn_.await;
+
+      // A REQUEST_ERROR was already sent during resolution; stop here.
+      if rejected {
+        return Ok(());
+      }
 
       // TODO: send fetch message to the publisher
       if track.is_none() {

--- a/apps/relay/src/server/track_manager.rs
+++ b/apps/relay/src/server/track_manager.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::subscription::Subscription;
 use super::track::Track;
 use crate::server::client::MOQTClient;
 use moqtail::model::common::tuple::Tuple;
@@ -184,6 +185,32 @@ impl TrackManager {
   pub async fn has_track(&self, full_track_name: &FullTrackName) -> bool {
     let tracks = self.tracks.read().await;
     tracks.contains_key(full_track_name)
+  }
+
+  /// Find the subscription a connection holds with the given request id, across
+  /// all tracks, regardless of how it was created (SUBSCRIBE, PUBLISH/PUBLISH_OK
+  /// or REQUEST_UPDATE). Used to resolve the subscription a Joining FETCH targets.
+  pub async fn find_subscription_by_request_id(
+    &self,
+    connection_id: usize,
+    request_id: u64,
+  ) -> Option<(Arc<RwLock<Track>>, Arc<RwLock<Subscription>>)> {
+    let track_arcs: Vec<Arc<RwLock<Track>>> = {
+      let tracks = self.tracks.read().await;
+      tracks.values().cloned().collect()
+    };
+    for track_arc in track_arcs {
+      let sub_opt = {
+        let track = track_arc.read().await;
+        track.get_subscription(connection_id).await
+      };
+      if let Some(sub) = sub_opt
+        && sub.read().await.request_id == request_id
+      {
+        return Some((track_arc, sub));
+      }
+    }
+    None
   }
 
   pub async fn has_track_alias(&self, connection_id: usize, track_alias: &u64) -> bool {


### PR DESCRIPTION
- A Joining FETCH is only permitted when the associated subscription has Forward State 1; otherwise the relay responds with REQUEST_ERROR INVALID_RANGE (draft-18 10.12.2). The live subscription state is read, so a processed REQUEST_UPDATE is already reflected.
- Resolve the associated subscription via a new TrackManager::find_subscription_by_request_id, which matches by (connection_id, request_id) across all tracks. This lets a Joining FETCH reference a subscription created via SUBSCRIBE, PUBLISH/PUBLISH_OK or REQUEST_UPDATE, not only SUBSCRIBE.
- Changing Forward State to 0 after acceptance has no effect: the accepted fetch delivers independently of subscription state.
- Fix a latent double REQUEST_ERROR on joining error paths via a rejected flag.

Client gains joining-FETCH tooling for end-to-end testing: subscribe now takes --forward, --joining-fetch, --joining-start and --joining-type, and issues a Joining FETCH against the subscription. README updated (and stale draft-16 / --forwarding-preference / --server references corrected).
