### PR TITLE
feat(relay,client): FETCH Stream Count and prior-gap semantics (RL-7b)

### DIFF
--- a/apps/client/README.md
+++ b/apps/client/README.md
@@ -31,14 +31,16 @@ cargo run --bin client -- --command <COMMAND> [OPTIONS]
 
 ## Publish Options
 
-| Option                 | Short | Default    | Description                                   |
-| ---------------------- | ----- | ---------- | --------------------------------------------- |
-| `--group-count`        |       | `100`      | Number of groups to send                      |
-| `--interval`           | `-i`  | `1000`     | Interval between objects in milliseconds      |
-| `--objects-per-group`  |       | `10`       | Number of objects per group                   |
-| `--payload-size`       |       | `1200`     | Payload size in bytes                         |
-| `--track-alias`        |       | _(random)_ | Track alias (random if not specified)         |
-| `--publisher-priority` |       | `128`      | Publisher priority 0 (highest) – 255 (lowest) |
+| Option                 | Short | Default    | Description                                                           |
+| ---------------------- | ----- | ---------- | --------------------------------------------------------------------- |
+| `--group-count`        |       | `100`      | Number of groups to send                                              |
+| `--interval`           | `-i`  | `1000`     | Interval between objects in milliseconds                              |
+| `--objects-per-group`  |       | `10`       | Number of objects per group                                           |
+| `--object-id-step`     |       | `1`        | Stride between object IDs (`2` → 0, 2, 4 …); sets Prior Object ID Gap |
+| `--group-id-step`      |       | `1`        | Stride between group IDs (`2` → 0, 2, 4 …); sets Prior Group ID Gap   |
+| `--payload-size`       |       | `1200`     | Payload size in bytes                                                 |
+| `--track-alias`        |       | _(random)_ | Track alias (random if not specified)                                 |
+| `--publisher-priority` |       | `128`      | Publisher priority 0 (highest) – 255 (lowest)                         |
 
 ## Subscribe Options
 
@@ -87,6 +89,26 @@ Fetch objects from groups 0-10:
 
 ```
 cargo run --bin client -- -c fetch --start-group 0 --end-group 10
+```
+
+Publish a track with gaps in the object IDs (0, 2, 4 …), then FETCH it — the
+response delivers only the existing objects and closes with a FIN, so the gaps
+signal non-existent objects. Each skipped object also carries the Prior Object
+ID Gap property (draft 12.9), which the fetcher logs as `[prior_object_gap=N]`:
+
+```
+cargo run --bin client -- -c publish --object-id-step 2 --objects-per-group 3
+cargo run --bin client -- -c fetch --start-group 0 --end-group 3
+```
+
+Group-ID gaps work the same way via `--group-id-step`, setting the Prior Group
+ID Gap property (draft 12.8) on the first object of each gapped group. Run the
+relay with `--max-upstream-fetch-gaps 0` so it serves only the cached groups
+instead of trying to fetch the (non-existent) missing groups upstream:
+
+```
+cargo run --bin client -- -c publish --group-id-step 2 --objects-per-group 2
+cargo run --bin client -- -c fetch --start-group 0 --end-group 7
 ```
 
 Subscribe, then issue a Joining FETCH for the last 2 groups (a Joining FETCH is

--- a/apps/client/src/cli.rs
+++ b/apps/client/src/cli.rs
@@ -125,6 +125,18 @@ pub struct Cli {
   #[arg(long, default_value_t = 10)]
   pub objects_per_group: u64,
 
+  /// Stride between object IDs within a group (publish only). >1 leaves gaps in
+  /// the object IDs (e.g. 2 emits 0, 2, 4) and sets the Prior Object ID Gap
+  /// property (draft 12.9) so gaps are communicated explicitly.
+  #[arg(long, default_value_t = 1)]
+  pub object_id_step: u64,
+
+  /// Stride between group IDs (publish only). >1 leaves gaps in the group IDs
+  /// (e.g. 2 emits 0, 2, 4) and sets the Prior Group ID Gap property
+  /// (draft 12.8) so gaps are communicated explicitly.
+  #[arg(long, default_value_t = 1)]
+  pub group_id_step: u64,
+
   /// Payload size in bytes (publish only)
   #[arg(long, default_value_t = 1200)]
   pub payload_size: usize,

--- a/apps/client/src/fetcher.rs
+++ b/apps/client/src/fetcher.rs
@@ -20,12 +20,31 @@ use moqtail::model::control::control_message::ControlMessage;
 use moqtail::model::control::fetch::{Fetch, StandaloneFetchProps};
 use moqtail::model::error::StreamResetCode;
 use moqtail::model::parameter::message_parameter::MessageParameter;
+use moqtail::model::property::object_property::ObjectProperty;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use moqtail::transport::data_stream_handler::{FetchRequest, RecvDataStream};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{error, info};
+
+/// Render any Prior Group/Object ID Gap properties (draft 12.8 / 12.9) for logging.
+fn format_prior_gaps(properties: &Option<Vec<ObjectProperty>>) -> String {
+  let Some(props) = properties else {
+    return String::new();
+  };
+  let mut out = String::new();
+  for p in props {
+    match p {
+      ObjectProperty::PriorGroupIdGap { gap } => out.push_str(&format!(" [prior_group_gap={gap}]")),
+      ObjectProperty::PriorObjectIdGap { gap } => {
+        out.push_str(&format!(" [prior_object_gap={gap}]"))
+      }
+      _ => {}
+    }
+  }
+  out
+}
 
 enum FetchReceiveSignal {
   // The configured cancel_after object threshold was reached.
@@ -110,8 +129,10 @@ pub async fn run(moq: MoqConnection, config: FetchConfig) -> Result<()> {
             match object {
               Some(obj) => {
                 info!(
-                  "Fetched object: group={}, object={}",
-                  obj.location.group, obj.location.object
+                  "Fetched object: group={}, object={}{}",
+                  obj.location.group,
+                  obj.location.object,
+                  format_prior_gaps(&obj.properties)
                 );
                 total_objects += 1;
                 handler = next_handler;

--- a/apps/client/src/main.rs
+++ b/apps/client/src/main.rs
@@ -50,6 +50,8 @@ async fn main() -> Result<(), anyhow::Error> {
         group_count: cli.group_count,
         interval: cli.interval,
         objects_per_group: cli.objects_per_group,
+        object_id_step: cli.object_id_step,
+        group_id_step: cli.group_id_step,
         payload_size: cli.payload_size,
         track_alias: cli
           .track_alias
@@ -65,6 +67,8 @@ async fn main() -> Result<(), anyhow::Error> {
         group_count: cli.group_count,
         interval: cli.interval,
         objects_per_group: cli.objects_per_group,
+        object_id_step: cli.object_id_step,
+        group_id_step: cli.group_id_step,
         payload_size: cli.payload_size,
         publisher_priority: cli.publisher_priority,
       };

--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -28,6 +28,7 @@ use moqtail::model::data::object::Object;
 use moqtail::model::data::subgroup_header::SubgroupHeader;
 use moqtail::model::data::subgroup_object::SubgroupObject;
 use moqtail::model::parameter::message_parameter::MessageParameter;
+use moqtail::model::property::object_property::ObjectProperty;
 use moqtail::transport::connection::TransportConnection;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use moqtail::transport::data_stream_handler::{HeaderInfo, SendDataStream};
@@ -43,6 +44,8 @@ pub struct PublishConfig {
   pub group_count: u64,
   pub interval: u64,
   pub objects_per_group: u64,
+  pub object_id_step: u64,
+  pub group_id_step: u64,
   pub payload_size: usize,
   pub track_alias: u64,
   pub publisher_priority: u8,
@@ -54,6 +57,8 @@ pub struct PublishNamespaceConfig {
   pub group_count: u64,
   pub interval: u64,
   pub objects_per_group: u64,
+  pub object_id_step: u64,
+  pub group_id_step: u64,
   pub payload_size: usize,
   pub publisher_priority: u8,
 }
@@ -72,6 +77,8 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
     group_count: config.group_count,
     interval: config.interval,
     objects_per_group: config.objects_per_group,
+    object_id_step: config.object_id_step,
+    group_id_step: config.group_id_step,
     payload_size: config.payload_size,
     publisher_priority: config.publisher_priority,
   };
@@ -181,6 +188,8 @@ pub async fn run(moq: MoqConnection, config: PublishConfig) -> Result<()> {
     group_count: config.group_count,
     interval: config.interval,
     objects_per_group: config.objects_per_group,
+    object_id_step: config.object_id_step,
+    group_id_step: config.group_id_step,
     payload_size: config.payload_size,
     publisher_priority: config.publisher_priority,
   };
@@ -239,6 +248,8 @@ struct DataConfig {
   group_count: u64,
   interval: u64,
   objects_per_group: u64,
+  object_id_step: u64,
+  group_id_step: u64,
   payload_size: usize,
   publisher_priority: u8,
 }
@@ -298,6 +309,8 @@ async fn send_data(
         config.group_count,
         config.interval,
         config.objects_per_group,
+        config.object_id_step,
+        config.group_id_step,
         config.payload_size,
         config.publisher_priority,
       )
@@ -310,6 +323,8 @@ async fn send_data(
         config.group_count,
         config.interval,
         config.objects_per_group,
+        config.object_id_step,
+        config.group_id_step,
         config.payload_size,
         config.publisher_priority,
       )
@@ -318,31 +333,49 @@ async fn send_data(
   }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn send_datagrams(
   connection: &TransportConnection,
   track_alias: u64,
   group_count: u64,
   interval_ms: u64,
   objects_per_group: u64,
+  object_id_step: u64,
+  group_id_step: u64,
   payload_size: usize,
   publisher_priority: u8,
 ) -> Result<()> {
   let interval = Duration::from_millis(interval_ms);
   info!(
-    "Sending datagrams: {} groups, {} objects/group, {} byte payloads",
-    group_count, objects_per_group, payload_size
+    "Sending datagrams: {} groups, {} objects/group, object-id step {}, group-id step {}, {} byte payloads",
+    group_count, objects_per_group, object_id_step, group_id_step, payload_size
   );
 
-  for group_id in 0..group_count {
-    for object_id in 0..objects_per_group {
+  for g in 0..group_count {
+    let group_id = g * group_id_step;
+    for i in 0..objects_per_group {
+      let object_id = i * object_id_step;
       let payload = generate_payload(payload_size);
+
+      // Communicate the ID gaps explicitly (draft 12.8 / 12.9).
+      let mut properties = Vec::new();
+      if g > 0 && i == 0 && group_id_step > 1 {
+        properties.push(ObjectProperty::PriorGroupIdGap {
+          gap: group_id_step - 1,
+        });
+      }
+      if i > 0 && object_id_step > 1 {
+        properties.push(ObjectProperty::PriorObjectIdGap {
+          gap: object_id_step - 1,
+        });
+      }
 
       let datagram_obj = Datagram::new_payload(
         track_alias,
         group_id,
         object_id,
-        Some(publisher_priority), // publisher_priority
-        None,                     // properties
+        Some(publisher_priority),
+        Some(properties),
         Bytes::from(payload),
         false, // end_of_group
       );
@@ -351,7 +384,7 @@ async fn send_datagrams(
 
       match connection.send_datagram(serialized) {
         Ok(_) => {
-          let total = group_id * objects_per_group + object_id;
+          let total = g * objects_per_group + i;
           if should_log(total) {
             info!(
               "Sent datagram: group={}, object={}, size={} bytes",
@@ -377,22 +410,26 @@ async fn send_datagrams(
   Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn send_via_streams(
   connection: &TransportConnection,
   track_alias: u64,
   group_count: u64,
   interval_ms: u64,
   objects_per_group: u64,
+  object_id_step: u64,
+  group_id_step: u64,
   payload_size: usize,
   publisher_priority: u8,
 ) -> Result<()> {
   let interval = Duration::from_millis(interval_ms);
   info!(
-    "Sending via streams: {} groups, {} objects/group, {} byte payloads",
-    group_count, objects_per_group, payload_size
+    "Sending via streams: {} groups, {} objects/group, object-id step {}, group-id step {}, {} byte payloads",
+    group_count, objects_per_group, object_id_step, group_id_step, payload_size
   );
 
-  for group_id in 0..group_count {
+  for g in 0..group_count {
+    let group_id = g * group_id_step;
     info!("Opening stream for group {}", group_id);
     let stream = connection.open_uni().await?;
 
@@ -411,12 +448,28 @@ async fn send_via_streams(
     let mut handler = SendDataStream::new(stream, header_info).await?;
 
     let mut prev_object_id = None;
-    for object_id in 0..objects_per_group {
+    for i in 0..objects_per_group {
+      let object_id = i * object_id_step;
       let payload = generate_payload(payload_size);
+
+      // Communicate the ID gaps explicitly (draft 12.8 / 12.9): the first object
+      // of a skipped group carries Prior Group ID Gap; every skipped object
+      // carries Prior Object ID Gap.
+      let mut properties = Vec::new();
+      if g > 0 && i == 0 && group_id_step > 1 {
+        properties.push(ObjectProperty::PriorGroupIdGap {
+          gap: group_id_step - 1,
+        });
+      }
+      if i > 0 && object_id_step > 1 {
+        properties.push(ObjectProperty::PriorObjectIdGap {
+          gap: object_id_step - 1,
+        });
+      }
 
       let subgroup_obj = SubgroupObject {
         object_id,
-        properties: Some(vec![]),
+        properties: Some(properties),
         object_status: None,
         payload: Some(Bytes::from(payload)),
       };
@@ -425,7 +478,7 @@ async fn send_via_streams(
 
       match handler.send_object(&object, prev_object_id).await {
         Ok(_) => {
-          let total = group_id * objects_per_group + object_id;
+          let total = g * objects_per_group + i;
           if should_log(total) {
             info!(
               "Sent object: group={}, object={}, size={} bytes",

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -659,10 +659,19 @@ pub async fn handle_request_update(
       let _ = stream_handler.send_impl(&err_msg).await;
 
       // A failed update terminates the subscription with PUBLISH_DONE(UPDATE_FAILED).
+      let stream_count = match track_arc
+        .read()
+        .await
+        .get_subscription(client.connection_id)
+        .await
+      {
+        Some(sub) => sub.read().await.opened_stream_count(),
+        None => 0,
+      };
       let done = PublishDone::new(
         existing_req_id,
         PublishDoneStatusCode::UpdateFailed,
-        0,
+        stream_count,
         ReasonPhrase::try_new("REQUEST_UPDATE failed".to_string()).unwrap(),
       );
       let _ = stream_handler.send_impl(&done).await;

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -45,7 +45,7 @@ use moqtail::transport::connection::TransportSendStream;
 use moqtail::transport::data_stream_handler::HeaderInfo;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -293,6 +293,9 @@ pub struct Subscription {
   subscriber: Arc<MOQTClient>,
   event_rx: Arc<Mutex<Option<UnboundedReceiver<TrackEvent>>>>,
   send_stream_last_object_ids: Arc<RwLock<HashMap<StreamId, Option<u64>>>>,
+  /// Monotonic count of data streams opened for this subscription, including
+  /// empty subgroups. Reported as PUBLISH_DONE Stream Count.
+  opened_stream_count: Arc<AtomicU64>,
   finished: Arc<AtomicBool>,
   #[allow(dead_code)]
   cache: TrackCache,
@@ -332,6 +335,7 @@ impl Subscription {
       subscriber,
       event_rx,
       send_stream_last_object_ids: Arc::new(RwLock::new(HashMap::new())),
+      opened_stream_count: Arc::new(AtomicU64::new(0)),
       finished: Arc::new(AtomicBool::new(false)),
       cache,
       client_connection_id,
@@ -518,6 +522,12 @@ impl Subscription {
   pub async fn is_forwarding(&self) -> bool {
     let state = self.subscription_state.read().await;
     state.forward
+  }
+
+  /// Number of data streams opened for this subscription (PUBLISH_DONE Stream
+  /// Count), including subgroups that carried no objects.
+  pub fn opened_stream_count(&self) -> u64 {
+    self.opened_stream_count.load(Ordering::Relaxed)
   }
 
   // Returns true if the subscription is active (not finished and forwarding objects)
@@ -1214,6 +1224,10 @@ impl Subscription {
 
       info!("Created stream: {}", stream_id.get_stream_id());
 
+      // Count every data stream opened for this subscription (PUBLISH_DONE
+      // Stream Count), including subgroups that end up carrying no objects.
+      self.opened_stream_count.fetch_add(1, Ordering::Relaxed);
+
       Ok((stream_id, send_stream.clone()))
     } else {
       error!(
@@ -1386,7 +1400,7 @@ impl Subscription {
     let publish_done = PublishDone::new(
       self.request_id,
       status_code,
-      0, // stream_count - set to 0 as track is ending
+      self.opened_stream_count.load(Ordering::Relaxed),
       reason_phrase,
     );
 
@@ -1396,8 +1410,11 @@ impl Subscription {
       .await;
 
     info!(
-      "Sent PublishDone to subscriber={} relay_track_id={} for request_id={}",
-      self.client_connection_id, self.relay_track_id, self.request_id
+      "Sent PublishDone to subscriber={} relay_track_id={} for request_id={} stream_count={}",
+      self.client_connection_id,
+      self.relay_track_id,
+      self.request_id,
+      self.opened_stream_count.load(Ordering::Relaxed)
     );
 
     Ok(())


### PR DESCRIPTION
Closes #316

Relay:
- PUBLISH_DONE Stream Count now reports the actual number of data streams opened for the subscription (monotonic opened_stream_count incremented in handle_header, the sole stream-open primitive), including subgroups that carried no objects. Previously hardcoded 0.

Client:
- Publisher can emit gapped tracks via --object-id-step and --group-id-step, and sets the Prior Object ID Gap (draft 12.9) and Prior Group ID Gap (draft 12.8) object properties to communicate the gaps explicitly. Applied to both the subgroup and datagram paths.
- Fetcher logs any prior-gap properties on received objects.

Prior-object-after-end-of-range (draft 10.12) needs no change: FETCH delivers existing objects in order and FIN-terminates, so gaps convey non-existence.

Verified live: FETCH over object-gapped and group-gapped tracks delivers the sparse IDs with the prior-gap properties and a FIN; PUBLISH_DONE reports a non-zero stream count.
