### PR TITLE
feat(moqtail-rs): EndGroup delta, datagram status/properties, padding

### DIFF
--- a/libs/moqtail-rs/src/model/control/request_update.rs
+++ b/libs/moqtail-rs/src/model/control/request_update.rs
@@ -103,7 +103,7 @@ mod tests {
           group: 81,
           object: 81,
         }),
-        Some(25),
+        Some(106),
       )],
     );
 
@@ -128,7 +128,7 @@ mod tests {
           group: 81,
           object: 81,
         }),
-        Some(25),
+        Some(106),
       )],
     );
 
@@ -159,7 +159,7 @@ mod tests {
           group: 81,
           object: 81,
         }),
-        Some(25),
+        Some(106),
       )],
     );
 

--- a/libs/moqtail-rs/src/model/data.rs
+++ b/libs/moqtail-rs/src/model/data.rs
@@ -19,6 +19,7 @@ pub mod fetch_object;
 pub mod full_track_name;
 pub mod group;
 pub mod object;
+pub mod padding;
 pub mod subgroup;
 pub mod subgroup_header;
 pub mod subgroup_object;

--- a/libs/moqtail-rs/src/model/data/datagram.rs
+++ b/libs/moqtail-rs/src/model/data/datagram.rs
@@ -22,7 +22,7 @@ use crate::model::property::object_property::{
 
 use super::constant::{ObjectDatagramType, ObjectStatus};
 
-/// Draft-16 unified Object Datagram.
+/// Unified Object Datagram.
 ///
 /// Type bit layout (form 0b00X0XXXX):
 /// - Bit 0 (0x01): PROPERTIES - Properties field present
@@ -239,6 +239,15 @@ impl Datagram {
     };
 
     let end_of_group = msg_type.is_end_of_group();
+
+    // Only Normal Objects can carry Properties: a STATUS datagram with a
+    // non-Normal status and Properties present is a protocol violation.
+    if properties.is_some() && matches!(object_status, Some(s) if s != ObjectStatus::Normal) {
+      return Err(ParseError::ProtocolViolation {
+        context: "Datagram::deserialize",
+        details: "STATUS datagram with non-Normal status carries Properties".to_string(),
+      });
+    }
 
     Ok(Datagram {
       track_alias,
@@ -466,5 +475,26 @@ mod tests {
   fn test_invalid_type_is_error() {
     let result = ObjectDatagramType::try_from(0x10u64);
     assert!(result.is_err());
+  }
+
+  #[test]
+  fn test_status_non_normal_with_properties_is_error() {
+    // Only Normal Objects can carry Properties: a STATUS datagram with a
+    // non-Normal status and Properties present is a PROTOCOL_VIOLATION.
+    let datagram = Datagram::new_status(
+      144,
+      9,
+      10,
+      Some(255),
+      Some(vec![ObjectProperty::Unknown {
+        kvp: KeyValuePair::try_new_varint(0, 10).unwrap(),
+      }]),
+      ObjectStatus::EndOfGroup,
+    );
+    let mut buf = datagram.serialize().unwrap();
+    assert!(matches!(
+      Datagram::deserialize(&mut buf),
+      Err(ParseError::ProtocolViolation { .. })
+    ));
   }
 }

--- a/libs/moqtail-rs/src/model/data/padding.rs
+++ b/libs/moqtail-rs/src/model/data/padding.rs
@@ -1,0 +1,139 @@
+// Copyright 2026 The MOQtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+
+use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
+use crate::model::error::ParseError;
+
+/// Stream type for a padding stream.
+pub const PADDING_STREAM_TYPE: u64 = 0x132B3E28;
+/// Datagram type for a padding datagram.
+pub const PADDING_DATAGRAM_TYPE: u64 = 0x132B3E29;
+
+/// A padding stream: the padding stream type followed by `length` zero bytes.
+/// It carries no application data; the receiver MUST discard the contents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaddingStream {
+  pub length: usize,
+}
+
+impl PaddingStream {
+  pub fn new(length: usize) -> Self {
+    Self { length }
+  }
+
+  pub fn serialize(&self) -> Result<Bytes, ParseError> {
+    let mut buf = BytesMut::new();
+    buf.put_vi(PADDING_STREAM_TYPE)?;
+    buf.put_bytes(0u8, self.length);
+    Ok(buf.freeze())
+  }
+
+  /// Reads the leading type then consumes (discards) the remaining padding bytes.
+  pub fn deserialize(bytes: &mut Bytes) -> Result<Self, ParseError> {
+    let type_value = bytes.get_vi()?;
+    if type_value != PADDING_STREAM_TYPE {
+      return Err(ParseError::ProtocolViolation {
+        context: "PaddingStream::deserialize",
+        details: format!(
+          "expected padding stream type {PADDING_STREAM_TYPE:#x}, got {type_value:#x}"
+        ),
+      });
+    }
+    let length = bytes.remaining();
+    bytes.advance(length);
+    Ok(Self { length })
+  }
+}
+
+/// A padding datagram: the padding datagram type followed by `length` zero
+/// bytes. It carries no application data; the receiver MUST discard it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaddingDatagram {
+  pub length: usize,
+}
+
+impl PaddingDatagram {
+  pub fn new(length: usize) -> Self {
+    Self { length }
+  }
+
+  pub fn serialize(&self) -> Result<Bytes, ParseError> {
+    let mut buf = BytesMut::new();
+    buf.put_vi(PADDING_DATAGRAM_TYPE)?;
+    buf.put_bytes(0u8, self.length);
+    Ok(buf.freeze())
+  }
+
+  /// Reads the leading type then consumes (discards) the remaining padding bytes.
+  pub fn deserialize(bytes: &mut Bytes) -> Result<Self, ParseError> {
+    let type_value = bytes.get_vi()?;
+    if type_value != PADDING_DATAGRAM_TYPE {
+      return Err(ParseError::ProtocolViolation {
+        context: "PaddingDatagram::deserialize",
+        details: format!(
+          "expected padding datagram type {PADDING_DATAGRAM_TYPE:#x}, got {type_value:#x}"
+        ),
+      });
+    }
+    let length = bytes.remaining();
+    bytes.advance(length);
+    Ok(Self { length })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_roundtrip_padding_stream() {
+    let padding = PaddingStream::new(100);
+    let serialized = padding.serialize().unwrap();
+    // The type prefix is followed by exactly `length` bytes, all zero.
+    let type_len = serialized.len() - padding.length;
+    assert!(serialized.iter().skip(type_len).all(|&b| b == 0));
+    let mut bytes = serialized;
+    let decoded = PaddingStream::deserialize(&mut bytes).unwrap();
+    assert_eq!(decoded, padding);
+    assert_eq!(bytes.remaining(), 0);
+  }
+
+  #[test]
+  fn test_roundtrip_empty_padding_stream() {
+    let padding = PaddingStream::new(0);
+    let mut bytes = padding.serialize().unwrap();
+    let decoded = PaddingStream::deserialize(&mut bytes).unwrap();
+    assert_eq!(decoded, padding);
+  }
+
+  #[test]
+  fn test_roundtrip_padding_datagram() {
+    let padding = PaddingDatagram::new(42);
+    let mut bytes = padding.serialize().unwrap();
+    let decoded = PaddingDatagram::deserialize(&mut bytes).unwrap();
+    assert_eq!(decoded, padding);
+    assert_eq!(bytes.remaining(), 0);
+  }
+
+  #[test]
+  fn test_padding_stream_wrong_type_is_error() {
+    let mut bytes = PaddingDatagram::new(8).serialize().unwrap();
+    assert!(matches!(
+      PaddingStream::deserialize(&mut bytes),
+      Err(ParseError::ProtocolViolation { .. })
+    ));
+  }
+}

--- a/libs/moqtail-rs/src/model/parameter/message_parameter.rs
+++ b/libs/moqtail-rs/src/model/parameter/message_parameter.rs
@@ -326,8 +326,17 @@ impl MessageParameter {
               }
               FilterType::AbsoluteRange => {
                 let loc = Location::deserialize(&mut payload)?;
-                let eg = payload.get_vi()?;
-                (Some(loc), Some(eg))
+                // End Group is a delta from the Start Group on the wire.
+                let delta = payload.get_vi()?;
+                let end_group =
+                  loc
+                    .group
+                    .checked_add(delta)
+                    .ok_or_else(|| ParseError::ProtocolViolation {
+                      context: "MessageParameter::deserialize",
+                      details: "AbsoluteRange End Group Delta overflows u64".to_string(),
+                    })?;
+                (Some(loc), Some(end_group))
               }
               _ => (None, None),
             };
@@ -436,10 +445,11 @@ impl TryInto<KeyValuePair> for MessageParameter {
       } => {
         let mut buf = BytesMut::new();
         buf.put_vi(filter_type as u64)?;
+        let start_group = start_location.as_ref().map(|l| l.group).unwrap_or(0);
         if matches!(
           filter_type,
           FilterType::AbsoluteStart | FilterType::AbsoluteRange
-        ) && let Some(loc) = start_location
+        ) && let Some(loc) = &start_location
         {
           buf.put_vi(loc.group)?;
           buf.put_vi(loc.object)?;
@@ -447,7 +457,8 @@ impl TryInto<KeyValuePair> for MessageParameter {
         if filter_type == FilterType::AbsoluteRange
           && let Some(eg) = end_group
         {
-          buf.put_vi(eg)?;
+          // End Group is encoded on the wire as a delta from the Start Group.
+          buf.put_vi(eg.saturating_sub(start_group))?;
         }
         KeyValuePair::try_new_bytes(
           MessageParameterType::SubscriptionFilter as u64,
@@ -612,6 +623,50 @@ mod tests {
       Some(20),
     );
     assert_eq!(roundtrip(orig.clone()), orig);
+  }
+
+  #[test]
+  fn test_absolute_range_end_group_is_delta_on_wire() {
+    // Start group 5, absolute End Group 20 must serialize End Group as the
+    // delta 15, not the absolute 20.
+    let orig = MessageParameter::new_subscription_filter(
+      FilterType::AbsoluteRange,
+      Some(Location {
+        group: 5,
+        object: 0,
+      }),
+      Some(20),
+    );
+    let mut bytes = orig.serialize().unwrap();
+    let kvp = KeyValuePair::deserialize(&mut bytes).unwrap();
+    let KeyValuePair::Bytes { value, .. } = kvp else {
+      panic!("SubscriptionFilter must be a bytes KVP");
+    };
+    let mut value = value;
+    assert_eq!(value.get_vi().unwrap(), FilterType::AbsoluteRange as u64);
+    assert_eq!(value.get_vi().unwrap(), 5); // start group
+    assert_eq!(value.get_vi().unwrap(), 0); // start object
+    assert_eq!(value.get_vi().unwrap(), 15); // End Group Delta = 20 - 5
+  }
+
+  #[test]
+  fn test_absolute_range_end_group_delta_overflow_is_protocol_violation() {
+    // Start group u64::MAX plus a non-zero delta overflows the absolute Group ID
+    // and MUST be rejected.
+    let mut value = BytesMut::new();
+    value.put_vi(FilterType::AbsoluteRange as u64).unwrap();
+    value.put_vi(u64::MAX).unwrap(); // start group
+    value.put_vi(0u64).unwrap(); // start object
+    value.put_vi(1u64).unwrap(); // End Group Delta -> overflow
+    let kvp = KeyValuePair::try_new_bytes(
+      MessageParameterType::SubscriptionFilter as u64,
+      value.freeze(),
+    )
+    .unwrap();
+    assert!(matches!(
+      MessageParameter::deserialize(&kvp),
+      Err(ParseError::ProtocolViolation { .. })
+    ));
   }
 
   #[test]


### PR DESCRIPTION
(RS-17, #252)

Serialization bullets of RS-17 (the .session namespace and subgroup-reopen behaviors remain deferred):

- Subscription filter AbsoluteRange now encodes End Group as a delta from the Start group on the wire (draft 2.6). The in-memory end_group stays absolute; deserialize computes start.group + delta and rejects u64 overflow with PROTOCOL_VIOLATION.
- Datagram: a STATUS datagram with a non-Normal status carrying Properties is a PROTOCOL_VIOLATION (only Normal Objects can have Properties, draft 11.3).
- Padding streams (0x132B3E28) and padding datagrams (0x132B3E29): new types that serialize a type followed by zero bytes and discard the content on receive (draft 11.5).

Also fixes three request_update tests that built invalid AbsoluteRange filters (end_group < start group), which only round-tripped under absolute encoding.