### PR TITLE
feat(relay): reject reserved namespaces (.session, .) locally (RS-17a)

### DIFF
--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -129,6 +129,24 @@ pub async fn handle(
           .insert(request_id, PendingRequest::Fetch(req));
       }
 
+      // Reserved namespaces are resolved locally and never forwarded upstream.
+      if let Some(props) = &fetch.standalone_fetch_props
+        && let Some(reason) = crate::server::utils::reserved_namespace_rejection(
+          &props.track_namespace,
+          &props.track_name,
+        )
+      {
+        info!("Rejecting FETCH for reserved namespace: {}", reason);
+        send_request_error(
+          client.clone(),
+          request_id,
+          RequestErrorCode::DoesNotExist,
+          ReasonPhrase::try_new(reason.to_string()).unwrap(),
+        )
+        .await;
+        return Ok(());
+      }
+
       // Resolves the fetch target. The bool is `rejected`: true when a
       // REQUEST_ERROR was already sent, so the caller must stop without also
       // sending DoesNotExist.

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -89,6 +89,21 @@ pub async fn handle(
         name: m.track_name.clone(),
       };
 
+      // Tracks MUST NOT be published under a reserved namespace.
+      if let Some(reason) =
+        crate::server::utils::reserved_namespace_rejection(&m.track_namespace, &m.track_name)
+      {
+        info!("Rejecting PUBLISH for reserved namespace: {}", reason);
+        let publish_error = Box::new(RequestError::new(
+          RequestErrorCode::DoesNotExist,
+          0,
+          ReasonPhrase::try_new(reason.to_string()).map_err(|_| TerminationCode::InternalError)?,
+        ));
+        return stream_handler
+          .send(&ControlMessage::RequestError(publish_error))
+          .await;
+      }
+
       // Multiple publishers may share the same alias for the same track (fan-out).
       // Only reject if the alias already maps to a different full track name for this connection.
       {

--- a/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
@@ -16,9 +16,11 @@ use crate::server::client::MOQTClient;
 use crate::server::session_context::{PendingRequest, SessionContext};
 use crate::server::track_manager::SubscribeKind;
 use core::result::Result;
+use moqtail::model::common::reason_phrase::ReasonPhrase;
 use moqtail::model::control::namespace::Namespace;
+use moqtail::model::control::request_error::RequestError;
 use moqtail::model::control::{control_message::ControlMessage, request_ok::RequestOk};
-use moqtail::model::error::{StreamResetCode, TerminationCode};
+use moqtail::model::error::{RequestErrorCode, StreamResetCode, TerminationCode};
 use moqtail::model::parameter::message_parameter::apply_message_parameter_update;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use std::sync::Arc;
@@ -34,6 +36,20 @@ pub async fn handle(
     ControlMessage::PublishNamespace(m) => {
       // TODO: the namespace is already announced, return error
       info!("received PublishNamespace message");
+
+      // Namespaces MUST NOT be published under a reserved namespace.
+      if m.track_namespace.is_reserved_dot() || m.track_namespace.is_session_namespace() {
+        info!("Rejecting PUBLISH_NAMESPACE for reserved namespace");
+        let err = RequestError::new(
+          RequestErrorCode::DoesNotExist,
+          0,
+          ReasonPhrase::try_new("reserved namespace cannot be published".to_string()).unwrap(),
+        );
+        stream_handler
+          .send(&ControlMessage::RequestError(Box::new(err)))
+          .await?;
+        return Ok(());
+      }
 
       // this is a publisher, add it to the client manager
       client

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -143,6 +143,20 @@ async fn handle_subscribe_message(
   let track_namespace = sub.track_namespace.clone();
   let full_track_name = sub.get_full_track_name();
 
+  // Reserved namespaces are resolved locally and never forwarded upstream.
+  if let Some(reason) =
+    crate::server::utils::reserved_namespace_rejection(&track_namespace, &sub.track_name)
+  {
+    info!("Rejecting SUBSCRIBE for reserved namespace: {}", reason);
+    let err = RequestError::new(
+      RequestErrorCode::DoesNotExist,
+      0,
+      ReasonPhrase::try_new(reason.to_string()).unwrap(),
+    );
+    stream_handler.send_impl(&err).await.unwrap();
+    return Ok(());
+  }
+
   // find who is the publisher
   // first we try with the full track name
   // if not found, we try with the announced track namespace

--- a/apps/relay/src/server/utils.rs
+++ b/apps/relay/src/server/utils.rs
@@ -15,6 +15,7 @@
 use crate::server::stream_id::StreamId;
 use bytes::Bytes;
 use fnv::FnvHasher;
+use moqtail::model::common::tuple::{Tuple, TupleField};
 use moqtail::{
   model::control::control_message::ControlMessageTrait, transport::data_stream_handler::HeaderInfo,
 };
@@ -24,6 +25,28 @@ use std::time::Instant;
 
 // Static reference time: set when the program starts
 pub static BASE_TIME: Lazy<Instant> = Lazy::new(Instant::now);
+
+/// Reserved-namespace policy. Returns a rejection reason when a request for this
+/// namespace/track must be rejected with DOES_NOT_EXIST: the single `.`
+/// namespace, and any `.session` request (session-level tracks are managed
+/// locally and never forwarded to other sessions; the relay defines none, and
+/// an empty track name under `.session` is defined not to exist). Other reserved
+/// namespaces (a first field beginning with `.`) are passed through unchanged.
+pub fn reserved_namespace_rejection(
+  namespace: &Tuple,
+  track_name: &TupleField,
+) -> Option<&'static str> {
+  if namespace.is_reserved_dot() {
+    return Some("the '.' namespace is reserved and does not exist");
+  }
+  if namespace.is_session_namespace() {
+    if track_name.is_empty() {
+      return Some(".session with an empty track name does not exist");
+    }
+    return Some("unrecognized session-level track");
+  }
+  None
+}
 
 pub fn print_msg_bytes(msg: &impl ControlMessageTrait) {
   let bytes = msg.serialize();

--- a/libs/moqtail-rs/src/model/common/tuple.rs
+++ b/libs/moqtail-rs/src/model/common/tuple.rs
@@ -190,6 +190,31 @@ impl Tuple {
     true
   }
 
+  /// Whether the first field marks a reserved namespace, i.e. begins with a
+  /// period (0x2e). Reserved namespaces are managed by MOQT, not the application.
+  pub fn is_reserved_namespace(&self) -> bool {
+    self
+      .fields
+      .first()
+      .and_then(|f| f.as_bytes().first())
+      .is_some_and(|b| *b == b'.')
+  }
+
+  /// Whether the first field is exactly a single period (`.`), the fully
+  /// reserved namespace that must never be used.
+  pub fn is_reserved_dot(&self) -> bool {
+    self.fields.first().is_some_and(|f| f.as_bytes() == b".")
+  }
+
+  /// Whether the first field is exactly `.session`, the session-level namespace
+  /// managed by the MOQT implementation and never forwarded across sessions.
+  pub fn is_session_namespace(&self) -> bool {
+    self
+      .fields
+      .first()
+      .is_some_and(|f| f.as_bytes() == b".session")
+  }
+
   pub fn serialize(&self) -> Result<Bytes, ParseError> {
     let mut buf = BytesMut::new();
     buf.put_vi(self.fields.len() as u64)?;
@@ -360,5 +385,30 @@ mod tests {
     let tuple = Tuple::new();
     let prefix = Tuple::new();
     assert!(tuple.starts_with(&prefix));
+  }
+
+  #[test]
+  fn test_reserved_namespace_helpers() {
+    let session = Tuple::from_utf8_path(".session/foo");
+    assert!(session.is_reserved_namespace());
+    assert!(session.is_session_namespace());
+    assert!(!session.is_reserved_dot());
+
+    let dot = Tuple::from_utf8_path(".");
+    assert!(dot.is_reserved_namespace());
+    assert!(dot.is_reserved_dot());
+    assert!(!dot.is_session_namespace());
+
+    let other_reserved = Tuple::from_utf8_path(".future/thing");
+    assert!(other_reserved.is_reserved_namespace());
+    assert!(!other_reserved.is_reserved_dot());
+    assert!(!other_reserved.is_session_namespace());
+
+    let normal = Tuple::from_utf8_path("meet/room1");
+    assert!(!normal.is_reserved_namespace());
+    assert!(!normal.is_reserved_dot());
+    assert!(!normal.is_session_namespace());
+
+    assert!(!Tuple::new().is_reserved_namespace());
   }
 }


### PR DESCRIPTION
closes #321

Reserved namespaces (first tuple field beginning with a period) are managed by MOQT, not the application:

- Tuple gains is_reserved_namespace / is_reserved_dot / is_session_namespace.
- SUBSCRIBE and FETCH for a reserved namespace are resolved locally and never forwarded upstream: the single "." namespace, and any ".session" request, are rejected with REQUEST_ERROR DOES_NOT_EXIST. An empty track name under ".session" is defined not to exist; the relay defines no session-level tracks, so any other ".session" track is likewise unrecognized.
- PUBLISH and PUBLISH_NAMESPACE under a reserved namespace are rejected.

Other reserved namespaces (beginning with "." but not "." or ".session") are passed through unchanged.

### Description

<!-- Please describe your changes in detail. Include motivation and context. -->

<!------------------------------------------------------------------------------
If you are contributing a new feature or fixing an issue, please provide references
to the relevant specifications, documentation, or issues. This helps maintainers
get familiar with the context of your changes.

Thank you for your contribution!
-------------------------------------------------------------------------------->
