### PR TITLE
test(client): drive Forward 0->1 to verify subgroup reopen (RS-17b)

### DIFF
--- a/apps/client/README.md
+++ b/apps/client/README.md
@@ -44,16 +44,17 @@ cargo run --bin client -- --command <COMMAND> [OPTIONS]
 
 ## Subscribe Options
 
-| Option                  | Short | Default     | Description                                                         |
-| ----------------------- | ----- | ----------- | ------------------------------------------------------------------- |
-| `--duration`            | `-d`  | `0`         | Duration to listen in seconds (0 = indefinite)                      |
-| `--subscriber-priority` |       | `128`       | Subscriber priority 0 (highest) – 255 (lowest)                      |
-| `--group-order`         |       | `ascending` | Group delivery order (`original`, `ascending`, `descending`)        |
-| `--extra-track`         |       | _(none)_    | Second track subscription for priority testing: `name:priority`     |
-| `--forward`             |       | `true`      | Subscription Forward State; set `false` to suppress object delivery |
-| `--joining-fetch`       |       | `false`     | After subscribing, issue a Joining FETCH against the subscription   |
-| `--joining-start`       |       | `0`         | Joining FETCH start group (with `--joining-fetch`)                  |
-| `--joining-type`        |       | `relative`  | Joining FETCH type (`relative` or `absolute`)                       |
+| Option                   | Short | Default     | Description                                                                |
+| ------------------------ | ----- | ----------- | -------------------------------------------------------------------------- |
+| `--duration`             | `-d`  | `0`         | Duration to listen in seconds (0 = indefinite)                             |
+| `--subscriber-priority`  |       | `128`       | Subscriber priority 0 (highest) – 255 (lowest)                             |
+| `--group-order`          |       | `ascending` | Group delivery order (`original`, `ascending`, `descending`)               |
+| `--extra-track`          |       | _(none)_    | Second track subscription for priority testing: `name:priority`            |
+| `--forward`              |       | `true`      | Subscription Forward State; set `false` to suppress object delivery        |
+| `--update-forward-after` |       | `0`         | Seconds after subscribing to REQUEST_UPDATE Forward State to 1 (0 = never) |
+| `--joining-fetch`        |       | `false`     | After subscribing, issue a Joining FETCH against the subscription          |
+| `--joining-start`        |       | `0`         | Joining FETCH start group (with `--joining-fetch`)                         |
+| `--joining-type`         |       | `relative`  | Joining FETCH type (`relative` or `absolute`)                              |
 
 ## Fetch Options
 
@@ -123,6 +124,13 @@ FETCH with `REQUEST_ERROR` / `INVALID_RANGE`:
 
 ```
 cargo run --bin client -- -c subscribe --forward false --joining-fetch --joining-start 2
+```
+
+Subscribe with Forward State 0 (no objects), then flip it to 1 after 3 seconds —
+the relay reopens the subgroup and delivery resumes:
+
+```
+cargo run --bin client -- -c subscribe --forward false --update-forward-after 3 --duration 8
 ```
 
 Connect to a remote server with certificate validation disabled:

--- a/apps/client/src/cli.rs
+++ b/apps/client/src/cli.rs
@@ -191,6 +191,12 @@ pub struct Cli {
   #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
   pub forward: bool,
 
+  /// Seconds after subscribing to send a REQUEST_UPDATE setting Forward State 1
+  /// (subscribe only, 0 = never). Use with --forward false to test that delivery
+  /// resumes after Forward flips 0->1.
+  #[arg(long, default_value_t = 0)]
+  pub update_forward_after: u64,
+
   /// After subscribing, issue a Joining FETCH referencing the subscription
   /// (subscribe only).
   #[arg(long, default_value_t = false)]

--- a/apps/client/src/main.rs
+++ b/apps/client/src/main.rs
@@ -91,6 +91,7 @@ async fn main() -> Result<(), anyhow::Error> {
         joining_fetch: cli.joining_fetch,
         joining_start: cli.joining_start,
         joining_type: cli.joining_type.into(),
+        update_forward_after: cli.update_forward_after,
       };
       subscriber::run(moq_conn, config).await
     }

--- a/apps/client/src/subscriber.rs
+++ b/apps/client/src/subscriber.rs
@@ -21,6 +21,7 @@ use moqtail::model::common::tuple::{Tuple, TupleField};
 use moqtail::model::control::constant::{FetchType, GroupOrder};
 use moqtail::model::control::control_message::ControlMessage;
 use moqtail::model::control::fetch::Fetch;
+use moqtail::model::control::request_update::RequestUpdate;
 use moqtail::model::control::subscribe::Subscribe;
 use moqtail::model::data::datagram::Datagram;
 use moqtail::model::parameter::message_parameter::MessageParameter;
@@ -94,6 +95,7 @@ pub struct SubscribeConfig {
   pub joining_fetch: bool,
   pub joining_start: u64,
   pub joining_type: FetchType,
+  pub update_forward_after: u64,
 }
 
 /// Issue a Joining FETCH referencing an existing subscription and log the
@@ -163,7 +165,27 @@ pub async fn run(moq: MoqConnection, config: SubscribeConfig) -> Result<()> {
     config.forward,
   )
   .await?;
-  request_streams.push(primary_stream);
+
+  // Optionally flip Forward State 0->1 after a delay by sending a REQUEST_UPDATE
+  // on the subscription's request stream, then hold the stream open.
+  if config.update_forward_after > 0 {
+    let delay = config.update_forward_after;
+    let mut stream = primary_stream;
+    tokio::spawn(async move {
+      tokio::time::sleep(tokio::time::Duration::from_secs(delay)).await;
+      info!("Sending REQUEST_UPDATE to set Forward State 1");
+      let update = RequestUpdate::new(10, 0, vec![MessageParameter::new_forward(true)]);
+      if let Err(e) = stream
+        .send(&ControlMessage::RequestUpdate(Box::new(update)))
+        .await
+      {
+        error!("Failed to send REQUEST_UPDATE: {:?}", e);
+      }
+      std::future::pending::<()>().await;
+    });
+  } else {
+    request_streams.push(primary_stream);
+  }
 
   // Issue a Joining FETCH against the primary subscription (request_id 0). Kept
   // before the receive loop so its response is observed directly.


### PR DESCRIPTION
Closes #322

The relay already reopens a subgroup after Forward State flips 0->1: while forward is 0 the subgroup header is cached (pending_header) and objects are withheld; on 0->1 the cached header is flushed to open the stream and delivery resumes, and a closed subgroup stream is removed from the send map so a later reopen gets a fresh stream. No relay change was needed.

Adds a client --update-forward-after option that sends a REQUEST_UPDATE setting Forward State 1 a few seconds after subscribing, so the behavior can be driven end-to-end. Verified live: with --forward false the subscriber receives nothing, then on the update the relay opens the pending subgroup stream and delivery resumes.
