### PR TITLE
feat(relay): emit PUBLISH_BLOCKED when out of streams (RL-2)

### DIFF
--- a/apps/client/README.md
+++ b/apps/client/README.md
@@ -15,6 +15,7 @@ cargo run --bin client -- --command <COMMAND> [OPTIONS]
 | `publish`           | Publish objects to a track                         |
 | `publish-namespace` | Publish a namespace and auto-respond to subscribes |
 | `subscribe`         | Subscribe to a track and receive objects           |
+| `subscribe-tracks`  | Subscribe to all tracks under a namespace prefix   |
 | `fetch`             | Fetch specific object ranges from a track          |
 
 ## Global Options
@@ -131,6 +132,15 @@ the relay reopens the subgroup and delivery resumes:
 
 ```
 cargo run --bin client -- -c subscribe --forward false --update-forward-after 3 --duration 8
+```
+
+Subscribe to every track under a namespace prefix (SUBSCRIBE_TRACKS). The relay
+answers `REQUEST_OK`, forwards a `PUBLISH` for each matching track, and sends
+`PUBLISH_BLOCKED` if it runs out of streams (start the relay with
+`--max-publish-streams N` to cap it):
+
+```
+cargo run --bin client -- -c subscribe-tracks -n test/ns --duration 5
 ```
 
 Connect to a remote server with certificate validation disabled:

--- a/apps/client/src/cli.rs
+++ b/apps/client/src/cli.rs
@@ -73,6 +73,8 @@ pub enum Command {
   PublishNamespace,
   /// Subscribe to a track and receive objects
   Subscribe,
+  /// Subscribe to all tracks under a namespace prefix (SUBSCRIBE_TRACKS)
+  SubscribeTracks,
   /// Fetch specific object ranges from a track
   Fetch,
 }

--- a/apps/client/src/main.rs
+++ b/apps/client/src/main.rs
@@ -95,6 +95,9 @@ async fn main() -> Result<(), anyhow::Error> {
       };
       subscriber::run(moq_conn, config).await
     }
+    Command::SubscribeTracks => {
+      subscriber::run_subscribe_tracks(moq_conn, cli.namespace, cli.duration).await
+    }
     Command::Fetch => {
       let config = fetcher::FetchConfig {
         namespace: cli.namespace,

--- a/apps/client/src/subscriber.rs
+++ b/apps/client/src/subscriber.rs
@@ -23,6 +23,7 @@ use moqtail::model::control::control_message::ControlMessage;
 use moqtail::model::control::fetch::Fetch;
 use moqtail::model::control::request_update::RequestUpdate;
 use moqtail::model::control::subscribe::Subscribe;
+use moqtail::model::control::subscribe_tracks::SubscribeTracks;
 use moqtail::model::data::datagram::Datagram;
 use moqtail::model::parameter::message_parameter::MessageParameter;
 use moqtail::transport::connection::TransportConnection;
@@ -143,6 +144,53 @@ async fn send_joining_fetch(
     Ok(m) => info!("Joining FETCH response: {:?}", m),
     Err(e) => error!("Joining FETCH: error reading response: {:?}", e),
   }
+  Ok(())
+}
+
+/// SUBSCRIBE_TRACKS for a namespace prefix: send the request on a bidi stream
+/// and log the response-stream messages (REQUEST_OK, and PUBLISH_BLOCKED when
+/// the relay runs out of streams). Forwarded PUBLISH messages arrive on the
+/// control stream and are observed via the relay logs.
+pub async fn run_subscribe_tracks(
+  moq: MoqConnection,
+  namespace: String,
+  duration: u64,
+) -> Result<()> {
+  let connection = moq.connection.clone();
+  let prefix = Tuple::from_utf8_path(&namespace);
+  info!("SUBSCRIBE_TRACKS for namespace prefix: {}", namespace);
+
+  let (send, recv) = connection.open_bi().await?;
+  let mut request_stream = ControlStreamHandler::new(send, recv);
+  let sub_tracks = SubscribeTracks::new(0, prefix, vec![]);
+  request_stream
+    .send(&ControlMessage::SubscribeTracks(Box::new(sub_tracks)))
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to send SUBSCRIBE_TRACKS: {:?}", e))?;
+
+  let reader = tokio::spawn(async move {
+    loop {
+      match request_stream.next_message().await {
+        Ok(ControlMessage::RequestOk(_)) => info!("SUBSCRIBE_TRACKS: received RequestOk"),
+        Ok(ControlMessage::PublishBlocked(m)) => info!(
+          "SUBSCRIBE_TRACKS: received PUBLISH_BLOCKED for namespace_suffix={:?} track_name={:?}",
+          m.track_namespace_suffix, m.track_name
+        ),
+        Ok(other) => info!("SUBSCRIBE_TRACKS: received {:?}", other.get_type()),
+        Err(e) => {
+          info!("SUBSCRIBE_TRACKS response stream ended: {:?}", e);
+          break;
+        }
+      }
+    }
+  });
+
+  if duration > 0 {
+    tokio::time::sleep(tokio::time::Duration::from_secs(duration)).await;
+  } else {
+    let _ = reader.await;
+  }
+  info!("SUBSCRIBE_TRACKS complete");
   Ok(())
 }
 

--- a/apps/relay/src/server/config.rs
+++ b/apps/relay/src/server/config.rs
@@ -89,6 +89,11 @@ pub struct Cli {
   #[arg(long, default_value_t = 0)]
   pub max_subscriber_lag: u64,
 
+  /// Max PUBLISH streams the relay initiates for one SUBSCRIBE_TRACKS before it
+  /// runs out of streams and emits PUBLISH_BLOCKED. 0 = unlimited.
+  #[arg(long, default_value_t = 0)]
+  pub max_publish_streams: u64,
+
   /// Simulate a bandwidth cap per subscriber connection (kbps). 0 = unlimited.
   /// Useful for testing QUIC stream priority scheduling without OS-level throttling.
   #[arg(long, default_value_t = 0)]
@@ -124,6 +129,7 @@ pub struct AppConfig {
   pub max_request_streams: u64,
   pub max_active_requests: u64,
   pub max_subscriber_lag: u64,
+  pub max_publish_streams: u64,
   /// 0 = unlimited. Non-zero caps relay writes to this many kbps per subscriber connection.
   pub write_kbps_limit: u64,
   /// Default GOAWAY redirect URI; the runtime value lives on `Server`.
@@ -154,6 +160,7 @@ impl AppConfig {
         max_request_streams: cli.max_request_streams,
         max_active_requests: cli.max_active_requests,
         max_subscriber_lag: cli.max_subscriber_lag,
+        max_publish_streams: cli.max_publish_streams,
         write_kbps_limit: cli.write_kbps_limit,
         redirect_uri: cli.redirect_uri,
         max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
@@ -273,6 +280,7 @@ mod tests {
       max_request_streams,
       max_active_requests: 0,
       max_subscriber_lag: 0,
+      max_publish_streams: 0,
       write_kbps_limit: 0,
       redirect_uri: None,
       max_upstream_fetch_gaps: 10,

--- a/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
@@ -22,6 +22,7 @@ use crate::server::track_manager::SubscribeKind;
 use core::result::Result;
 use moqtail::model::common::reason_phrase::ReasonPhrase;
 use moqtail::model::control::control_message::ControlMessage;
+use moqtail::model::control::publish_blocked::PublishBlocked;
 use moqtail::model::control::request_error::RequestError;
 use moqtail::model::control::request_ok::RequestOk;
 use moqtail::model::control::subscribe_tracks::SubscribeTracks;
@@ -118,6 +119,9 @@ pub async fn handle_subscribe_tracks(
     .get_tracks_and_publishes_by_namespace_prefix(&sub_tracks.track_namespace_prefix)
     .await;
 
+  let max_publish_streams = context.server_config.max_publish_streams;
+  let mut published = 0u64;
+
   for (full_track_name, track_arc, original_publish_message_opt) in matched_tracks {
     // Exclude the subscriber's own published tracks, and let an explicit
     // SUBSCRIBE take precedence over SUBSCRIBE_TRACKS for the same track.
@@ -131,6 +135,24 @@ pub async fn handle_subscribe_tracks(
     }
 
     if let Some(mut original_publish_message) = original_publish_message_opt {
+      // Out of streams to initiate this subscription: send PUBLISH_BLOCKED on
+      // the response stream and stop (no PUBLISH may follow it).
+      if max_publish_streams > 0 && published >= max_publish_streams {
+        let suffix = full_track_name
+          .namespace
+          .suffix(&sub_tracks.track_namespace_prefix)
+          .unwrap_or_else(|| full_track_name.namespace.clone());
+        warn!(
+          "SUBSCRIBE_TRACKS out of streams ({} sent, max {}); PUBLISH_BLOCKED for {full_track_name:?}",
+          published, max_publish_streams
+        );
+        let blocked = PublishBlocked::new(suffix, full_track_name.name.clone());
+        stream_handler
+          .send(&ControlMessage::PublishBlocked(Box::new(blocked)))
+          .await?;
+        break;
+      }
+
       info!("Forwarding existing track to SUBSCRIBE_TRACKS subscriber: {full_track_name:?}");
 
       let relay_track_id = {
@@ -160,6 +182,7 @@ pub async fn handle_subscribe_tracks(
           original_publish_message.clone(),
         )))
         .await;
+      published += 1;
 
       let track_read = track_arc.read().await;
       if let Err(e) = track_read


### PR DESCRIPTION
on SUBSCRIBE_TRACKS 

Closes #253 

SUBSCRIBE_TRACKS already answers REQUEST_OK, forwards a PUBLISH for every matching track, and fans out future publishes; Track Aliases are the globally unique relay_track_id, so they are unique per session.

New: when the relay would initiate more PUBLISH streams than --max-publish-streams for one SUBSCRIBE_TRACKS, it stops and sends PUBLISH_BLOCKED (namespace suffix + track name) on the response stream, per draft 10.20; no PUBLISH follows it. 0 = unlimited.

Adds a client `subscribe-tracks` command that sends SUBSCRIBE_TRACKS and logs the response-stream messages. Verified live: with three tracks under a prefix and --max-publish-streams 2, the relay forwards two PUBLISH then sends PUBLISH_BLOCKED for the third, which the client receives.

Note: PUBLISH_BLOCKED is emitted on the retroactive SUBSCRIBE_TRACKS path; blocking future publishes past the limit is left as a follow-up.