### PR TITLE
feat(relay): forward SUBSCRIBE_TRACKS PUBLISH on its own bidi stream

### DIFF
--- a/apps/client/src/subscriber.rs
+++ b/apps/client/src/subscriber.rs
@@ -21,6 +21,7 @@ use moqtail::model::common::tuple::{Tuple, TupleField};
 use moqtail::model::control::constant::{FetchType, GroupOrder};
 use moqtail::model::control::control_message::ControlMessage;
 use moqtail::model::control::fetch::Fetch;
+use moqtail::model::control::request_ok::RequestOk;
 use moqtail::model::control::request_update::RequestUpdate;
 use moqtail::model::control::subscribe::Subscribe;
 use moqtail::model::control::subscribe_tracks::SubscribeTracks;
@@ -179,6 +180,38 @@ pub async fn run_subscribe_tracks(
         Ok(other) => info!("SUBSCRIBE_TRACKS: received {:?}", other.get_type()),
         Err(e) => {
           info!("SUBSCRIBE_TRACKS response stream ended: {:?}", e);
+          break;
+        }
+      }
+    }
+  });
+
+  // Each forwarded track arrives as a PUBLISH on its own bidi stream; log it and
+  // answer REQUEST_OK.
+  let conn = connection.clone();
+  tokio::spawn(async move {
+    loop {
+      match conn.accept_bi().await {
+        Ok((send, recv)) => {
+          tokio::spawn(async move {
+            let mut handler = ControlStreamHandler::new(send, recv);
+            match handler.next_message().await {
+              Ok(ControlMessage::Publish(m)) => {
+                info!(
+                  "SUBSCRIBE_TRACKS: received PUBLISH for {:?}/{:?}",
+                  m.track_namespace, m.track_name
+                );
+                let _ = handler
+                  .send(&ControlMessage::RequestOk(Box::new(RequestOk::new(vec![]))))
+                  .await;
+              }
+              Ok(other) => info!("SUBSCRIBE_TRACKS: bidi stream got {:?}", other.get_type()),
+              Err(e) => info!("SUBSCRIBE_TRACKS: bidi stream ended: {:?}", e),
+            }
+          });
+        }
+        Err(e) => {
+          info!("SUBSCRIBE_TRACKS: accept_bi ended: {:?}", e);
           break;
         }
       }

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -438,7 +438,7 @@ pub async fn handle(
 /// Push a PUBLISH to a subscriber on its own bidirectional request stream and
 /// read the PUBLISH_OK (or REQUEST_ERROR) there. The subscription is already
 /// wired before this runs; a rejection is logged.
-async fn forward_publish_downstream(subscriber: Arc<MOQTClient>, publish: Publish) {
+pub(crate) async fn forward_publish_downstream(subscriber: Arc<MOQTClient>, publish: Publish) {
   let (send, recv) = match subscriber.connection.open_bi().await {
     Ok(streams) => streams,
     Err(e) => {

--- a/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
@@ -177,13 +177,6 @@ pub async fn handle_subscribe_tracks(
         );
       }
 
-      client
-        .queue_message(ControlMessage::Publish(Box::new(
-          original_publish_message.clone(),
-        )))
-        .await;
-      published += 1;
-
       let track_read = track_arc.read().await;
       if let Err(e) = track_read
         .add_subscription(client.clone(), original_publish_message.clone(), false)
@@ -191,6 +184,16 @@ pub async fn handle_subscribe_tracks(
       {
         warn!("Failed retroactive auto-subscribe for track: {:?}", e);
       }
+      drop(track_read);
+
+      // Each PUBLISH is a request on its own bidi stream.
+      let sub = client.clone();
+      let push_msg = original_publish_message.clone();
+      tokio::spawn(async move {
+        crate::server::message_handlers::publish_handler::forward_publish_downstream(sub, push_msg)
+          .await;
+      });
+      published += 1;
     } else {
       warn!("The track has no associated publish message, track: {full_track_name:?}");
     }


### PR DESCRIPTION
PUBLISH is one of the request types and must be sent on its own bidirectional stream. The retroactive SUBSCRIBE_TRACKS catch-up was queueing each PUBLISH on the control stream; it now forwards each on its own bidi stream via forward_publish_downstream, matching the future-publish path and the request-per-stream model.

The client subscribe-tracks command now accepts the forwarded PUBLISH bidi streams and answers REQUEST_OK. Verified live: SUBSCRIBE_TRACKS over a prefix delivers each matching track as a PUBLISH on its own bidi stream.
