### PR TITLE
feat(moqtail,relay): log control messages per bidi 

### DIFF
--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -446,7 +446,7 @@ pub(crate) async fn forward_publish_downstream(subscriber: Arc<MOQTClient>, publ
       return;
     }
   };
-  let mut stream = ControlStreamHandler::new(send, recv);
+  let mut stream = ControlStreamHandler::new(send, recv).with_peer_id(subscriber.connection_id);
   if let Err(e) = stream
     .send(&ControlMessage::Publish(Box::new(publish)))
     .await

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -80,7 +80,7 @@ async fn forward_subscribe_upstream(
   // we sent upstream rather than a field in the response.
   let relay_request_id = new_sub.request_id;
   let full_track_name = new_sub.get_full_track_name();
-  let mut upstream = ControlStreamHandler::new(send, recv);
+  let mut upstream = ControlStreamHandler::new(send, recv).with_peer_id(publisher.connection_id);
   if let Err(e) = upstream
     .send(&ControlMessage::Subscribe(Box::new(new_sub)))
     .await

--- a/apps/relay/src/server/message_handlers/track_status_handler.rs
+++ b/apps/relay/src/server/message_handlers/track_status_handler.rs
@@ -130,7 +130,7 @@ async fn forward_track_status_upstream(
       return;
     }
   };
-  let mut upstream = ControlStreamHandler::new(send, recv);
+  let mut upstream = ControlStreamHandler::new(send, recv).with_peer_id(publisher.connection_id);
   if let Err(e) = upstream
     .send(&ControlMessage::TrackStatus(Box::new(new_req)))
     .await

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -236,7 +236,8 @@ impl Session {
     recv_stream: TransportRecvStream,
   ) -> core::result::Result<(), TerminationCode> {
     info!("new control message stream");
-    let mut control_stream_handler = ControlStreamHandler::new(send_stream, recv_stream);
+    let mut control_stream_handler =
+      ControlStreamHandler::new(send_stream, recv_stream).with_peer_id(context.connection_id);
 
     // Client-server negotiation
     let client = match Self::negotiate(context.clone(), &mut control_stream_handler)
@@ -456,7 +457,8 @@ impl Session {
       Some(c) => c,
       None => return,
     };
-    let mut stream_handler = ControlStreamHandler::new(send_stream, recv_stream);
+    let mut stream_handler =
+      ControlStreamHandler::new(send_stream, recv_stream).with_peer_id(context.connection_id);
 
     let msg = match stream_handler.next_message().await {
       Ok(m) => m,

--- a/libs/moqtail-rs/src/transport/control_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/control_stream_handler.rs
@@ -25,12 +25,27 @@ const CONTROL_MESSAGE_TIMEOUT: Duration = Duration::from_secs(5);
 
 const MTU_SIZE: usize = 1500; // Standard MTU size, max 2^16-1
 
+/// Formats bytes as space-separated lowercase hex, for tracing raw control
+/// messages on the wire (paste straight into tools/moq_decode.py).
+fn to_hex(bytes: &[u8]) -> String {
+  use std::fmt::Write;
+  let mut s = String::with_capacity(bytes.len() * 3);
+  for b in bytes {
+    let _ = write!(s, "{b:02x} ");
+  }
+  s.pop();
+  s
+}
+
 pub struct ControlStreamHandler {
   send: TransportSendStream,
   recv: TransportRecvStream,
   recv_bytes: BytesMut,
   recv_buf: Box<[u8; MTU_SIZE]>,
   partial_message_deadline: Option<Instant>,
+  /// Id of the peer connection on the other end of this stream, used to label
+  /// control-message traces. `None` when the caller did not set one.
+  peer_id: Option<usize>,
 }
 
 impl ControlStreamHandler {
@@ -41,6 +56,23 @@ impl ControlStreamHandler {
       recv_bytes: BytesMut::new(),
       recv_buf: Box::new([0; MTU_SIZE]),
       partial_message_deadline: None,
+      peer_id: None,
+    }
+  }
+
+  /// Associates the peer connection id with this stream so control-message
+  /// traces can name the other endpoint. RX lines read as "received from" this
+  /// peer, TX lines as "sending to" it.
+  pub fn with_peer_id(mut self, peer_id: usize) -> Self {
+    self.peer_id = Some(peer_id);
+    self
+  }
+
+  /// Renders the peer connection for trace lines, e.g. `conn 12` or `conn ?`.
+  fn peer(&self) -> String {
+    match self.peer_id {
+      Some(id) => format!("conn {id}"),
+      None => "conn ?".to_string(),
     }
   }
 
@@ -48,6 +80,13 @@ impl ControlStreamHandler {
     let bytes = message
       .serialize()
       .map_err(|_| TerminationCode::InternalError)?;
+    info!(
+      "control message sending to {} — {:?} ({} bytes): {}",
+      self.peer(),
+      message.get_type(),
+      bytes.len(),
+      to_hex(&bytes)
+    );
     if (self.send.write_all(&bytes).await).is_err() {
       warn!("Error sending message: {:?}", message);
       return Err(TerminationCode::InternalError);
@@ -71,6 +110,13 @@ impl ControlStreamHandler {
     let bytes = message
       .serialize()
       .map_err(|_| TerminationCode::InternalError)?;
+    info!(
+      "control message sending to {} — {:?} ({} bytes): {}",
+      self.peer(),
+      message.get_type(),
+      bytes.len(),
+      to_hex(&bytes)
+    );
     if (self.send.write_all(&bytes).await).is_err() {
       warn!("Error sending (send_impl) message: {:?}", message);
       return Err(TerminationCode::InternalError);
@@ -102,6 +148,13 @@ impl ControlStreamHandler {
         match ControlMessage::deserialize(&mut bytes) {
           Ok(msg) => {
             let consumed = original_remaining - bytes.remaining();
+            info!(
+              "control message received from {} — {:?} ({} bytes): {}",
+              self.peer(),
+              msg.get_type(),
+              consumed,
+              to_hex(&self.recv_bytes[..consumed])
+            );
             self.recv_bytes.advance(consumed);
 
             self.partial_message_deadline = None;
@@ -109,6 +162,12 @@ impl ControlStreamHandler {
             return Ok(msg);
           }
           Err(ParseError::ProtocolViolation { .. }) => {
+            warn!(
+              "control message received from {} failed to parse ({} bytes): {}",
+              self.peer(),
+              self.recv_bytes.len(),
+              to_hex(&self.recv_bytes)
+            );
             return Err(TerminationCode::ProtocolViolation);
           }
 


### PR DESCRIPTION
with peer and direction

Trace every control message on any bidirectional control stream at info level, one line each with direction, peer, message type, length and hex:

  control message received from conn 12 — Subscribe (23 bytes): 03 00 14 ...
  control message sending to conn 12 — SubscribeOk (5 bytes): 04 00 03 ...

RX logs on successful parse, TX before write, and the raw buffer is dumped on a parse failure (the one case a success-only log would miss). The hex pastes straight into tools/moq_decode.py.

ControlStreamHandler carries an optional peer connection id (with_peer_id); the relay sets it to the client connection id on the main control and request streams, and to the upstream publisher/subscriber id on forwarded streams. Unset peers render as "conn ?".