### PR TITLE
fix(relay): remove track when last subscriber leaves 

### DIFF
--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -561,14 +561,32 @@ pub(crate) async fn cancel_subscription(
   let track_option = context.track_manager.get_track(&full_track_name).await;
 
   if let Some(track_lock) = track_option {
-    let track = track_lock.read().await;
-    track.remove_subscription(context.connection_id).await;
-    // When the last subscriber goes away, reset the upstream subscribe stream so
-    // the publisher observes the cancellation.
-    if track.subscriber_count().await == 0
-      && let Some(cancel) = track.upstream_cancel.lock().await.take()
-    {
-      let _ = cancel.send(());
+    let is_last_subscriber = {
+      let track = track_lock.read().await;
+      track.remove_subscription(context.connection_id).await;
+      // When the last subscriber goes away, reset the upstream subscribe stream so
+      // the publisher observes the cancellation.
+      if track.subscriber_count().await == 0 {
+        if let Some(cancel) = track.upstream_cancel.lock().await.take() {
+          let _ = cancel.send(());
+        }
+        true
+      } else {
+        false
+      }
+    }; // track read lock dropped here
+
+    // With the last subscriber gone the upstream subscription has been cancelled,
+    // so the cached track is stale (its status stays Confirmed and its
+    // largest_location keeps the old value). Remove it, so the next SUBSCRIBE for
+    // this track is treated as a fresh subscription and re-forwarded upstream to
+    // the publisher instead of being answered from the stale cache.
+    if is_last_subscriber {
+      context.track_manager.remove_track(&full_track_name).await;
+      info!(
+        "Removed track {:?} after last subscriber left; next SUBSCRIBE will re-subscribe upstream",
+        full_track_name
+      );
     }
   } else {
     warn!(


### PR DESCRIPTION
so re-subscribe works

When the last downstream subscriber went away, the relay reset the upstream SUBSCRIBE stream (unsubscribing from the publisher) but left the track in the track manager, still Confirmed and holding a stale largest_location. A later SUBSCRIBE for the same track then found the lingering track (is_creator = false), answered from cache with a phantom LargestObject, and never re-forwarded the SUBSCRIBE upstream, so no objects flowed.

Remove the track once the last subscriber leaves and the upstream subscription is cancelled, so the next SUBSCRIBE is treated as a fresh subscription and re-subscribed upstream to the publisher.

