### PR TITLE
Fix relay resubscribe after last subscriber

### DIFF
--- a/apps/client/src/fetcher.rs
+++ b/apps/client/src/fetcher.rs
@@ -200,7 +200,7 @@ pub async fn run(moq: MoqConnection, config: FetchConfig) -> Result<()> {
     }
 
     info!("Cancelling fetch by resetting the request stream");
-    request_stream.reset(StreamResetCode::Cancelled.to_u64());
+    request_stream.reset_and_stop(StreamResetCode::Cancelled.to_u64());
   }
 
   // Wait for fetch data to arrive

--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -17,9 +17,12 @@ use crate::connection::MoqConnection;
 use crate::utils::should_log;
 use anyhow::Result;
 use bytes::Bytes;
+use moqtail::model::common::reason_phrase::ReasonPhrase;
 use moqtail::model::common::tuple::{Tuple, TupleField};
+use moqtail::model::control::constant::PublishDoneStatusCode;
 use moqtail::model::control::control_message::ControlMessage;
 use moqtail::model::control::publish::Publish;
+use moqtail::model::control::publish_done::PublishDone;
 use moqtail::model::control::publish_namespace::PublishNamespace;
 use moqtail::model::control::request_ok::RequestOk;
 use moqtail::model::control::subscribe_ok::SubscribeOk;
@@ -127,8 +130,12 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
           // Serve data, but stop if the subscriber cancels by resetting the stream.
           tokio::select! {
             res = send_data(&conn, track_alias, &dc) => {
-              if let Err(e) = res {
-                error!("Data sending failed: {:?}", e);
+              match res {
+                Ok(()) => {
+                  // Finished delivering; signal completion on the request stream.
+                  send_publish_done(&mut request_stream, m.request_id, stream_count(&dc)).await;
+                }
+                Err(e) => error!("Data sending failed: {:?}", e),
               }
             }
             _ = request_stream.next_message() => {
@@ -254,6 +261,30 @@ struct DataConfig {
   publisher_priority: u8,
 }
 
+/// Send PUBLISH_DONE as the final message on a subscription's request stream to
+/// signal the publisher is done sending objects for it.
+async fn send_publish_done(
+  request_stream: &mut ControlStreamHandler,
+  request_id: u64,
+  stream_count: u64,
+) {
+  let reason = ReasonPhrase::try_new("done".to_string()).expect("reason within length limit");
+  let done = PublishDone::new(
+    request_id,
+    PublishDoneStatusCode::TrackEnded,
+    stream_count,
+    reason,
+  );
+  if let Err(e) = request_stream
+    .send(&ControlMessage::PublishDone(Box::new(done)))
+    .await
+  {
+    error!("Failed to send PUBLISH_DONE: {:?}", e);
+  } else {
+    info!("Sent PUBLISH_DONE for request_id={}", request_id);
+  }
+}
+
 async fn publish_track(
   connection: &Arc<TransportConnection>,
   namespace: &Tuple,
@@ -292,8 +323,24 @@ async fn publish_track(
 
   // Hold the request stream open while objects are delivered on uni streams.
   let result = send_data(connection, track_alias, data_config).await;
+
+  // PUBLISH_DONE is the final message on the request stream once all objects are
+  // delivered, so the peer learns the publisher is done rather than inferring it
+  // from the stream closing.
+  if result.is_ok() {
+    send_publish_done(&mut request_stream, 0, stream_count(data_config)).await;
+  }
+
   drop(request_stream);
   result
+}
+
+/// Number of subgroup streams a run opens (one per group); datagram mode opens none.
+fn stream_count(config: &DataConfig) -> u64 {
+  match config.delivery_mode {
+    DeliveryMode::Subgroup => config.group_count,
+    DeliveryMode::Datagram => 0,
+  }
 }
 
 async fn send_data(

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -561,14 +561,32 @@ pub(crate) async fn cancel_subscription(
   let track_option = context.track_manager.get_track(&full_track_name).await;
 
   if let Some(track_lock) = track_option {
-    let track = track_lock.read().await;
-    track.remove_subscription(context.connection_id).await;
-    // When the last subscriber goes away, reset the upstream subscribe stream so
-    // the publisher observes the cancellation.
-    if track.subscriber_count().await == 0
-      && let Some(cancel) = track.upstream_cancel.lock().await.take()
-    {
-      let _ = cancel.send(());
+    let is_last_subscriber = {
+      let track = track_lock.read().await;
+      track.remove_subscription(context.connection_id).await;
+      // When the last subscriber goes away, reset the upstream subscribe stream so
+      // the publisher observes the cancellation.
+      if track.subscriber_count().await == 0 {
+        if let Some(cancel) = track.upstream_cancel.lock().await.take() {
+          let _ = cancel.send(());
+        }
+        true
+      } else {
+        false
+      }
+    }; // track read lock dropped here
+
+    // With the last subscriber gone the upstream subscription has been cancelled,
+    // so the cached track is stale (its status stays Confirmed and its
+    // largest_location keeps the old value). Remove it, so the next SUBSCRIBE for
+    // this track is treated as a fresh subscription and re-forwarded upstream to
+    // the publisher instead of being answered from the stale cache.
+    if is_last_subscriber {
+      context.track_manager.remove_track(&full_track_name).await;
+      info!(
+        "Removed track {:?} after last subscriber left; next SUBSCRIBE will re-subscribe upstream",
+        full_track_name
+      );
     }
   } else {
     warn!(

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -101,8 +101,13 @@ async fn forward_subscribe_upstream(
       biased;
       _ = &mut cancel_rx => {
         info!("Downstream unsubscribed; resetting upstream subscribe stream (CANCELLED)");
-        upstream.reset(StreamResetCode::Cancelled.to_u64());
-        return;
+        // Break and tear the stream down after the loop: `reset_and_stop`
+        // consumes `upstream`, which can't be moved inside the select while the
+        // `next_message()` branch borrows it. Reset the send half and stop the
+        // recv half with the same CANCELLED code, so the publisher sees a
+        // coherent cancellation on both halves rather than a STOP_SENDING(0)
+        // (InternalError) emitted when the handler is dropped.
+        break;
       }
       msg = upstream.next_message() => {
         match msg {
@@ -119,17 +124,44 @@ async fn forward_subscribe_upstream(
             let _ = handle_subscribe_error_message(relay_request_id, *m, context.clone()).await;
             return;
           }
+          Ok(ControlMessage::PublishDone(m)) => {
+            // Upstream is done for this track; relay its PUBLISH_DONE (status and
+            // reason verbatim) to the downstream subscribers. It usually arrives
+            // coalesced with the upstream stream FIN.
+            info!(
+              "Upstream PUBLISH_DONE for {:?}: status={:?} reason={}",
+              full_track_name,
+              m.status_code,
+              m.reason_phrase.as_str()
+            );
+            if let Some(track) = context.track_manager.get_track(&full_track_name).await
+              && let Err(e) = track
+                .read()
+                .await
+                .notify_publish_done(m.status_code, m.reason_phrase.as_str().to_string())
+                .await
+            {
+              error!("Failed to relay upstream PUBLISH_DONE downstream: {:?}", e);
+            }
+            return;
+          }
           Ok(other) => {
             warn!("Unexpected {:?} on upstream subscribe stream", other.get_type());
+            let _ = handle_subscribe_error_message(relay_request_id, RequestError::new(RequestErrorCode::InternalError, 0, ReasonPhrase::try_new("Unexpected message on upstream subscription stream".to_string()).unwrap()), context.clone()).await;
+            return;
           }
-          Err(_) => {
-            debug!("Upstream subscribe stream closed");
+          Err(code) => {
+            warn!("Upstream subscribe stream closed with error; resetting: {:?}", code);
+            // TODO: is this the right error code to send downstream?
+            let _ = handle_subscribe_error_message(relay_request_id, RequestError::new(RequestErrorCode::InternalError, 0, ReasonPhrase::try_new("Upstream subscription failed".to_string()).unwrap()), context.clone()).await;
             return;
           }
         }
       }
     }
   }
+
+  upstream.reset_and_stop(StreamResetCode::Cancelled.to_u64());
 }
 
 async fn handle_subscribe_message(

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -1157,17 +1157,17 @@ impl Subscription {
         );
         let _ = self.handle_stream_closed(&stream_id).await;
       }
-      TrackEvent::PublisherDisconnected { reason } => {
+      TrackEvent::PublisherDisconnected {
+        status_code,
+        reason,
+      } => {
         info!(
-          "Received PublisherDisconnected event: subscriber={}, reason={} relay_track_id={}",
-          self.client_connection_id, reason, self.relay_track_id
+          "Received PublisherDisconnected event: subscriber={}, status={:?} reason={} relay_track_id={}",
+          self.client_connection_id, status_code, reason, self.relay_track_id
         );
 
         // Send PublishDone message and finish the subscription
-        if let Err(e) = self
-          .send_publish_done(PublishDoneStatusCode::TrackEnded, &reason)
-          .await
-        {
+        if let Err(e) = self.send_publish_done(status_code, &reason).await {
           error!(
             "Failed to send PublishDone for publisher disconnect: subscriber={} relay_track_id={} error: {:?}",
             self.client_connection_id, self.relay_track_id, e

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -23,6 +23,7 @@ use crate::server::{client::MOQTClient, subscription::SubscriptionOrigin};
 use anyhow::Result;
 use moqtail::model::common::location::Location;
 use moqtail::model::common::reason_phrase::ReasonPhrase;
+use moqtail::model::control::constant::PublishDoneStatusCode;
 use moqtail::model::data::datagram::Datagram;
 use moqtail::model::data::full_track_name::FullTrackName;
 use moqtail::model::data::object::Object;
@@ -69,6 +70,7 @@ pub enum TrackEvent {
     stream_id: StreamId,
   },
   PublisherDisconnected {
+    status_code: PublishDoneStatusCode,
     reason: String,
   },
 }
@@ -495,8 +497,26 @@ impl Track {
       self.relay_track_id
     );
 
+    self
+      .notify_publish_done(
+        PublishDoneStatusCode::TrackEnded,
+        "Publisher disconnected".to_string(),
+      )
+      .await
+  }
+
+  /// Fan a PUBLISH_DONE out to all subscribers with the given status/reason.
+  /// Used when an upstream publisher signals it is done for the track, so the
+  /// upstream's status code is relayed downstream verbatim rather than being
+  /// flattened to a generic disconnect.
+  pub async fn notify_publish_done(
+    &self,
+    status_code: PublishDoneStatusCode,
+    reason: String,
+  ) -> Result<(), anyhow::Error> {
     let event = TrackEvent::PublisherDisconnected {
-      reason: "Publisher disconnected".to_string(),
+      status_code,
+      reason,
     };
 
     self

--- a/libs/moqtail-rs/src/model/common/reason_phrase.rs
+++ b/libs/moqtail-rs/src/model/common/reason_phrase.rs
@@ -37,6 +37,10 @@ impl ReasonPhrase {
     }
   }
 
+  pub fn as_str(&self) -> &str {
+    &self.phrase
+  }
+
   pub fn serialize(&self) -> Result<Bytes, ParseError> {
     let data = self.phrase.as_bytes();
     let mut buf = BytesMut::new();

--- a/libs/moqtail-rs/src/transport/connection.rs
+++ b/libs/moqtail-rs/src/transport/connection.rs
@@ -223,6 +223,26 @@ impl TransportRecvStream {
       Self::Quic(s) => s.read(buf).await.map_err(Into::into),
     }
   }
+
+  /// Asks the peer to stop sending on this stream (QUIC STOP_SENDING) with an
+  /// application error code, consuming the stream. Simply dropping the stream
+  /// instead sends STOP_SENDING with code 0, which the peer decodes as
+  /// InternalError; passing an explicit code keeps a cancellation coherent with
+  /// the RESET_STREAM sent on the peer's paired send half.
+  pub fn stop(self, code: u64) {
+    match self {
+      Self::WebTransport(s) => {
+        if let Ok(vi) = wtransport::VarInt::try_from_u64(code) {
+          s.stop(vi);
+        }
+      }
+      Self::Quic(mut s) => {
+        if let Ok(vi) = quinn::VarInt::from_u64(code) {
+          let _ = s.stop(vi);
+        }
+      }
+    }
+  }
 }
 
 #[derive(Debug, Clone)]

--- a/libs/moqtail-rs/src/transport/control_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/control_stream_handler.rs
@@ -102,6 +102,19 @@ impl ControlStreamHandler {
     }
   }
 
+  /// Aborts this bidirectional request stream in both directions with the same
+  /// application error code: RESET_STREAM on the send half and STOP_SENDING on
+  /// the recv half. Consumes the handler, since stopping the recv half takes
+  /// ownership. Prefer this over `reset` when cancelling a bidi request, so the
+  /// peer observes a coherent code on both halves instead of a STOP_SENDING(0)
+  /// (InternalError) emitted when the handler is later dropped.
+  pub fn reset_and_stop(mut self, code: u64) {
+    if let Err(e) = self.send.reset(code) {
+      warn!("Error resetting request stream: {:?}", e);
+    }
+    self.recv.stop(code);
+  }
+
   // TODO: refactor here, implement Serializable trait for ControlMessage
   pub async fn send_impl(
     &mut self,
@@ -632,6 +645,44 @@ mod tests {
     }
 
     Ok(())
+  }
+
+  /// A PUBLISH_DONE written and immediately followed by the stream FIN (so the
+  /// payload and the FIN arrive together) must still be delivered by
+  /// `next_message()` before the FIN is reported on the following call. This is
+  /// what lets the relay forward an upstream's final PUBLISH_DONE instead of
+  /// losing it to the coalesced close.
+  #[tokio::test]
+  async fn test_publish_done_coalesced_with_fin_is_delivered() -> Result<(), Box<dyn Error>> {
+    use crate::model::common::reason_phrase::ReasonPhrase;
+    use crate::model::control::constant::PublishDoneStatusCode;
+    use crate::model::control::publish_done::PublishDone;
+
+    let setup = TestSetup::new().await?;
+    let (mut plane, mut server_send) = setup.create_control_plane().await?;
+
+    let done = PublishDone::new(
+      42,
+      PublishDoneStatusCode::TrackEnded,
+      3,
+      ReasonPhrase::try_new("bye".to_string()).unwrap(),
+    );
+    let msg = ControlMessage::PublishDone(Box::new(done.clone()));
+
+    // Write the message, then FIN so the payload and the FIN are coalesced.
+    server_send.write_all(&msg.serialize()?).await?;
+    server_send.finish().await?;
+
+    match plane.next_message().await {
+      Ok(ControlMessage::PublishDone(rec)) => assert_eq!(*rec, done),
+      other => panic!("Expected PublishDone, got {other:?}"),
+    }
+
+    // The FIN is only observed as an error on the following call.
+    match plane.next_message().await {
+      Err(_) => Ok(()),
+      Ok(m) => panic!("Expected error after FIN, got {m:?}"),
+    }
   }
 
   #[tokio::test]


### PR DESCRIPTION
fix(relay): remove track when last subscriber leaves so re-subscribe works
fix(relay): forward upstream PUBLISH_DONE to downstream subscribers