### PR TITLE
fix(moqtail,relay): make PUBLISH-initiated delivery work against a peer

### DIFF
--- a/apps/client/src/subscriber.rs
+++ b/apps/client/src/subscriber.rs
@@ -255,7 +255,7 @@ pub async fn run(moq: MoqConnection, config: SubscribeConfig) -> Result<()> {
     tokio::spawn(async move {
       tokio::time::sleep(tokio::time::Duration::from_secs(delay)).await;
       info!("Sending REQUEST_UPDATE to set Forward State 1");
-      let update = RequestUpdate::new(10, 0, vec![MessageParameter::new_forward(true)]);
+      let update = RequestUpdate::new(10, vec![MessageParameter::new_forward(true)]);
       if let Err(e) = stream
         .send(&ControlMessage::RequestUpdate(Box::new(update)))
         .await

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -102,6 +102,7 @@ pub async fn handle(
   stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
+  opening_request_id: Option<u64>,
 ) -> Result<(), TerminationCode> {
   match msg {
     ControlMessage::Fetch(m) => {
@@ -698,16 +699,19 @@ pub async fn handle(
 
       Ok(())
     }
-    ControlMessage::RequestUpdate(m) => {
+    ControlMessage::RequestUpdate(_) => {
+      let Some(target_request_id) = opening_request_id else {
+        return Err(TerminationCode::ProtocolViolation);
+      };
       warn!(
         "REQUEST_UPDATE for FETCH request {} cannot be applied; stopping delivery",
-        m.existing_request_id
+        target_request_id
       );
       let cancel_tx = client
         .fetch_cancel_senders
         .write()
         .await
-        .remove(&m.existing_request_id);
+        .remove(&target_request_id);
       if let Some(tx) = cancel_tx {
         let _ = tx.send(FetchStop::UpdateFailed);
       }

--- a/apps/relay/src/server/message_handlers/mod.rs
+++ b/apps/relay/src/server/message_handlers/mod.rs
@@ -41,28 +41,58 @@ impl MessageHandler {
     stream_handler: &mut ControlStreamHandler,
     msg: ControlMessage,
     context: Arc<SessionContext>,
+    // Request ID of the First-marked message that opened this request stream,
+    // or None on the control stream.
+    opening_request_id: Option<u64>,
   ) -> Result<(), TerminationCode> {
     let handling_result = match &msg {
       ControlMessage::PublishNamespace(_) => {
-        publish_namespace_handler::handle(client.clone(), stream_handler, msg, context.clone())
-          .await
+        publish_namespace_handler::handle(
+          client.clone(),
+          stream_handler,
+          msg,
+          context.clone(),
+          opening_request_id,
+        )
+        .await
       }
       ControlMessage::SubscribeNamespace(_) => {
         warn!("SUBSCRIBE_NAMESPACE received on control stream — must use a dedicated bi-stream");
         Err(TerminationCode::ProtocolViolation)
       }
       ControlMessage::Subscribe(_) | ControlMessage::Switch(_) => {
-        subscribe_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
+        subscribe_handler::handle(
+          client.clone(),
+          stream_handler,
+          msg,
+          context.clone(),
+          opening_request_id,
+        )
+        .await
       }
 
       ControlMessage::TrackStatus(_) => {
-        track_status_handler::handle(stream_handler, msg, context.clone()).await
+        track_status_handler::handle(stream_handler, msg, context.clone(), opening_request_id).await
       }
       ControlMessage::Fetch(_) => {
-        fetch_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
+        fetch_handler::handle(
+          client.clone(),
+          stream_handler,
+          msg,
+          context.clone(),
+          opening_request_id,
+        )
+        .await
       }
       ControlMessage::Publish(_) | ControlMessage::PublishDone(_) => {
-        publish_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
+        publish_handler::handle(
+          client.clone(),
+          stream_handler,
+          msg,
+          context.clone(),
+          opening_request_id,
+        )
+        .await
       }
 
       // A response is read on the request's own bidi stream; reaching the control
@@ -78,8 +108,11 @@ impl MessageHandler {
         Err(TerminationCode::ProtocolViolation)
       }
 
-      ControlMessage::RequestUpdate(m) => {
-        let target_req_id = m.existing_request_id;
+      ControlMessage::RequestUpdate(_) => {
+        let Some(target_req_id) = opening_request_id else {
+          warn!("REQUEST_UPDATE on the control stream; closing session");
+          return Err(TerminationCode::ProtocolViolation);
+        };
 
         enum Route {
           Fetch,
@@ -112,17 +145,44 @@ impl MessageHandler {
         // Route to the appropriate handler (defined only once!)
         match route {
           Route::Fetch => {
-            fetch_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
+            fetch_handler::handle(
+              client.clone(),
+              stream_handler,
+              msg,
+              context.clone(),
+              opening_request_id,
+            )
+            .await
           }
           Route::Publish => {
-            publish_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
+            publish_handler::handle(
+              client.clone(),
+              stream_handler,
+              msg,
+              context.clone(),
+              opening_request_id,
+            )
+            .await
           }
           Route::PublishNamespace => {
-            publish_namespace_handler::handle(client.clone(), stream_handler, msg, context.clone())
-              .await
+            publish_namespace_handler::handle(
+              client.clone(),
+              stream_handler,
+              msg,
+              context.clone(),
+              opening_request_id,
+            )
+            .await
           }
           Route::Subscribe => {
-            subscribe_handler::handle(client.clone(), stream_handler, msg, context.clone()).await
+            subscribe_handler::handle(
+              client.clone(),
+              stream_handler,
+              msg,
+              context.clone(),
+              opening_request_id,
+            )
+            .await
           }
           Route::SubscribeNamespace => {
             subscribe_namespace_handler::handle(
@@ -130,11 +190,13 @@ impl MessageHandler {
               stream_handler,
               msg,
               context.clone(),
+              opening_request_id,
             )
             .await
           }
           Route::TrackStatus => {
-            track_status_handler::handle(stream_handler, msg, context.clone()).await
+            track_status_handler::handle(stream_handler, msg, context.clone(), opening_request_id)
+              .await
           }
           Route::NotFound => {
             // A REQUEST_UPDATE referencing an unknown request is disallowed: it

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -21,11 +21,8 @@ use crate::server::track_manager::SubscribeKind;
 use core::result::Result;
 use moqtail::model::common::reason_phrase::ReasonPhrase;
 use moqtail::model::control::{
-  constant::{FilterType, GroupOrder},
-  control_message::ControlMessage,
-  publish::Publish,
-  request_error::RequestError,
-  request_ok::RequestOk,
+  constant::GroupOrder, control_message::ControlMessage, publish::Publish,
+  request_error::RequestError, request_ok::RequestOk,
 };
 use moqtail::model::error::{RequestErrorCode, TerminationCode};
 use moqtail::model::parameter::constant::MessageParameterType;
@@ -34,6 +31,7 @@ use moqtail::model::parameter::message_parameter::{MessageParameter, MessagePara
 use moqtail::model::property::track_property::has_unsupported_mandatory;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use tracing::{debug, error, info, warn};
 
 pub async fn handle(
@@ -41,6 +39,7 @@ pub async fn handle(
   stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
+  opening_request_id: Option<u64>,
 ) -> Result<(), TerminationCode> {
   match msg {
     ControlMessage::Publish(m) => {
@@ -282,16 +281,35 @@ pub async fn handle(
       }
 
       let m_clone = m.clone();
-      let publish_forward_param = m_clone.parameters.get_param_or(
-        MessageParameterType::Forward,
-        MessageParameter::new_forward(true),
+      // FORWARD in PUBLISH is the publisher declaring its own behaviour: 0 means
+      // it sends nothing until we raise the state, omitted or 1 means it sends
+      // immediately. That declaration is the initial Forward State, but the reply
+      // must be 1 whenever a downstream subscriber already wants Objects.
+      let publisher_forwards = matches!(
+        m_clone.parameters.get_param_or(
+          MessageParameterType::Forward,
+          MessageParameter::new_forward(true),
+        ),
+        MessageParameter::Forward { forward: true }
       );
+      let forwarding = match context.track_manager.get_track(&full_track_name).await {
+        Some(track_arc) => {
+          let track = track_arc.read().await;
+          let forwarding = publisher_forwards || track.has_forwarding_subscriber().await;
+          track.upstream_forward.store(forwarding, Ordering::Relaxed);
+          forwarding
+        }
+        None => publisher_forwards,
+      };
       // PUBLISH is answered by REQUEST_OK (PUBLISH_OK); no Track Properties.
+      // SUBSCRIBER_PRIORITY is omitted so the publisher uses the default of 128;
+      // the relay has no reason to rank a pushed track above everything else.
+      // SUBSCRIPTION_FILTER is omitted so the subscription is unfiltered: a relay
+      // wants every Object, both to serve downstream filters and to fill its
+      // cache for FETCH.
       let publish_ok = Box::new(RequestOk::new(vec![
-        publish_forward_param,
-        MessageParameter::new_subscriber_priority(5),
+        MessageParameter::new_forward(forwarding),
         MessageParameter::new_group_order(GroupOrder::Ascending),
-        MessageParameter::new_subscription_filter(FilterType::LatestObject, None, None),
       ]));
 
       info!(
@@ -328,7 +346,10 @@ pub async fn handle(
 
     ControlMessage::RequestUpdate(m) => {
       let update_msg = *m;
-      let publisher_req_id = update_msg.existing_request_id;
+      let Some(target_request_id) = opening_request_id else {
+        return Err(TerminationCode::ProtocolViolation);
+      };
+      let publisher_req_id = target_request_id;
 
       {
         let mut map = client.inbound_requests.write().await;
@@ -417,10 +438,14 @@ pub async fn handle(
 
         let mut forwarded_update = update_msg.clone();
         forwarded_update.request_id = relay_update_id;
-        forwarded_update.existing_request_id = subscriber_existing_id;
 
+        // Goes on the subscription's own request stream, which is what names
+        // the request being updated.
         subscriber_client
-          .queue_message(ControlMessage::RequestUpdate(Box::new(forwarded_update)))
+          .send_response(
+            subscriber_existing_id,
+            ControlMessage::RequestUpdate(Box::new(forwarded_update)),
+          )
           .await;
       }
 
@@ -433,6 +458,72 @@ pub async fn handle(
       Ok(())
     }
     _ => Ok(()),
+  }
+}
+
+/// Raise a PUBLISH-created track's upstream Forward State to 1 once something
+/// downstream wants Objects. A publisher that declared FORWARD=0 sends nothing
+/// until told to, so without this the track never delivers.
+pub(crate) async fn ensure_upstream_forwarding(
+  track_arc: &Arc<tokio::sync::RwLock<Track>>,
+  context: &Arc<SessionContext>,
+) {
+  let (origin, full_track_name) = {
+    let track = track_arc.read().await;
+    (track.origin, track.full_track_name.clone())
+  };
+  if origin != TrackOrigin::Publish {
+    return;
+  }
+
+  let publisher_ids: Vec<usize> = {
+    let track = track_arc.read().await;
+    if !track.has_forwarding_subscriber().await {
+      return;
+    }
+    // swap returns the previous value, so false means this call is the one that
+    // set the flag and therefore owns the update; true means someone beat us.
+    if track.upstream_forward.swap(true, Ordering::Relaxed) {
+      return;
+    }
+    let aliases = track.publisher_aliases.read().await;
+    aliases.keys().copied().collect()
+  };
+
+  for connection_id in publisher_ids {
+    let Some(publisher_request_id) = context
+      .track_manager
+      .get_publish_request_id(&full_track_name, connection_id)
+      .await
+    else {
+      warn!("No stored PUBLISH for publisher {connection_id} on {full_track_name:?}");
+      continue;
+    };
+    let publisher = {
+      let manager = context.client_manager.read().await;
+      manager.get(connection_id).await
+    };
+    let Some(publisher) = publisher else {
+      continue;
+    };
+
+    let update = moqtail::model::control::request_update::RequestUpdate::new(
+      Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await,
+      vec![MessageParameter::new_forward(true)],
+    );
+    // Goes on the publisher's own PUBLISH request stream, where the responses to
+    // that request belong.
+    let delivered = publisher
+      .send_response(
+        publisher_request_id,
+        ControlMessage::RequestUpdate(Box::new(update)),
+      )
+      .await;
+    if delivered {
+      info!("Raised upstream Forward State for {full_track_name:?} (publisher {connection_id})");
+    } else {
+      warn!("No open PUBLISH request stream for publisher {connection_id} on {full_track_name:?}");
+    }
   }
 }
 

--- a/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
@@ -31,6 +31,7 @@ pub async fn handle(
   stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
+  opening_request_id: Option<u64>,
 ) -> Result<(), TerminationCode> {
   match msg {
     ControlMessage::PublishNamespace(m) => {
@@ -114,7 +115,10 @@ pub async fn handle(
 
     ControlMessage::RequestUpdate(m) => {
       let update_msg = *m;
-      let existing_req_id = update_msg.existing_request_id;
+      let Some(target_request_id) = opening_request_id else {
+        return Err(TerminationCode::ProtocolViolation);
+      };
+      let existing_req_id = target_request_id;
 
       let target_namespace = {
         let mut map = client.inbound_requests.write().await;
@@ -158,7 +162,6 @@ pub async fn handle(
 
           let fanout_msg = moqtail::model::control::request_update::RequestUpdate::new(
             relay_update_id,
-            downstream_req_id,
             update_msg.parameters.clone(),
           );
 
@@ -174,8 +177,13 @@ pub async fn handle(
             );
           }
 
+          // Goes on the namespace subscription's own request stream, which is
+          // what names the request being updated.
           session
-            .queue_message(ControlMessage::RequestUpdate(Box::new(fanout_msg)))
+            .send_response(
+              downstream_req_id,
+              ControlMessage::RequestUpdate(Box::new(fanout_msg)),
+            )
             .await;
         } else {
           warn!(

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -376,6 +376,12 @@ async fn handle_subscribe_message(
     }
   };
 
+  // A subscriber attaching to a PUBLISH-created track is what makes the relay
+  // want Objects, so tell the publisher to start sending.
+  if res.is_ok() {
+    super::publish_handler::ensure_upstream_forwarding(&track_arc, &context).await;
+  }
+
   // Store in client's subscribe requests on success
   if res.is_ok() {
     let mut requests = client.subscribe_requests.write().await;
@@ -655,9 +661,8 @@ pub async fn handle_request_update(
   stream_handler: &mut ControlStreamHandler,
   update_msg: moqtail::model::control::request_update::RequestUpdate,
   context: Arc<SessionContext>,
+  existing_req_id: u64,
 ) -> Result<(), TerminationCode> {
-  let existing_req_id = update_msg.existing_request_id;
-
   let full_track_name = {
     let mut client_requests = client.subscribe_requests.write().await;
     match client_requests.get_mut(&existing_req_id) {
@@ -720,6 +725,9 @@ pub async fn handle_request_update(
         "Subscription updated successfully for track: {:?}",
         full_track_name
       );
+      // The update may have turned this subscriber's Forward State on, which is
+      // the first thing wanting Objects from a PUBLISH-created track.
+      super::publish_handler::ensure_upstream_forwarding(&track_arc, &context).await;
       let ok_msg = RequestOk::new(vec![]);
       let _ = stream_handler.send_impl(&ok_msg).await;
     }
@@ -1011,13 +1019,17 @@ pub async fn handle(
   stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
+  opening_request_id: Option<u64>,
 ) -> Result<(), TerminationCode> {
   match msg {
     ControlMessage::Subscribe(m) => {
       handle_subscribe_message(client, stream_handler, *m, context, false).await
     }
     ControlMessage::RequestUpdate(m) => {
-      handle_request_update(client, stream_handler, *m, context).await
+      let Some(target_request_id) = opening_request_id else {
+        return Err(TerminationCode::ProtocolViolation);
+      };
+      handle_request_update(client, stream_handler, *m, context, target_request_id).await
     }
     ControlMessage::Switch(m) => handle_switch_message(client, stream_handler, *m, context).await,
     _ => {

--- a/apps/relay/src/server/message_handlers/subscribe_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_namespace_handler.rs
@@ -217,11 +217,15 @@ pub async fn handle(
   handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
+  opening_request_id: Option<u64>,
 ) -> Result<(), TerminationCode> {
   match msg {
     ControlMessage::RequestUpdate(m) => {
       let update_msg = *m;
-      let existing_req_id = update_msg.existing_request_id;
+      let Some(target_request_id) = opening_request_id else {
+        return Err(TerminationCode::ProtocolViolation);
+      };
+      let existing_req_id = target_request_id;
 
       let target_prefix = {
         let mut map = client.inbound_requests.write().await;

--- a/apps/relay/src/server/message_handlers/track_status_handler.rs
+++ b/apps/relay/src/server/message_handlers/track_status_handler.rs
@@ -30,6 +30,7 @@ pub async fn handle(
   stream_handler: &mut ControlStreamHandler,
   msg: ControlMessage,
   context: Arc<SessionContext>,
+  opening_request_id: Option<u64>,
 ) -> Result<(), TerminationCode> {
   match msg {
     ControlMessage::TrackStatus(m) => {
@@ -98,10 +99,10 @@ pub async fn handle(
       Ok(())
     }
 
-    ControlMessage::RequestUpdate(m) => {
+    ControlMessage::RequestUpdate(_) => {
       warn!(
-        "REQUEST_UPDATE is not valid for a TRACK_STATUS request (id {})",
-        m.existing_request_id
+        "REQUEST_UPDATE is not valid for a TRACK_STATUS request (id {:?})",
+        opening_request_id
       );
       let err = track_status_update_error();
       stream_handler

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -327,6 +327,7 @@ impl Session {
         &mut control_stream_handler,
         msg,
         context.clone(),
+        None,
       )
       .await;
 
@@ -642,6 +643,7 @@ impl Session {
           &mut stream_handler,
           first,
           context.clone(),
+          Some(request_id),
         )
         .await
         {
@@ -672,6 +674,7 @@ impl Session {
                     &mut stream_handler,
                     follow_up,
                     context.clone(),
+                    Some(request_id),
                   )
                   .await
                   {

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -124,6 +124,11 @@ pub struct Track {
   /// None, so a subscriber leaving never cancels the publisher; the pushed track
   /// stays alive as long as the publisher keeps publishing.
   pub upstream_cancel: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+  /// Forward State the relay last gave the upstream publisher of a
+  /// PUBLISH-created track. A relay may answer PUBLISH with Forward State 0
+  /// while nothing downstream wants the track; this records whether it has
+  /// since been raised, so it is raised only once.
+  pub upstream_forward: Arc<AtomicBool>,
 }
 
 // TODO: this track implementation should be static? At least
@@ -158,7 +163,18 @@ impl Track {
       track_properties: Arc::new(RwLock::new(Vec::new())),
       active_subgroup_headers: Arc::new(RwLock::new(HashMap::new())),
       upstream_cancel: Arc::new(Mutex::new(None)),
+      upstream_forward: Arc::new(AtomicBool::new(false)),
     }
+  }
+
+  /// Whether any subscription on this track currently wants Objects forwarded.
+  pub async fn has_forwarding_subscriber(&self) -> bool {
+    for sub in self.subscription_manager.get_all_subscriptions().await {
+      if sub.read().await.is_forwarding().await {
+        return true;
+      }
+    }
+    false
   }
 
   /// Add a publisher (connection_id -> track_alias) to this track.

--- a/apps/relay/src/server/track_manager.rs
+++ b/apps/relay/src/server/track_manager.rs
@@ -443,6 +443,20 @@ impl TrackManager {
     }
   }
 
+  /// The request id of the PUBLISH this connection used for the track, which
+  /// identifies the request stream its responses belong on.
+  pub async fn get_publish_request_id(
+    &self,
+    full_track_name: &FullTrackName,
+    connection_id: usize,
+  ) -> Option<u64> {
+    let publishes = self.publishes.read().await;
+    publishes
+      .get(full_track_name)
+      .and_then(|by_connection| by_connection.get(&connection_id))
+      .map(|publish| publish.request_id)
+  }
+
   pub async fn get_tracks_and_publishes_by_namespace_prefix(
     &self,
     prefix: &Tuple,

--- a/libs/moqtail-rs/src/model/control/request_update.rs
+++ b/libs/moqtail-rs/src/model/control/request_update.rs
@@ -24,15 +24,13 @@ use bytes::{BufMut, Bytes, BytesMut};
 #[derive(Debug, PartialEq, Clone)]
 pub struct RequestUpdate {
   pub request_id: u64,
-  pub existing_request_id: u64,
   pub parameters: Vec<MessageParameter>,
 }
 
 impl RequestUpdate {
-  pub fn new(request_id: u64, existing_request_id: u64, parameters: Vec<MessageParameter>) -> Self {
+  pub fn new(request_id: u64, parameters: Vec<MessageParameter>) -> Self {
     Self {
       request_id,
-      existing_request_id,
       parameters,
     }
   }
@@ -45,7 +43,6 @@ impl ControlMessageTrait for RequestUpdate {
 
     let mut payload = BytesMut::new();
     payload.put_vi(self.request_id)?;
-    payload.put_vi(self.existing_request_id)?;
     payload.put_vi(self.parameters.len())?;
     payload.extend_from_slice(&serialize_message_parameters(&self.parameters)?);
 
@@ -67,7 +64,6 @@ impl ControlMessageTrait for RequestUpdate {
 
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
     let request_id = payload.get_vi()?;
-    let existing_request_id = payload.get_vi()?;
 
     let param_count = payload.get_vi()?;
     let parameters =
@@ -75,7 +71,6 @@ impl ControlMessageTrait for RequestUpdate {
 
     Ok(Box::new(RequestUpdate {
       request_id,
-      existing_request_id,
       parameters,
     }))
   }
@@ -96,7 +91,6 @@ mod tests {
   fn test_roundtrip() {
     let request_update = RequestUpdate::new(
       120205,
-      54321,
       vec![MessageParameter::new_subscription_filter(
         FilterType::AbsoluteRange,
         Some(Location {
@@ -121,7 +115,6 @@ mod tests {
   fn test_excess_roundtrip() {
     let request_update = RequestUpdate::new(
       120205,
-      54321,
       vec![MessageParameter::new_subscription_filter(
         FilterType::AbsoluteRange,
         Some(Location {
@@ -152,7 +145,6 @@ mod tests {
   fn test_partial_message() {
     let request_update = RequestUpdate::new(
       120205,
-      54321,
       vec![MessageParameter::new_subscription_filter(
         FilterType::AbsoluteRange,
         Some(Location {

--- a/libs/moqtail-ts/src/client/client.ts
+++ b/libs/moqtail-ts/src/client/client.ts
@@ -1202,7 +1202,7 @@ export class MOQtailClient {
             new SubscriptionFilter(FilterType.AbsoluteRange, startLocation, endGroup),
             ...(parameters ?? []),
           ]
-          const msg = new RequestUpdate(requestId, subscriptionRequestId, updateParams)
+          const msg = new RequestUpdate(requestId, updateParams)
           subscription.update(msg) // This also updates the request since both maps store the same object
           // A REQUEST_UPDATE travels on the stream of the request it updates.
           await this.#requestStreamFor(subscriptionRequestId, 'MOQtailClient.subscribeUpdate').send(msg)

--- a/libs/moqtail-ts/src/model/control/request_update.ts
+++ b/libs/moqtail-ts/src/model/control/request_update.ts
@@ -30,7 +30,6 @@ import { Forward } from '../parameter/message/forward'
 export class RequestUpdate {
   constructor(
     public requestId: bigint,
-    public existingRequestId: bigint,
     public parameters: MessageParameter[],
   ) {}
 
@@ -44,7 +43,6 @@ export class RequestUpdate {
 
     const payload = new ByteBuffer()
     payload.putVI(this.requestId)
-    payload.putVI(this.existingRequestId)
     payload.putVI(this.parameters.length)
 
     payload.putBytes(serializeMessageParameterKvps(this.parameters.map((p) => p.toKeyValuePair())).toUint8Array())
@@ -61,7 +59,6 @@ export class RequestUpdate {
 
   static parsePayload(buf: BaseByteBuffer): RequestUpdate {
     const requestId = buf.getVI()
-    const existingRequestId = buf.getVI()
 
     const paramCountBig = buf.getVI()
     const paramCount = Number(paramCountBig)
@@ -75,15 +72,11 @@ export class RequestUpdate {
       if (param !== undefined) parameters.push(param)
     }
 
-    return new RequestUpdate(requestId, existingRequestId, parameters)
+    return new RequestUpdate(requestId, parameters)
   }
 
   equals(other: RequestUpdate): boolean {
-    if (
-      this.requestId !== other.requestId ||
-      this.existingRequestId !== other.existingRequestId ||
-      this.parameters.length !== other.parameters.length
-    ) {
+    if (this.requestId !== other.requestId || this.parameters.length !== other.parameters.length) {
       return false
     }
 
@@ -114,7 +107,7 @@ if (import.meta.vitest) {
         const bt = b.toKeyValuePair().typeValue
         return at < bt ? -1 : at > bt ? 1 : 0
       })
-      return new RequestUpdate(120205n, 120204n, parameters)
+      return new RequestUpdate(120205n, parameters)
     }
 
     it('should roundtrip correctly', () => {
@@ -175,7 +168,7 @@ if (import.meta.vitest) {
     })
 
     it('should handle empty parameters', () => {
-      const update = new RequestUpdate(120206n, 120205n, [])
+      const update = new RequestUpdate(120206n, [])
       const serialized = update.serialize()
       const buf = new ByteBuffer()
       buf.putBytes(serialized.toUint8Array())


### PR DESCRIPTION
Three defects, found in sequence while making a PUBLISH-created track actually deliver Objects.

REQUEST_UPDATE carried an Existing Request ID field that does not exist. The message is Request ID, Number of Parameters, Parameters -- the request being modified is the one that opened the stream the update arrives on. The extra varint meant a peer read our parameter count as the target id and then saw zero parameters, so every REQUEST_UPDATE we sent was inert, and every one we received was misparsed and routed to no request at all, which reset the subscription's stream. The relay now takes the target from the stream that carries the update, and the fan-outs moved from the control stream to the request stream, since that is now what names the request.

PUBLISH_OK answered with a hardcoded SUBSCRIBER_PRIORITY of 5, which ranks a pushed track above nearly everything else in the session, and a LATEST_OBJECT SUBSCRIPTION_FILTER, which discards Objects already published and leaves the cache unable to serve a FETCH for earlier groups. Both are omitted: the defaults are 128 and unfiltered, which is what a relay wants.

FORWARD in PUBLISH is the publisher describing its own behaviour, not a value to echo back: 0 means it waits to be told, omitted or 1 means it sends immediately. The reply keeps that as the initial state but is 1 whenever a downstream subscriber already wants Objects, and is raised later with a REQUEST_UPDATE when a subscriber arrives or an existing one turns forwarding on.
