### PR TITLE
fix(moqtail,moqtail-ts,relay): drop the Request ID from PUBLISH_DONE

### DIFF
--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -269,12 +269,7 @@ async fn send_publish_done(
   stream_count: u64,
 ) {
   let reason = ReasonPhrase::try_new("done".to_string()).expect("reason within length limit");
-  let done = PublishDone::new(
-    request_id,
-    PublishDoneStatusCode::TrackEnded,
-    stream_count,
-    reason,
-  );
+  let done = PublishDone::new(PublishDoneStatusCode::TrackEnded, stream_count, reason);
   if let Err(e) = request_stream
     .send(&ControlMessage::PublishDone(Box::new(done)))
     .await

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -323,21 +323,27 @@ pub async fn handle(
     }
 
     ControlMessage::PublishDone(m) => {
+      // PUBLISH_DONE names no request; it ends the one that opened this stream.
+      let Some(publisher_req_id) = opening_request_id else {
+        warn!("PUBLISH_DONE on the control stream; closing session");
+        return Err(TerminationCode::ProtocolViolation);
+      };
+
       info!(
         "Received PublishDone message for request ID: {} with status: {:?}",
-        m.request_id, m.status_code
+        publisher_req_id, m.status_code
       );
 
       // Clean up the published track
-      cleanup_published_track(&client, m.request_id, &context).await;
+      cleanup_published_track(&client, publisher_req_id, &context).await;
 
       // Remove the request from the unified map to avoid memory leak
       {
         let mut map = client.inbound_requests.write().await;
-        map.remove(&m.request_id);
+        map.remove(&publisher_req_id);
         debug!(
           "Removed terminated PUBLISH request {} from pending requests map",
-          m.request_id
+          publisher_req_id
         );
       }
 

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -756,7 +756,6 @@ pub async fn handle_request_update(
         None => 0,
       };
       let done = PublishDone::new(
-        existing_req_id,
         PublishDoneStatusCode::UpdateFailed,
         stream_count,
         ReasonPhrase::try_new("REQUEST_UPDATE failed".to_string()).unwrap(),

--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -1398,7 +1398,6 @@ impl Subscription {
       .map_err(|e| anyhow::anyhow!("Failed to create reason phrase: {:?}", e))?;
 
     let publish_done = PublishDone::new(
-      self.request_id,
       status_code,
       self.opened_stream_count.load(Ordering::Relaxed),
       reason_phrase,

--- a/libs/moqtail-rs/src/model/control/publish_done.rs
+++ b/libs/moqtail-rs/src/model/control/publish_done.rs
@@ -21,7 +21,6 @@ use bytes::{BufMut, Bytes, BytesMut};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct PublishDone {
-  pub request_id: u64,
   pub status_code: PublishDoneStatusCode,
   pub stream_count: u64,
   pub reason_phrase: ReasonPhrase,
@@ -29,13 +28,11 @@ pub struct PublishDone {
 
 impl PublishDone {
   pub fn new(
-    request_id: u64,
     status_code: PublishDoneStatusCode,
     stream_count: u64,
     reason_phrase: ReasonPhrase,
   ) -> Self {
     Self {
-      request_id,
       status_code,
       stream_count,
       reason_phrase,
@@ -49,7 +46,6 @@ impl ControlMessageTrait for PublishDone {
     buf.put_vi(ControlMessageType::PublishDone)?;
 
     let mut payload = BytesMut::new();
-    payload.put_vi(self.request_id)?;
     payload.put_vi(self.status_code)?;
     payload.put_vi(self.stream_count)?;
     payload.extend_from_slice(&self.reason_phrase.serialize()?);
@@ -70,7 +66,6 @@ impl ControlMessageTrait for PublishDone {
   }
 
   fn parse_payload(payload: &mut Bytes) -> Result<Box<Self>, ParseError> {
-    let request_id = payload.get_vi()?;
     // An unknown or GREASE status code is not fatal; treat it as InternalError.
     let status_code_raw = payload.get_vi()?;
     let status_code = PublishDoneStatusCode::from_wire(status_code_raw);
@@ -78,7 +73,6 @@ impl ControlMessageTrait for PublishDone {
     let reason_phrase = ReasonPhrase::deserialize(payload)?;
 
     Ok(Box::new(PublishDone {
-      request_id,
       status_code,
       stream_count,
       reason_phrase,
@@ -98,12 +92,10 @@ mod tests {
 
   #[test]
   fn test_roundtrip() {
-    let request_id = 209455;
     let status_code = PublishDoneStatusCode::SubscriptionEnded;
     let stream_count = 9;
     let reason_phrase = ReasonPhrase::try_new("It's not you, it's me.".to_string()).unwrap();
     let subscribe_done = PublishDone {
-      request_id,
       status_code,
       stream_count,
       reason_phrase,
@@ -120,12 +112,10 @@ mod tests {
 
   #[test]
   fn test_excess_roundtrip() {
-    let request_id = 209455;
     let status_code = PublishDoneStatusCode::SubscriptionEnded;
     let stream_count = 9;
     let reason_phrase = ReasonPhrase::try_new("It's not you, it's me.".to_string()).unwrap();
     let subscribe_done = PublishDone {
-      request_id,
       status_code,
       stream_count,
       reason_phrase,
@@ -148,12 +138,10 @@ mod tests {
 
   #[test]
   fn test_partial_message() {
-    let request_id = 209455;
     let status_code = PublishDoneStatusCode::SubscriptionEnded;
     let stream_count = 9;
     let reason_phrase = ReasonPhrase::try_new("It's not you, it's me.".to_string()).unwrap();
     let subscribe_done = PublishDone {
-      request_id,
       status_code,
       stream_count,
       reason_phrase,

--- a/libs/moqtail-rs/src/transport/control_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/control_stream_handler.rs
@@ -662,7 +662,6 @@ mod tests {
     let (mut plane, mut server_send) = setup.create_control_plane().await?;
 
     let done = PublishDone::new(
-      42,
       PublishDoneStatusCode::TrackEnded,
       3,
       ReasonPhrase::try_new("bye".to_string()).unwrap(),

--- a/libs/moqtail-ts/src/client/client.ts
+++ b/libs/moqtail-ts/src/client/client.ts
@@ -1565,7 +1565,8 @@ export class MOQtailClient {
       if (typeof publishRequestId === 'number') publishRequestId = BigInt(publishRequestId)
 
       // Create the PublishDone message. (StreamCount is set to 0n as a default)
-      const msg = new PublishDone(publishRequestId, statusCode, 0n, new ReasonPhrase(reasonPhrase))
+      // It carries no request id: the stream it is sent on names the request it ends.
+      const msg = new PublishDone(statusCode, 0n, new ReasonPhrase(reasonPhrase))
 
       // PUBLISH_DONE is the last message on the PUBLISH request's own stream.
       const requestStream = this.#requestStreams.get(publishRequestId)
@@ -1976,7 +1977,7 @@ export class MOQtailClient {
             `${msg.constructor.name} is not valid on a request stream (request id ${requestId})`,
           )
         }
-        await handler(this, msg, requestStream)
+        await handler(this, msg, requestStream, requestId)
         answered = true
       }
       logger.debug('MOQtailClient', `request stream for requestId=${requestId} closed by peer`)
@@ -2086,6 +2087,9 @@ export class MOQtailClient {
       return
     }
 
+    // The first message names the request; everything later on this stream belongs to it.
+    const openingRequestId = (first as { requestId: bigint }).requestId
+
     try {
       let msg: ControlMessage | undefined = first
       while (msg) {
@@ -2096,7 +2100,7 @@ export class MOQtailClient {
             `No handler for ${msg.constructor.name} on a request stream`,
           )
         }
-        await handler(this, msg, requestStream)
+        await handler(this, msg, requestStream, openingRequestId)
         msg = await requestStream.next()
       }
     } catch (error) {

--- a/libs/moqtail-ts/src/client/handler/handler.ts
+++ b/libs/moqtail-ts/src/client/handler/handler.ts
@@ -65,9 +65,16 @@ export type ControlMessageHandler<T> = (client: MOQtailClient, msg: T) => Promis
 
 /**
  * A message on a bidirectional request stream. `stream` is the stream the message
- * arrived on and the only place a response to it may be written.
+ * arrived on and the only place a response to it may be written. `openingRequestId` is
+ * the id of the request that opened it, which is what names the request for messages
+ * that carry no id of their own.
  */
-export type RequestStreamMessageHandler<T> = (client: MOQtailClient, msg: T, stream: RequestStream) => Promise<void>
+export type RequestStreamMessageHandler<T> = (
+  client: MOQtailClient,
+  msg: T,
+  stream: RequestStream,
+  openingRequestId: bigint,
+) => Promise<void>
 
 /**
  * Draft-18 §3.3: the control stream carries SETUP and GOAWAY, nothing else. SETUP is

--- a/libs/moqtail-ts/src/client/handler/publish_done.ts
+++ b/libs/moqtail-ts/src/client/handler/publish_done.ts
@@ -20,12 +20,17 @@ import { RequestStreamMessageHandler } from './handler'
 import { SubscribeRequest } from '../request/subscribe'
 import { logger } from '../../util/logger'
 
-export const handlerPublishDone: RequestStreamMessageHandler<PublishDone> = async (client, msg) => {
+export const handlerPublishDone: RequestStreamMessageHandler<PublishDone> = async (
+  client,
+  msg,
+  _stream,
+  openingRequestId,
+) => {
   if (client.onPeerPublishDone) {
     client.onPeerPublishDone(msg)
   }
   //TODO: Check for all kinds of subscriptions, not jus tthe ones initiated with subscribe messages
-  const request = client.requests.get(msg.requestId)
+  const request = client.requests.get(openingRequestId)
   if (request instanceof SubscribeRequest) {
     request.expectedStreams = msg.streamCount
   } else {

--- a/libs/moqtail-ts/src/client/publication/subscribe.ts
+++ b/libs/moqtail-ts/src/client/publication/subscribe.ts
@@ -193,12 +193,7 @@ export class SubscribePublication {
    */
   async done(statusCode: PublishDoneStatusCode): Promise<void> {
     this.#isCompleted = true
-    const publishDone = new PublishDone(
-      this.subscribeMsg.requestId,
-      statusCode,
-      BigInt(this.#streamsOpened),
-      new ReasonPhrase('Subscription ended'),
-    )
+    const publishDone = new PublishDone(statusCode, BigInt(this.#streamsOpened), new ReasonPhrase('Subscription ended'))
     // TODO: Handle track completion, there might be ongoing streams. Wait for all to finish before cleaning the state
     await this.requestStream.send(publishDone)
   }

--- a/libs/moqtail-ts/src/model/control/publish_done.ts
+++ b/libs/moqtail-ts/src/model/control/publish_done.ts
@@ -21,19 +21,13 @@ import { ControlMessageType, PublishDoneStatusCode } from './constant'
 
 export class PublishDone {
   constructor(
-    public readonly requestId: bigint,
     public readonly statusCode: PublishDoneStatusCode,
     public readonly streamCount: bigint,
     public readonly errorReason: ReasonPhrase,
   ) {}
 
-  static new(
-    requestId: bigint | number,
-    statusCode: PublishDoneStatusCode,
-    streamCount: bigint,
-    errorReason: ReasonPhrase,
-  ): PublishDone {
-    return new PublishDone(BigInt(requestId), statusCode, streamCount, errorReason)
+  static new(statusCode: PublishDoneStatusCode, streamCount: bigint, errorReason: ReasonPhrase): PublishDone {
+    return new PublishDone(statusCode, streamCount, errorReason)
   }
 
   getType(): ControlMessageType {
@@ -44,7 +38,6 @@ export class PublishDone {
     const buf = new ByteBuffer()
     buf.putVI(ControlMessageType.PublishDone)
     const payload = new ByteBuffer()
-    payload.putVI(this.requestId)
     payload.putVI(this.statusCode)
     payload.putVI(this.streamCount)
     payload.putReasonPhrase(this.errorReason)
@@ -58,12 +51,11 @@ export class PublishDone {
   }
 
   static parsePayload(buf: BaseByteBuffer): PublishDone {
-    const requestId = buf.getVI()
     const statusCodeRaw = buf.getVI()
     const statusCode = PublishDoneStatusCode.tryFrom(statusCodeRaw)
     const streamCount = buf.getVI()
     const errorReason = buf.getReasonPhrase()
-    return new PublishDone(requestId, statusCode, streamCount, errorReason)
+    return new PublishDone(statusCode, streamCount, errorReason)
   }
 }
 
@@ -72,11 +64,10 @@ if (import.meta.vitest) {
 
   describe('PublishDone', () => {
     test('roundtrip', () => {
-      const requestId = 12345n
       const statusCode = PublishDoneStatusCode.SubscriptionEnded
       const streamCount = 123n
       const errorReason = new ReasonPhrase('Lorem ipsum dolor sit amet')
-      const publishDone = PublishDone.new(requestId, statusCode, streamCount, errorReason)
+      const publishDone = PublishDone.new(statusCode, streamCount, errorReason)
 
       const frozen = publishDone.serialize()
       const msgType = frozen.getVI()
@@ -84,7 +75,6 @@ if (import.meta.vitest) {
       const msgLength = frozen.getU16()
       expect(msgLength).toBe(frozen.remaining)
       const deserialized = PublishDone.parsePayload(frozen)
-      expect(deserialized.requestId).toBe(publishDone.requestId)
       expect(deserialized.statusCode).toBe(publishDone.statusCode)
       expect(deserialized.streamCount).toBe(publishDone.streamCount)
       expect(deserialized.errorReason.phrase).toBe(publishDone.errorReason.phrase)
@@ -92,11 +82,10 @@ if (import.meta.vitest) {
     })
 
     test('excess roundtrip', () => {
-      const requestId = 12345n
       const statusCode = PublishDoneStatusCode.Expired
       const streamCount = 123n
       const errorReason = new ReasonPhrase('Lorem ipsum dolor sit amet')
-      const publishDone = PublishDone.new(requestId, statusCode, streamCount, errorReason)
+      const publishDone = PublishDone.new(statusCode, streamCount, errorReason)
       const serialized = publishDone.serialize().toUint8Array()
       const excess = new Uint8Array([9, 1, 1])
       const buf = new ByteBuffer()
@@ -108,7 +97,6 @@ if (import.meta.vitest) {
       const msgLength = frozen.getU16()
       expect(msgLength).toBe(frozen.remaining - 3)
       const deserialized = PublishDone.parsePayload(frozen)
-      expect(deserialized.requestId).toBe(publishDone.requestId)
       expect(deserialized.statusCode).toBe(publishDone.statusCode)
       expect(deserialized.streamCount).toBe(publishDone.streamCount)
       expect(deserialized.errorReason.phrase).toBe(publishDone.errorReason.phrase)
@@ -117,11 +105,10 @@ if (import.meta.vitest) {
     })
 
     test('partial message', () => {
-      const requestId = 12345n
       const statusCode = PublishDoneStatusCode.Expired
       const streamCount = 123n
       const errorReason = new ReasonPhrase('Lorem ipsum dolor sit amet')
-      const publishDone = PublishDone.new(requestId, statusCode, streamCount, errorReason)
+      const publishDone = PublishDone.new(statusCode, streamCount, errorReason)
       const serialized = publishDone.serialize().toUint8Array()
       const upper = Math.floor(serialized.length / 2)
       const partial = serialized.slice(0, upper)


### PR DESCRIPTION
PUBLISH_DONE is a response: it carries no Request ID, because the stream it is sent on already names the request it ends. Both implementations put one at the front of the payload, which broke interoperation in both directions.

Outbound, a peer read our Request ID as the Status Code and the Status Code as the Stream Count, so it was told a subscription had ended normally when it had not -- silently, with no parse error. Inbound, a correctly formed PUBLISH_DONE failed to parse; the relay treated that as a protocol violation on the upstream subscribe stream and answered its downstream subscriber with a REQUEST_ERROR after the PUBLISH_DONE it had already sent, which is invalid on an accepted subscription and killed the subscriber's session.

Verified against another implementation: the relay now parses the peer's PUBLISH_DONE, emits the same byte shape, and the subscriber reports the true status, stream count and reason phrase, propagated from the origin publisher.

PublishDone::new and the TypeScript constructor lose their first argument. The relay takes the id from the stream instead, and the TypeScript request stream handlers gain an openingRequestId argument, mirroring the relay.
