### PR TITLE
fix(moqtail): report a peer closing the control stream as a pro. vio.

### DIFF
--- a/libs/moqtail-rs/src/transport/control_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/control_stream_handler.rs
@@ -250,8 +250,10 @@ impl ControlStreamHandler {
         } else {
           warn!("Stream closed cleanly while waiting for data");
         }
-        // The stream was closed cleanly by the peer.
-        Err(TerminationCode::InternalError)
+        // A peer that closes the control stream mid-session commits a protocol
+        // violation. On a request stream a clean close is instead the ordinary
+        // cancellation, and those callers act on the close rather than this code.
+        Err(TerminationCode::ProtocolViolation)
       }
       Err(e) => {
         match e {


### PR DESCRIPTION
as a protocol violation

A peer that closes the control stream while the session is alive commits a protocol violation, so the session must end with that code. The handler returned INTERNAL_ERROR, which blames the relay for the peer's mistake and tells the peer nothing about what it did wrong.

The same handler also serves request streams, where a clean close is the ordinary way to cancel a request. That is unaffected: every request stream reader acts on the close itself and discards the code, so the control stream loop is the only caller that propagates it.

Verified against another implementation: the peer now reports the session closing with code 3 rather than 1.
