### PR TITLE
fix(moqtail,moqtail-ts): correct the PUBLISH_DONE status codes

### DIFF
--- a/dev/conformance/draft18/publish_done_codes.json
+++ b/dev/conformance/draft18/publish_done_codes.json
@@ -1,0 +1,23 @@
+{
+  "source": "draft-ietf-moq-transport-18 §15.10.3 Table 19",
+  "description": "Status codes carried by PUBLISH_DONE (§10.11).",
+
+  "greasing": {
+    "formula": "0x7f * N + 0x9D",
+    "spec": "Section 14",
+    "notes": "Reserved for greasing. Not a single codepoint; excluded from the entries below."
+  },
+
+  "entries": [
+    { "name": "INTERNAL_ERROR", "value": "0x0", "spec": "Section 10.11" },
+    { "name": "UNAUTHORIZED", "value": "0x1", "spec": "Section 10.11" },
+    { "name": "TRACK_ENDED", "value": "0x2", "spec": "Section 10.11" },
+    { "name": "SUBSCRIPTION_ENDED", "value": "0x3", "spec": "Section 10.11" },
+    { "name": "GOING_AWAY", "value": "0x4", "spec": "Section 10.11" },
+    { "name": "TOO_FAR_BEHIND", "value": "0x5", "spec": "Section 10.11" },
+    { "name": "EXPIRED", "value": "0x6", "spec": "Section 10.11" },
+    { "name": "UPDATE_FAILED", "value": "0x8", "spec": "Section 10.11" },
+    { "name": "EXCESSIVE_LOAD", "value": "0x9", "spec": "Section 10.11" },
+    { "name": "MALFORMED_TRACK", "value": "0x12", "spec": "Section 10.11" }
+  ]
+}

--- a/libs/moqtail-rs/src/conformance.rs
+++ b/libs/moqtail-rs/src/conformance.rs
@@ -145,6 +145,13 @@ pub fn request_error_codes() -> Registry {
   )
 }
 
+pub fn publish_done_codes() -> Registry {
+  parse(
+    fixture!("publish_done_codes.json"),
+    "publish_done_codes.json",
+  )
+}
+
 pub fn termination_codes() -> Registry {
   parse(fixture!("termination_codes.json"), "termination_codes.json")
 }
@@ -294,7 +301,7 @@ mod tests {
 #[cfg(test)]
 mod enum_conformance {
   use super::*;
-  use crate::model::control::constant::ControlMessageType;
+  use crate::model::control::constant::{ControlMessageType, PublishDoneStatusCode};
   use crate::model::error::RequestErrorCode;
   use crate::model::error::TerminationCode;
   use crate::model::parameter::constant::{MessageParameterType, SetupOptionType};
@@ -399,6 +406,15 @@ mod enum_conformance {
   fn request_error_codes_match_fixture() {
     assert_registry(&request_error_codes(), &[], |cp| {
       RequestErrorCode::try_from(cp)
+        .ok()
+        .map(|c| format!("{c:?}"))
+    });
+  }
+
+  #[test]
+  fn publish_done_codes_match_fixture() {
+    assert_registry(&publish_done_codes(), &[], |cp| {
+      PublishDoneStatusCode::try_from(cp)
         .ok()
         .map(|c| format!("{c:?}"))
     });

--- a/libs/moqtail-rs/src/model/control/constant.rs
+++ b/libs/moqtail-rs/src/model/control/constant.rs
@@ -284,9 +284,10 @@ pub enum PublishDoneStatusCode {
   TrackEnded = 0x2,
   SubscriptionEnded = 0x3,
   GoingAway = 0x4,
-  Expired = 0x5,
-  TooFarBehind = 0x6,
+  TooFarBehind = 0x5,
+  Expired = 0x6,
   UpdateFailed = 0x8,
+  ExcessiveLoad = 0x9,
   MalformedTrack = 0x12,
 }
 
@@ -300,9 +301,10 @@ impl TryFrom<u64> for PublishDoneStatusCode {
       0x2 => Ok(PublishDoneStatusCode::TrackEnded),
       0x3 => Ok(PublishDoneStatusCode::SubscriptionEnded),
       0x4 => Ok(PublishDoneStatusCode::GoingAway),
-      0x5 => Ok(PublishDoneStatusCode::Expired),
-      0x6 => Ok(PublishDoneStatusCode::TooFarBehind),
+      0x5 => Ok(PublishDoneStatusCode::TooFarBehind),
+      0x6 => Ok(PublishDoneStatusCode::Expired),
       0x8 => Ok(PublishDoneStatusCode::UpdateFailed),
+      0x9 => Ok(PublishDoneStatusCode::ExcessiveLoad),
       0x12 => Ok(PublishDoneStatusCode::MalformedTrack),
       _ => Err(ParseError::InvalidType {
         context: "PublishDoneStatusCode::try_from(u64)",

--- a/libs/moqtail-ts/src/model/control/constant.ts
+++ b/libs/moqtail-ts/src/model/control/constant.ts
@@ -316,9 +316,10 @@ export enum PublishDoneStatusCode {
   TrackEnded = 0x2,
   SubscriptionEnded = 0x3,
   GoingAway = 0x4,
-  Expired = 0x5,
-  TooFarBehind = 0x6,
+  TooFarBehind = 0x5,
+  Expired = 0x6,
   UpdateFailed = 0x8,
+  ExcessiveLoad = 0x9,
   MalformedTrack = 0x12,
 }
 
@@ -342,11 +343,13 @@ export namespace PublishDoneStatusCode {
       case 0x4n:
         return PublishDoneStatusCode.GoingAway
       case 0x5n:
-        return PublishDoneStatusCode.Expired
-      case 0x6n:
         return PublishDoneStatusCode.TooFarBehind
+      case 0x6n:
+        return PublishDoneStatusCode.Expired
       case 0x8n:
         return PublishDoneStatusCode.UpdateFailed
+      case 0x9n:
+        return PublishDoneStatusCode.ExcessiveLoad
       case 0x12n:
         return PublishDoneStatusCode.MalformedTrack
       default:
@@ -441,6 +444,17 @@ if (import.meta.vitest) {
       assertRegistry(requestErrorCodes(), pascalIdent(), (codepoint) => {
         try {
           return RequestErrorCode[Number(RequestErrorCode.tryFrom(codepoint))]
+        } catch {
+          return undefined
+        }
+      })
+    })
+
+    test('PublishDoneStatusCode matches publish_done_codes.json', async () => {
+      const { publishDoneCodes, assertRegistry, pascalIdent } = await fixture()
+      assertRegistry(publishDoneCodes(), pascalIdent(), (codepoint) => {
+        try {
+          return PublishDoneStatusCode[Number(PublishDoneStatusCode.tryFrom(codepoint))]
         } catch {
           return undefined
         }

--- a/libs/moqtail-ts/test/conformance.ts
+++ b/libs/moqtail-ts/test/conformance.ts
@@ -108,6 +108,7 @@ export interface PropertyTypes extends Registry {
 
 export const messageTypes = (): Registry => load<Registry>('message_types.json')
 export const requestErrorCodes = (): Registry => load<Registry>('request_error_codes.json')
+export const publishDoneCodes = (): Registry => load<Registry>('publish_done_codes.json')
 export const terminationCodes = (): Registry => load<Registry>('termination_codes.json')
 export const streamResetCodes = (): Registry => load<Registry>('stream_reset_codes.json')
 export const propertyTypes = (): PropertyTypes => load<PropertyTypes>('property_types.json')


### PR DESCRIPTION
TOO_FAR_BEHIND and EXPIRED were transposed in both implementations -- the table puts TOO_FAR_BEHIND at 0x5 and EXPIRED at 0x6 -- so each was reported to a peer as the other. EXCESSIVE_LOAD (0x9) was missing entirely, and since an unparsable status is folded into INTERNAL_ERROR rather than rejected, a peer shedding load was reported as a generic failure.

Every other code table in the enum registries is pinned by a fixture in dev/conformance/draft18; this was the one without one, which is why it drifted unnoticed. Adding publish_done_codes.json closes the gap and both suites now assert against it. Reintroducing the transposition makes the new tests fail.