### PR TITLE
fix(relay): reject a duplicate SUBSCRIBE with DUPLICATE_SUBSCRIPTION

### DIFF
--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -364,7 +364,23 @@ async fn handle_subscribe_message(
 
   let track = track_arc.read().await;
 
-  add_subscription(sub.clone(), &track, client.clone(), is_switch).await;
+  // An endpoint may hold only one subscription per track in a given role. A SWITCH is
+  // the exception: it deliberately reuses the existing subscription, and the failure
+  // here is how it hands over.
+  if !add_subscription(sub.clone(), &track, client.clone(), is_switch).await && !is_switch {
+    drop(track);
+    info!(
+      "Rejecting SUBSCRIBE from {} for {:?}: already subscribed",
+      context.connection_id, &full_track_name
+    );
+    let err = RequestError::new(
+      RequestErrorCode::DuplicateSubscription,
+      0,
+      ReasonPhrase::try_new("already subscribed to this track".to_string()).unwrap(),
+    );
+    stream_handler.send_impl(&err).await.unwrap();
+    return Ok(());
+  }
 
   let res: Result<(), TerminationCode> = if is_creator {
     // First subscriber for this track: forward Subscribe to publisher


### PR DESCRIPTION
An endpoint may hold only one subscription per track in a given role, and a second attempt must be failed. Track::add_subscription already detected the case and returned an error, the local wrapper turned it into false, and the caller dropped it on the floor -- so the subscriber was sent a SUBSCRIBE_OK for a subscription that was never created.

A SWITCH is the exception and is left alone: it deliberately reuses the existing subscription, and that same error return is how it hands over.

The rejection happens before the request is recorded in subscribe_requests, which matters more than it looks: the duplicate's stream is about to close, and the teardown path cancels by request id. Not recording it makes that teardown inert rather than something that tears down the subscription the client legitimately holds.

Verified against another implementation by having one connection subscribe twice to the same track: the second is answered "error 25 (already subscribed to this track)" -- 0x19 -- while the first stays accepted and keeps delivering, and the publisher sees no unsubscribe.