### PR TITLE
fix(relay): report the true LARGEST_OBJECT downstream

### DIFF
--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -28,6 +28,7 @@ use moqtail::model::data::full_track_name::FullTrackName;
 use moqtail::model::error::RequestErrorCode;
 use moqtail::model::error::StreamResetCode;
 use moqtail::model::error::TerminationCode;
+use moqtail::model::parameter::constant::MessageParameterType;
 use moqtail::model::parameter::message_parameter::{
   MessageParameter, MessageParameterVecExt, apply_message_parameter_update,
 };
@@ -254,6 +255,37 @@ async fn end_upstream_subscription(
   }
 }
 
+/// The larger of what the upstream publisher reported and what the relay has observed
+/// itself. `None` when neither exists, which is how "no Objects yet" is expressed: the
+/// parameter is then omitted rather than sent as `{0,0}`.
+fn merge_largest_object(
+  upstream: Option<Location>,
+  observed: Option<Location>,
+) -> Option<Location> {
+  match (upstream, observed) {
+    (Some(u), Some(o)) => Some(if o > u { o } else { u }),
+    (u, o) => u.or(o),
+  }
+}
+
+/// The LARGEST_OBJECT to advertise downstream for a track.
+///
+/// A relay reports the larger of what its upstream told it and what it has seen itself,
+/// and omits the parameter entirely when neither exists — an absent parameter means no
+/// Objects, where `{0,0}` would claim one at the start of the track. `set_param` rather
+/// than a push, because a single-valued parameter must not appear twice.
+async fn apply_largest_object(params: &mut Vec<MessageParameter>, track: &Track) {
+  let upstream = match params.get_param(MessageParameterType::LargestObject) {
+    Some(MessageParameter::LargestObject { location }) => Some(location.clone()),
+    _ => None,
+  };
+  let observed = track.largest_object().await;
+
+  if let Some(largest) = merge_largest_object(upstream, observed) {
+    params.set_param(MessageParameter::new_largest_object(largest));
+  }
+}
+
 async fn handle_subscribe_message(
   client: Arc<MOQTClient>,
   stream_handler: &mut ControlStreamHandler,
@@ -442,12 +474,8 @@ async fn handle_subscribe_message(
           client.connection_id
         );
         let cached_properties = { track.track_properties.read().await.clone() };
-        let largest_loc = {
-          let ll = track.largest_location.read().await;
-          Location::new(ll.group, ll.object)
-        };
         let mut params = subscribe_parameters;
-        params.push(MessageParameter::new_largest_object(largest_loc));
+        apply_largest_object(&mut params, &track).await;
         let subscribe_ok = moqtail::model::control::subscribe_ok::SubscribeOk::new(
           track.relay_track_id,
           params,
@@ -594,6 +622,15 @@ async fn handle_subscribe_ok_message(
     )
     .await;
 
+  // What the relay advertises downstream is not necessarily what upstream sent: by the
+  // time this runs the relay may already have seen a later Object than upstream knew of.
+  let downstream_params = {
+    let track = track_arc.read().await;
+    let mut params = msg.subscribe_parameters.clone();
+    apply_largest_object(&mut params, &track).await;
+    params
+  };
+
   // Send SubscribeOk to the FIRST subscriber (the creator)
   {
     let subscriber = {
@@ -607,7 +644,7 @@ async fn handle_subscribe_ok_message(
       };
       let subscribe_ok = moqtail::model::control::subscribe_ok::SubscribeOk::new(
         relay_track_id,
-        msg.subscribe_parameters.clone(),
+        downstream_params.clone(),
         cached_properties,
       );
       info!(
@@ -654,7 +691,7 @@ async fn handle_subscribe_ok_message(
         };
         let subscribe_ok = moqtail::model::control::subscribe_ok::SubscribeOk::new(
           relay_track_id,
-          msg.subscribe_parameters.clone(),
+          downstream_params.clone(),
           cached_properties,
         );
         info!(
@@ -1147,6 +1184,37 @@ pub async fn handle(
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn largest_object_takes_the_larger_of_the_two() {
+    let earlier = Location::new(4, 2);
+    let later = Location::new(4, 9);
+    let later_group = Location::new(5, 0);
+
+    // Whichever side is ahead wins, regardless of which side it is.
+    assert_eq!(
+      merge_largest_object(Some(earlier.clone()), Some(later.clone())),
+      Some(later.clone())
+    );
+    assert_eq!(
+      merge_largest_object(Some(later.clone()), Some(earlier.clone())),
+      Some(later.clone())
+    );
+    assert_eq!(
+      merge_largest_object(Some(later.clone()), Some(later_group.clone())),
+      Some(later_group)
+    );
+
+    // One side only.
+    assert_eq!(
+      merge_largest_object(Some(later.clone()), None),
+      Some(later.clone())
+    );
+    assert_eq!(merge_largest_object(None, Some(later.clone())), Some(later));
+
+    // Neither: the parameter is omitted, never sent as {0,0}.
+    assert_eq!(merge_largest_object(None, None), None);
+  }
 
   #[test]
   fn upstream_errors_map_to_a_publish_done_status() {


### PR DESCRIPTION
Three problems in one parameter. A subsequent subscriber was sent the upstream's parameters with another LARGEST_OBJECT appended, so if upstream had sent one the subscriber received two copies of a single-valued parameter. The appended value was read from largest_location directly rather than through largest_object(), so a track with no Objects yet advertised {0,0} -- a claim that an Object exists at the start of the track, where the parameter should simply be absent. And the fan-out to the creator and to pending subscribers forwarded the upstream value verbatim, when a relay owes the larger of what upstream reported and what it has seen itself.

All four send sites now go through one helper, and the merge is a separate function so it can be tested without building a Track. The value stored on the track by confirm() stays verbatim: that is the record of what upstream said, not what the relay advertises.

Verified against another implementation: the creator is sent no LARGEST_OBJECT at all, having joined before any Object existed, and a later subscriber is sent exactly one carrying the relay's own observation. That peer's publisher never sends the parameter upstream, so the duplicate and merge branches are covered by the unit test rather than on the wire.
