### PR TITLE
fix(relay): reset a cancelled subscription's streams

### DIFF
--- a/apps/relay/src/server/subscription.rs
+++ b/apps/relay/src/server/subscription.rs
@@ -900,14 +900,32 @@ impl Subscription {
   }
 
   /// Reset every data stream this subscription has opened with the given code.
+  /// Resets every open data stream, draining the map so `finish` does not then try to
+  /// close a stream that has already been reset.
   async fn reset_data_streams(&self, code: u64) {
     let stream_ids: Vec<StreamId> = {
-      let map = self.send_stream_last_object_ids.read().await;
-      map.keys().cloned().collect()
+      let mut map = self.send_stream_last_object_ids.write().await;
+      map.drain().map(|(stream_id, _)| stream_id).collect()
     };
     for stream_id in stream_ids {
       self.subscriber.reset_stream(&stream_id, code).await;
     }
+  }
+
+  /// Ends the subscription because the subscriber cancelled it.
+  ///
+  /// A cancelled subscription's streams are reset, not finished. A finish is a FIN,
+  /// which asks the peer to take delivery of everything already written — data the
+  /// subscriber has just said it no longer wants.
+  pub async fn cancel(&self) {
+    info!(
+      "Cancelling subscription for subscriber={} relay_track_id={}",
+      self.client_connection_id, self.relay_track_id
+    );
+    self
+      .reset_data_streams(StreamResetCode::Cancelled.to_u64())
+      .await;
+    self.finish().await;
   }
 
   async fn handle_track_event(&self, event: TrackEvent) {

--- a/apps/relay/src/server/subscription_manager.rs
+++ b/apps/relay/src/server/subscription_manager.rs
@@ -164,10 +164,11 @@ impl SubscriptionManager {
     let sub = subscriptions.remove(&subscriber_id);
     drop(subscriptions);
 
-    // find the subscription by subscriber_id and finish it
+    // find the subscription by subscriber_id and cancel it. Every caller of this
+    // reaches it because the subscriber went away, so its streams are reset.
     if let Some(subscription) = sub {
       let sub = subscription.write().await;
-      sub.finish().await;
+      sub.cancel().await;
     }
 
     // Remove and dispose the sender for this subscriber from the appropriate partition


### PR DESCRIPTION
The current implementation finishes the streams. This is wrong.

A publisher that has been told to stop must reset the streams it opened for the subscription. Finishing them sends a FIN, which asks the peer to take delivery of everything already written -- data the subscriber has just said it no longer wants -- and waits on a peer that has stopped reading.

Every path into subscription removal arrives there because the subscriber went away, so removal now cancels: reset with CANCELLED, then finish. Ending for any other reason, such as the publisher going away after a PUBLISH_DONE, still finishes gracefully.

reset_data_streams now drains the stream map rather than copying out of it, so a stream that has been reset is not then handed to finish to be closed as well. That also tightens the existing TOO_FAR_BEHIND path, which had the same overlap.

Verified against another implementation with two subscribers on one track: cancelling one resets exactly its own stream with code 1, and the other keeps receiving throughout.