### PR TITLE
fix(relay): wait for a track alias on notification, and abandon

### DIFF
--- a/apps/relay/src/server/config.rs
+++ b/apps/relay/src/server/config.rs
@@ -110,6 +110,10 @@ pub struct Cli {
   /// Timeout in seconds for upstream fetch responses
   #[arg(long, default_value_t = 10)]
   pub upstream_fetch_timeout_secs: u64,
+  /// How long a data stream waits for the control message that establishes its track
+  /// alias before the stream is abandoned
+  #[arg(long, default_value_t = 500)]
+  pub track_alias_resolution_timeout_ms: u64,
 }
 #[derive(Debug, Clone)]
 pub struct AppConfig {
@@ -136,6 +140,9 @@ pub struct AppConfig {
   pub redirect_uri: Option<String>,
   pub max_upstream_fetch_gaps: u64,
   pub upstream_fetch_timeout: Duration,
+  /// A data stream can arrive before the control message that establishes its track
+  /// alias. The stream waits this long for it, then is abandoned.
+  pub track_alias_resolution_timeout: Duration,
 }
 
 impl AppConfig {
@@ -165,6 +172,9 @@ impl AppConfig {
         redirect_uri: cli.redirect_uri,
         max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
         upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
+        track_alias_resolution_timeout: Duration::from_millis(
+          cli.track_alias_resolution_timeout_ms,
+        ),
       }
     })
   }
@@ -285,6 +295,7 @@ mod tests {
       redirect_uri: None,
       max_upstream_fetch_gaps: 10,
       upstream_fetch_timeout: Duration::from_secs(10),
+      track_alias_resolution_timeout: Duration::from_millis(500),
     }
   }
 

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -884,51 +884,27 @@ impl Session {
               }
             }
 
-            // The track might have not been added yet, wait for it for a few attempts
-            let mut attempt_count = 5;
-            let attempt_interval_ms = 100;
+            // A data stream can outrun the control message that establishes its alias,
+            // so wait briefly for it. An alias that never arrives is not a session
+            // error: the stream is abandoned and the session carries on.
             debug!("looking for track with alias: {:?}", track_alias);
-            loop {
-              if attempt_count == 0 {
-                error!("track not found after multiple attempts: {:?}", track_alias);
-                return Err(anyhow::Error::msg(TerminationCode::InternalError.to_json()));
-              }
-              let full_track_name_opt = context
-                .track_manager
-                .track_aliases
-                .read()
-                .await
-                .get(&(client.connection_id, track_alias))
-                .cloned();
-
-              if full_track_name_opt.is_none() {
-                attempt_count -= 1;
-                tokio::time::sleep(std::time::Duration::from_millis(attempt_interval_ms)).await;
-                continue;
-              }
-
-              current_track = if let Some(full_track_name) = full_track_name_opt {
-                if let Some(t) = context.track_manager.get_track(&full_track_name).await {
-                  debug!("track found: {:?}", track_alias);
-                  Some(t)
-                } else {
-                  error!(
-                    "track not found: {:?} full track name: {:?}",
-                    track_alias, &full_track_name
-                  );
-                  return Err(anyhow::Error::msg(TerminationCode::InternalError.to_json()));
-                }
-              } else {
-                None
-              };
-              break;
-            }
+            current_track = context
+              .track_manager
+              .resolve_track_by_alias(
+                client.connection_id,
+                track_alias,
+                context.server_config.track_alias_resolution_timeout,
+              )
+              .await;
 
             let relay_track_id = match current_track.as_ref() {
               Some(t) => t.read().await.relay_track_id,
               None => {
-                error!("track not found when building stream_id: {:?}", track_alias);
-                return Err(anyhow::Error::msg(TerminationCode::InternalError.to_json()));
+                warn!(
+                  "Abandoning data stream for unresolved track alias {} after {:?}",
+                  track_alias, context.server_config.track_alias_resolution_timeout
+                );
+                return Ok(());
               }
             };
             stream_id = Some(utils::build_stream_id(relay_track_id, &header_info));

--- a/apps/relay/src/server/track_manager.rs
+++ b/apps/relay/src/server/track_manager.rs
@@ -26,8 +26,11 @@ use moqtail::model::parameter::message_parameter::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use tokio::sync::Notify;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
+use tokio::time::Instant;
 use tracing::{debug, info, warn};
 
 pub type NamespacePrefix = Tuple;
@@ -65,6 +68,9 @@ pub struct TrackManager {
   pub publishes: Arc<RwLock<HashMap<FullTrackName, HashMap<usize, Publish>>>>,
   /// Counter for generating stable relay_track_id values.
   next_relay_track_id: Arc<AtomicU64>,
+  /// Fires whenever a track alias is registered, so a data stream that arrived ahead of
+  /// the control message establishing its alias can wait instead of polling.
+  alias_registered: Arc<Notify>,
 }
 
 impl TrackManager {
@@ -72,6 +78,7 @@ impl TrackManager {
     TrackManager {
       tracks: Arc::new(RwLock::new(HashMap::new())),
       track_aliases: Arc::new(RwLock::new(HashMap::new())),
+      alias_registered: Arc::new(Notify::new()),
       namespace_subscribers: Arc::new(RwLock::new(HashMap::new())),
       announcements: Arc::new(RwLock::new(HashMap::new())),
       publishes: Arc::new(RwLock::new(HashMap::new())),
@@ -282,12 +289,44 @@ impl TrackManager {
     track_alias: u64,
     full_track_name: FullTrackName,
   ) {
-    let mut track_aliases = self.track_aliases.write().await;
-    track_aliases.insert((connection_id, track_alias), full_track_name.clone());
+    {
+      let mut track_aliases = self.track_aliases.write().await;
+      track_aliases.insert((connection_id, track_alias), full_track_name.clone());
+    }
+    self.alias_registered.notify_waiters();
     info!(
       "Registered track alias {}@{} -> {:?}",
       track_alias, connection_id, full_track_name
     );
+  }
+
+  /// Resolves an alias to its track, waiting up to `timeout` for the control message
+  /// that establishes it. Data streams can outrun that message, which the specification
+  /// anticipates: a receiver may buffer briefly before abandoning the stream.
+  pub async fn resolve_track_by_alias(
+    &self,
+    connection_id: usize,
+    track_alias: u64,
+    timeout: Duration,
+  ) -> Option<Arc<RwLock<Track>>> {
+    let deadline = Instant::now() + timeout;
+    loop {
+      // Subscribe before looking, so a registration between the two is not missed.
+      let registered = self.alias_registered.notified();
+
+      let full_track_name = {
+        let aliases = self.track_aliases.read().await;
+        aliases.get(&(connection_id, track_alias)).cloned()
+      };
+      if let Some(full_track_name) = full_track_name {
+        return self.get_track(&full_track_name).await;
+      }
+
+      let remaining = deadline.saturating_duration_since(Instant::now());
+      if remaining.is_zero() || tokio::time::timeout(remaining, registered).await.is_err() {
+        return None;
+      }
+    }
   }
 
   pub async fn add_namespace_subscriber(


### PR DESCRIPTION
Wait for a track alias on notification, and abandon if the stream if it never arrives.

A data stream can outrun the control message that establishes its track alias. The relay polled for the mapping five times at 100ms and then returned an error whose message was a serialized termination code -- which the caller only logged. The session was never closed, so the code was decoration and the objects vanished with an error line.

Abandoning the stream is the right outcome and is not a session error, so that path now warns, names the alias, and returns. The wait is driven by a notification from alias registration rather than a sleep, so a stream that arrives a few milliseconds early proceeds at once instead of sitting out a 100ms tick. The notification is subscribed to before the map is read, so a registration landing between the two is not missed.

The budget is now --track-alias-resolution-timeout-ms, defaulting to 500ms, which is what the old five ticks added up to.

Verified by delaying alias registration by three seconds: at a 50ms budget exactly one stream is abandoned and the session carries on, and at 5s the same stream resolves and is delivered instead.
