### PR TITLE
chore: take wtransport from git rev d96cbb87

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,8 +1893,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 [[package]]
 name = "wtransport"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4aacf790813ee1956751491800537f4e04af7557b7b370501ccbfbc85963e4"
+source = "git+https://github.com/BiagioFesta/wtransport?rev=d96cbb87c9127fcb453fb05bbb47ef93402daec2#d96cbb87c9127fcb453fb05bbb47ef93402daec2"
 dependencies = [
  "bytes",
  "pem",
@@ -1917,8 +1916,7 @@ dependencies = [
 [[package]]
 name = "wtransport-proto"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5867c629e4252f7439d82315923daaf27f4fa442410d51b78ab93ef4c432a11"
+source = "git+https://github.com/BiagioFesta/wtransport?rev=d96cbb87c9127fcb453fb05bbb47ef93402daec2#d96cbb87c9127fcb453fb05bbb47ef93402daec2"
 dependencies = [
  "httlib-huffman",
  "octets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = ["apps/relay", "apps/client", "libs/moqtail-rs"]
 resolver = "2"
 
 [workspace.dependencies]
-wtransport = { version = "0.7.1", features = ["quinn"] }
+wtransport = { git = "https://github.com/BiagioFesta/wtransport", rev = "d96cbb87c9127fcb453fb05bbb47ef93402daec2", features = ["quinn"] }


### PR DESCRIPTION
The published 0.7.1 does not carry what the relay needs to interoperate, so the workspace pins the upstream commit instead. All three members already take the dependency through workspace inheritance, so relay, client and the library resolve to this one copy rather than being kept in step by hand.

Confirmed by cargo tree: a single wtransport in the graph. The client's dangerous-configuration feature still exists on this rev, which is the thing most likely to break when moving from a registry release to a git pin. The workspace builds and its tests pass, and a client publisher through the relay to a client subscriber delivers objects in order.

A git pin is worth revisiting once the fix reaches a release: a rev has no semver, so cargo cannot tell anyone that it moved.
