### PR TITLE
fix(relay): end a namespace announcement when its request stream ends

### DIFF
--- a/apps/client/src/cli.rs
+++ b/apps/client/src/cli.rs
@@ -147,6 +147,11 @@ pub struct Cli {
   #[arg(long)]
   pub track_alias: Option<u64>,
 
+  /// Seconds after announcing to withdraw the namespace, by resetting its request
+  /// stream while the session stays open (publish-namespace only, 0 = never).
+  #[arg(long, default_value_t = 0)]
+  pub withdraw_after: u64,
+
   /// Duration to listen in seconds, 0 = indefinite (subscribe only)
   #[arg(long, short, default_value_t = 0)]
   pub duration: u64,

--- a/apps/client/src/main.rs
+++ b/apps/client/src/main.rs
@@ -63,6 +63,7 @@ async fn main() -> Result<(), anyhow::Error> {
     Command::PublishNamespace => {
       let config = publisher::PublishNamespaceConfig {
         namespace: cli.namespace,
+        withdraw_after: cli.withdraw_after,
         delivery_mode: cli.delivery_mode,
         group_count: cli.group_count,
         interval: cli.interval,

--- a/apps/client/src/publisher.rs
+++ b/apps/client/src/publisher.rs
@@ -30,6 +30,7 @@ use moqtail::model::data::datagram::Datagram;
 use moqtail::model::data::object::Object;
 use moqtail::model::data::subgroup_header::SubgroupHeader;
 use moqtail::model::data::subgroup_object::SubgroupObject;
+use moqtail::model::error::StreamResetCode;
 use moqtail::model::parameter::message_parameter::MessageParameter;
 use moqtail::model::property::object_property::ObjectProperty;
 use moqtail::transport::connection::TransportConnection;
@@ -56,6 +57,7 @@ pub struct PublishConfig {
 
 pub struct PublishNamespaceConfig {
   pub namespace: String,
+  pub withdraw_after: u64,
   pub delivery_mode: DeliveryMode,
   pub group_count: u64,
   pub interval: u64,
@@ -72,8 +74,22 @@ pub async fn run_namespace(moq: MoqConnection, config: PublishNamespaceConfig) -
 
   let ns = Tuple::from_utf8_path(&config.namespace);
 
-  // Step 1: Announce namespace on its own request stream (kept open below).
-  let _namespace_stream = publish_namespace(&connection, &ns).await?;
+  // Step 1: Announce namespace on its own request stream. The namespace is published
+  // for exactly as long as that stream is open, so a publisher withdraws by resetting
+  // it -- and keeps the announcement by simply holding it.
+  let namespace_stream = publish_namespace(&connection, &ns).await?;
+  let _namespace_stream = if config.withdraw_after > 0 {
+    let after = config.withdraw_after;
+    let namespace = config.namespace.clone();
+    tokio::spawn(async move {
+      tokio::time::sleep(Duration::from_secs(after)).await;
+      info!("Withdrawing namespace '{namespace}' after {after}s; session stays open");
+      namespace_stream.reset_and_stop(StreamResetCode::Cancelled.to_u64());
+    });
+    None
+  } else {
+    Some(namespace_stream)
+  };
 
   let data_config = DataConfig {
     delivery_mode: config.delivery_mode,

--- a/apps/relay/src/server/client.rs
+++ b/apps/relay/src/server/client.rs
@@ -198,6 +198,12 @@ impl MOQTClient {
     announced_track_namespaces.push(track_namespace);
   }
 
+  /// Leaving a withdrawn namespace here would keep routing subscriptions to this client.
+  pub(crate) async fn remove_announced_track_namespace(&self, track_namespace: &Tuple) {
+    let mut announced_track_namespaces = self.announced_track_namespaces.write().await;
+    announced_track_namespaces.retain(|ns| ns != track_namespace);
+  }
+
   pub(crate) async fn add_subscriber(&self, subscriber_id: usize) {
     let mut subscribers = self.subscribers.write().await;
     subscribers.push(subscriber_id);

--- a/apps/relay/src/server/message_handlers/mod.rs
+++ b/apps/relay/src/server/message_handlers/mod.rs
@@ -30,7 +30,7 @@ use crate::server::{
 use std::sync::Arc;
 pub(crate) mod fetch_handler;
 mod publish_handler;
-mod publish_namespace_handler;
+pub(crate) mod publish_namespace_handler;
 pub(crate) mod subscribe_handler;
 pub(crate) mod subscribe_namespace_handler;
 pub(crate) mod subscribe_tracks_handler;

--- a/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
@@ -17,7 +17,9 @@ use crate::server::session_context::{PendingRequest, SessionContext};
 use crate::server::track_manager::SubscribeKind;
 use core::result::Result;
 use moqtail::model::common::reason_phrase::ReasonPhrase;
+use moqtail::model::common::tuple::Tuple;
 use moqtail::model::control::namespace::Namespace;
+use moqtail::model::control::namespace_done::NamespaceDone;
 use moqtail::model::control::request_error::RequestError;
 use moqtail::model::control::{control_message::ControlMessage, request_ok::RequestOk};
 use moqtail::model::error::{RequestErrorCode, StreamResetCode, TerminationCode};
@@ -25,6 +27,69 @@ use moqtail::model::parameter::message_parameter::apply_message_parameter_update
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use std::sync::Arc;
 use tracing::{info, warn};
+
+/// Sends one message per matching discovery subscriber, naming the namespace by the
+/// suffix that subscriber's own prefix leaves. The announcer is skipped so it is never
+/// told about its own namespace.
+pub(crate) async fn announce_to_namespace_subscribers(
+  context: &Arc<SessionContext>,
+  namespace: &Tuple,
+  announcer_connection_id: usize,
+  message_for: impl Fn(Tuple) -> ControlMessage,
+) {
+  let subs_map = context.track_manager.namespace_subscribers.read().await;
+  for (prefix, subscribers) in subs_map.iter() {
+    if !namespace.starts_with(prefix) {
+      continue;
+    }
+    let Some(suffix) = namespace.suffix(prefix) else {
+      continue;
+    };
+    for (sub, kind, _params, namespace_tx) in subscribers {
+      if *kind != SubscribeKind::Namespace || sub.connection_id == announcer_connection_id {
+        continue;
+      }
+      info!(
+        "Forwarding namespace suffix {:?} to subscriber {}",
+        suffix, sub.connection_id
+      );
+      let _ = namespace_tx.send(message_for(suffix.clone()));
+    }
+  }
+}
+
+/// A namespace is announced for as long as its request stream is open, so closing that
+/// stream withdraws it. Everything that named the publisher for this namespace is
+/// dropped, and the subscribers that heard the announcement are told it is over.
+pub async fn cancel(client: Arc<MOQTClient>, request_id: u64, context: &Arc<SessionContext>) {
+  let namespace = {
+    let mut map = client.inbound_requests.write().await;
+    match map.remove(&request_id) {
+      Some(PendingRequest::PublishNamespace { message, .. }) => Some(message.track_namespace),
+      _ => None,
+    }
+  };
+  let Some(namespace) = namespace else {
+    return;
+  };
+
+  client.remove_announced_track_namespace(&namespace).await;
+
+  // A publisher whose announcement was already replaced by another's has nothing to
+  // withdraw, and must not send a NAMESPACE_DONE for a namespace that is still served.
+  if !context
+    .track_manager
+    .remove_announcement(&namespace, client.connection_id)
+    .await
+  {
+    return;
+  }
+
+  announce_to_namespace_subscribers(context, &namespace, client.connection_id, |s| {
+    ControlMessage::NamespaceDone(Box::new(NamespaceDone::new(s)))
+  })
+  .await;
+}
 
 pub async fn handle(
   client: Arc<MOQTClient>,
@@ -64,7 +129,8 @@ pub async fn handle(
         .add_announcement(m.track_namespace.clone(), client.clone(), (*m).clone())
         .await;
 
-      // Track in inbound_requests so a REQUEST_UPDATE on this request's stream can find it
+      // Track in inbound_requests so a REQUEST_UPDATE on this request's stream can find it,
+      // and so closing that stream can find the namespace to withdraw.
       {
         let mut map = client.inbound_requests.write().await;
         map.insert(
@@ -76,35 +142,11 @@ pub async fn handle(
           },
         );
       }
-      // TODO: Remove this request_id when a PUBLISH_NAMESPACE_DONE is received for this namespace.
 
-      // Forward the announcement to namespace subscribers via their bi-stream channels
-      {
-        let subs_map = context.track_manager.namespace_subscribers.read().await;
-        for (prefix, subscribers) in subs_map.iter() {
-          if m.track_namespace.starts_with(prefix) {
-            for (sub, kind, _params, namespace_tx) in subscribers {
-              // NAMESPACE advertisements go to discovery (SUBSCRIBE_NAMESPACE) subscribers.
-              if *kind != SubscribeKind::Namespace {
-                continue;
-              }
-              // Don't echo back to announcer
-              if sub.connection_id == client.connection_id {
-                continue;
-              }
-
-              if let Some(suffix) = m.track_namespace.suffix(prefix) {
-                info!(
-                  "Forwarding NAMESPACE suffix {:?} to subscriber {}",
-                  suffix, sub.connection_id
-                );
-                let ns_msg = ControlMessage::Namespace(Box::new(Namespace::new(suffix)));
-                let _ = namespace_tx.send(ns_msg);
-              }
-            }
-          }
-        }
-      }
+      announce_to_namespace_subscribers(&context, &m.track_namespace, client.connection_id, |s| {
+        ControlMessage::Namespace(Box::new(Namespace::new(s)))
+      })
+      .await;
 
       let request_ok = Box::new(RequestOk::new(vec![]));
 

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -18,6 +18,7 @@ use moqtail::model::{
   control::{
     constant::SUPPORTED_VERSIONS,
     control_message::ControlMessage,
+    namespace_done::NamespaceDone,
     request_error::RequestError,
     setup::{Setup, SetupSender},
   },
@@ -54,6 +55,7 @@ use super::{
 enum RequestStreamKind {
   Subscribe,
   Fetch,
+  PublishNamespace,
   Other,
 }
 
@@ -630,6 +632,7 @@ impl Session {
         let request_kind = match &first {
           ControlMessage::Subscribe(_) => RequestStreamKind::Subscribe,
           ControlMessage::Fetch(_) => RequestStreamKind::Fetch,
+          ControlMessage::PublishNamespace(_) => RequestStreamKind::PublishNamespace,
           _ => RequestStreamKind::Other,
         };
 
@@ -698,6 +701,14 @@ impl Session {
                     RequestStreamKind::Fetch => {
                       message_handlers::fetch_handler::cancel_fetch(client.clone(), request_id)
                         .await;
+                    }
+                    RequestStreamKind::PublishNamespace => {
+                      message_handlers::publish_namespace_handler::cancel(
+                        client.clone(),
+                        request_id,
+                        &context,
+                      )
+                      .await;
                     }
                     RequestStreamKind::Other => {}
                   }
@@ -774,10 +785,21 @@ impl Session {
       );
     }
 
-    // Remove announcements for the disconnecting publisher
-    track_manager_cleanup
+    // Remove announcements for the disconnecting publisher. Losing the publisher ends
+    // its namespaces just as closing the request stream would, so subscribers are told
+    // the same way.
+    let withdrawn = track_manager_cleanup
       .remove_announcements_by_connection(context.connection_id)
       .await;
+    for namespace in &withdrawn {
+      message_handlers::publish_namespace_handler::announce_to_namespace_subscribers(
+        &context,
+        namespace,
+        context.connection_id,
+        |s| ControlMessage::NamespaceDone(Box::new(NamespaceDone::new(s))),
+      )
+      .await;
+    }
 
     // Remove the disconnecting client from namespace_subscribers
     track_manager_cleanup

--- a/apps/relay/src/server/track_manager.rs
+++ b/apps/relay/src/server/track_manager.rs
@@ -403,19 +403,39 @@ impl TrackManager {
     info!("Stored announcement for namespace: {:?}", namespace);
   }
 
-  pub async fn remove_announcements_by_connection(&self, connection_id: usize) {
+  /// Drops the announcement only if this connection is the one that made it.
+  pub async fn remove_announcement(&self, namespace: &Tuple, connection_id: usize) -> bool {
     let mut announcements = self.announcements.write().await;
+    match announcements.get(namespace) {
+      Some((client, _message)) if client.connection_id == connection_id => {
+        announcements.remove(namespace);
+        info!(
+          "Removed announcement for namespace {:?} (publisher {})",
+          namespace, connection_id
+        );
+        true
+      }
+      _ => false,
+    }
+  }
+
+  /// Returns what it removed, so the caller can tell the subscribers that heard about them.
+  pub async fn remove_announcements_by_connection(&self, connection_id: usize) -> Vec<Tuple> {
+    let mut announcements = self.announcements.write().await;
+    let mut removed = Vec::new();
     announcements.retain(|ns, (client, _message)| {
       if client.connection_id == connection_id {
         info!(
           "Removed announcement for namespace {:?} (publisher {} disconnected)",
           ns, connection_id
         );
+        removed.push(ns.clone());
         false
       } else {
         true
       }
     });
+    removed
   }
 
   pub async fn remove_namespace_subscriber(&self, connection_id: usize) {


### PR DESCRIPTION
An announcement lived until the publisher's whole connection died. Closing just the PUBLISH_NAMESPACE stream left the relay still advertising the namespace, still routing subscriptions to that publisher, and still holding the request in the client's map -- the leak the TODO there described.

Closing that stream now withdraws the announcement, which is the same cleanup the other request kinds already run on stream close.

Subscribers were never told either way. A discovery subscriber that had been sent a NAMESPACE got nothing when the namespace stopped being served, so its view only ever grew. Both endings -- the stream closing and the publisher disconnecting -- now fan out NAMESPACE_DONE to the subscribers that heard the announcement, sharing one fan-out with the announcement path so the two cannot drift on which subscribers match.

Removal is guarded on the announcing connection. The map holds one publisher per namespace, so a publisher whose announcement had already been replaced would otherwise withdraw someone else's on its way out, and report a namespace done that is still being served.
