### PR TITLE
fix(relay): build the relay's own parameters instead of forwarding them

### DIFF
--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::server::client::MOQTClient;
+use crate::server::message_handlers::parameters;
 use crate::server::session_context::{PendingRequest, SessionContext, UpstreamFetchEvent};
 use crate::server::stream_id::StreamId;
 use crate::server::utils::build_stream_id;
@@ -490,15 +491,9 @@ pub async fn handle(
             upstream_gap_count += 1;
 
             // Issue upstream fetch for the gap
-            let upstream_rx = send_upstream_fetch_for_range(
-              &client,
-              &context,
-              &track_read,
-              &fetch,
-              gap_start,
-              gap_end,
-            )
-            .await;
+            let upstream_rx =
+              send_upstream_fetch_for_range(&client, &context, &track_read, gap_start, gap_end)
+                .await;
 
             if let Some((relay_request_id, upstream_publisher, mut rx)) = upstream_rx {
               let timeout = context.server_config.upstream_fetch_timeout;
@@ -754,7 +749,6 @@ async fn send_upstream_fetch_for_range(
   client: &Arc<MOQTClient>,
   context: &Arc<SessionContext>,
   track_read: &crate::server::track::Track,
-  original_fetch: &Fetch,
   gap_start: u64,
   gap_end: u64,
 ) -> Option<(u64, Arc<MOQTClient>, mpsc::Receiver<UpstreamFetchEvent>)> {
@@ -796,7 +790,7 @@ async fn send_upstream_fetch_for_range(
   let upstream_fetch = Fetch::new_standalone(
     relay_request_id,
     standalone_props,
-    original_fetch.parameters.clone(),
+    parameters::upstream_fetch(),
   );
 
   let (upstream_tx, upstream_rx) = mpsc::channel(UPSTREAM_FETCH_CHANNEL_CAPACITY);

--- a/apps/relay/src/server/message_handlers/mod.rs
+++ b/apps/relay/src/server/message_handlers/mod.rs
@@ -29,6 +29,7 @@ use crate::server::{
 };
 use std::sync::Arc;
 pub(crate) mod fetch_handler;
+pub(crate) mod parameters;
 mod publish_handler;
 pub(crate) mod publish_namespace_handler;
 pub(crate) mod subscribe_handler;

--- a/apps/relay/src/server/message_handlers/parameters.rs
+++ b/apps/relay/src/server/message_handlers/parameters.rs
@@ -1,0 +1,267 @@
+// Copyright 2026 The MOQtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The parameters the relay puts in the messages it originates.
+//!
+//! A Message Parameter addresses the peer on one hop. A relay is an endpoint on two,
+//! so it re-originates rather than forwards: every message it sends carries a list it
+//! built, which may take a received value into account but never carries one across
+//! unread. The functions here are that decision, in one place, so a new message type
+//! has to state what it means rather than inherit whatever arrived.
+//!
+//! Passing a received list along is not merely untidy. An AUTHORIZATION_TOKEN alias is
+//! scoped to the session it was registered on, and the two endpoints of a session have
+//! separate alias spaces, so an alias copied to another hop names nothing there — and
+//! two subscribers who each register alias 1, both legally, would collide on the
+//! relay's upstream session.
+
+use moqtail::model::common::location::Location;
+use moqtail::model::control::constant::{FilterType, GroupOrder};
+use moqtail::model::parameter::constant::MessageParameterType;
+use moqtail::model::parameter::message_parameter::MessageParameter;
+
+/// The ergonomic lookup lives on `Vec`, but everything here reads a borrowed list.
+fn find(
+  params: &[MessageParameter],
+  param_type: MessageParameterType,
+) -> Option<&MessageParameter> {
+  params.iter().find(|p| p.type_value() == param_type as u64)
+}
+
+/// The relay's SUBSCRIBE to an upstream publisher.
+///
+/// Deliberately not derived from the subscriber's SUBSCRIBE. One upstream subscription
+/// serves every current and future subscriber, so adopting the filter, priority or
+/// order that one of them happened to ask for would let the first subscriber decide
+/// what the rest can be served. Each of those is applied per subscriber on the way out
+/// instead, where it belongs.
+///
+/// The filter is stated rather than omitted. An omitted filter means unfiltered, which
+/// starts at `{0,0}` — a demand for the track's entire history, which is not what a
+/// relay joining a live track wants and not what it would do with the result. Largest
+/// Object starts it at the present; earlier Objects reach a subscriber through FETCH,
+/// which has its own upstream path.
+pub fn upstream_subscribe() -> Vec<MessageParameter> {
+  vec![
+    MessageParameter::new_forward(true),
+    MessageParameter::new_group_order(GroupOrder::Ascending),
+    MessageParameter::new_subscription_filter(FilterType::LatestObject, None, None),
+  ]
+}
+
+/// The relay's SUBSCRIBE_OK to a subscriber, given what the upstream publisher said.
+///
+/// LARGEST_OBJECT is the only parameter that survives the hop, and only as an input:
+/// the relay reports the larger of what upstream told it and what it has since seen,
+/// and omits it when there is neither, because an absent parameter means no Objects
+/// where `{0,0}` would claim one. EXPIRES is dropped rather than relayed — it states
+/// when *the sender* will end the subscription, and the relay makes no such promise on
+/// its own behalf.
+pub fn downstream_subscribe_ok(
+  upstream: &[MessageParameter],
+  observed: Option<Location>,
+) -> Vec<MessageParameter> {
+  match largest_object(upstream, observed) {
+    Some(largest) => vec![MessageParameter::new_largest_object(largest)],
+    None => Vec::new(),
+  }
+}
+
+/// The relay's PUBLISH to a subscriber, given the upstream PUBLISH being passed on and
+/// the SUBSCRIBE_TRACKS that asked for it.
+///
+/// FORWARD comes from that SUBSCRIBE_TRACKS, not from the publisher: a subscriber that
+/// asked for tracks without forwarding must be offered them the same way. Absent or 1
+/// there means forwarding, so only an explicit 0 turns it off.
+pub fn downstream_publish(
+  upstream: &[MessageParameter],
+  subscribe_tracks: &[MessageParameter],
+  observed: Option<Location>,
+) -> Vec<MessageParameter> {
+  let forward = matches!(
+    find(subscribe_tracks, MessageParameterType::Forward),
+    None | Some(MessageParameter::Forward { forward: true })
+  );
+
+  let mut params = vec![MessageParameter::new_forward(forward)];
+  if let Some(largest) = largest_object(upstream, observed) {
+    params.push(MessageParameter::new_largest_object(largest));
+  }
+  params
+}
+
+/// The relay's FETCH to an upstream publisher, filling a gap it cannot serve itself.
+///
+/// The range is what the relay is missing and travels in the message body; nothing the
+/// downstream FETCH carried as a parameter describes it.
+pub fn upstream_fetch() -> Vec<MessageParameter> {
+  vec![MessageParameter::new_group_order(GroupOrder::Ascending)]
+}
+
+/// The larger of what an upstream told the relay and what the relay has seen itself.
+fn largest_object(upstream: &[MessageParameter], observed: Option<Location>) -> Option<Location> {
+  let reported = match find(upstream, MessageParameterType::LargestObject) {
+    Some(MessageParameter::LargestObject { location }) => Some(location.clone()),
+    _ => None,
+  };
+
+  match (reported, observed) {
+    (Some(u), Some(o)) => Some(if o > u { o } else { u }),
+    (u, o) => u.or(o),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use moqtail::model::parameter::authorization_token::AuthorizationToken;
+  use moqtail::model::parameter::message_parameter::MessageParameterVecExt;
+
+  fn loc(group: u64, object: u64) -> Location {
+    Location::new(group, object)
+  }
+
+  fn token() -> MessageParameter {
+    MessageParameter::new_authorization_token(AuthorizationToken::new_use_alias(1))
+  }
+
+  #[test]
+  fn an_upstream_subscribe_starts_at_the_present_and_forwards() {
+    let params = upstream_subscribe();
+    assert!(matches!(
+      params.get_param(MessageParameterType::Forward),
+      Some(MessageParameter::Forward { forward: true })
+    ));
+    // Stated, not omitted: omitted would ask for the track from {0,0}.
+    assert!(matches!(
+      params.get_param(MessageParameterType::SubscriptionFilter),
+      Some(MessageParameter::SubscriptionFilter {
+        filter_type: FilterType::LatestObject,
+        ..
+      })
+    ));
+    assert!(
+      params
+        .get_param(MessageParameterType::AuthorizationToken)
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn largest_object_takes_the_larger_of_the_two() {
+    let earlier = loc(4, 2);
+    let later = loc(4, 9);
+    let later_group = loc(5, 0);
+
+    let reported = |l: &Location| vec![MessageParameter::new_largest_object(l.clone())];
+
+    // Whichever side is ahead wins, regardless of which side it is on.
+    assert_eq!(
+      largest_object(&reported(&earlier), Some(later.clone())),
+      Some(later.clone())
+    );
+    assert_eq!(
+      largest_object(&reported(&later), Some(earlier.clone())),
+      Some(later.clone())
+    );
+    // A later group beats a later object within an earlier group.
+    assert_eq!(
+      largest_object(&reported(&later), Some(later_group.clone())),
+      Some(later_group)
+    );
+
+    // One side only.
+    assert_eq!(largest_object(&reported(&later), None), Some(later.clone()));
+    assert_eq!(largest_object(&[], Some(later.clone())), Some(later));
+
+    // Neither: the parameter is omitted, never sent as {0,0}.
+    assert_eq!(largest_object(&[], None), None);
+  }
+
+  #[test]
+  fn a_subscribe_ok_reports_the_larger_of_the_two() {
+    let upstream = vec![MessageParameter::new_largest_object(loc(4, 1))];
+    let params = downstream_subscribe_ok(&upstream, Some(loc(7, 0)));
+    assert_eq!(
+      params.get_param(MessageParameterType::LargestObject),
+      Some(&MessageParameter::new_largest_object(loc(7, 0)))
+    );
+  }
+
+  #[test]
+  fn a_subscribe_ok_keeps_the_upstream_value_when_it_is_ahead() {
+    let upstream = vec![MessageParameter::new_largest_object(loc(9, 2))];
+    let params = downstream_subscribe_ok(&upstream, Some(loc(3, 0)));
+    assert_eq!(
+      params.get_param(MessageParameterType::LargestObject),
+      Some(&MessageParameter::new_largest_object(loc(9, 2)))
+    );
+  }
+
+  #[test]
+  fn a_subscribe_ok_with_no_objects_anywhere_carries_nothing() {
+    assert!(downstream_subscribe_ok(&[], None).is_empty());
+  }
+
+  #[test]
+  fn a_subscribe_ok_drops_what_the_upstream_addressed_to_us() {
+    let upstream = vec![
+      token(),
+      MessageParameter::new_expires(30_000),
+      MessageParameter::new_largest_object(loc(1, 0)),
+    ];
+    let params = downstream_subscribe_ok(&upstream, None);
+    assert_eq!(params.len(), 1);
+    assert!(
+      params
+        .get_param(MessageParameterType::AuthorizationToken)
+        .is_none()
+    );
+    assert!(params.get_param(MessageParameterType::Expires).is_none());
+  }
+
+  #[test]
+  fn a_pushed_publish_takes_forwarding_from_the_request_that_asked_for_it() {
+    let upstream = vec![token(), MessageParameter::new_forward(true)];
+
+    let off = downstream_publish(&upstream, &[MessageParameter::new_forward(false)], None);
+    assert!(matches!(
+      off.get_param(MessageParameterType::Forward),
+      Some(MessageParameter::Forward { forward: false })
+    ));
+
+    // Omitted in SUBSCRIBE_TRACKS means forwarding, the same as an explicit 1.
+    let on = downstream_publish(&upstream, &[], None);
+    assert!(matches!(
+      on.get_param(MessageParameterType::Forward),
+      Some(MessageParameter::Forward { forward: true })
+    ));
+
+    assert!(
+      off
+        .get_param(MessageParameterType::AuthorizationToken)
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn a_pushed_publish_reports_the_track_position() {
+    let upstream = vec![MessageParameter::new_largest_object(loc(2, 5))];
+    let params = downstream_publish(&upstream, &[], Some(loc(2, 9)));
+    assert_eq!(
+      params.get_param(MessageParameterType::LargestObject),
+      Some(&MessageParameter::new_largest_object(loc(2, 9)))
+    );
+  }
+}

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::server::client::MOQTClient;
+use crate::server::message_handlers::parameters;
 use crate::server::session::Session;
 use crate::server::session_context::PendingRequest;
 use crate::server::session_context::SessionContext;
@@ -138,7 +139,7 @@ pub async fn handle(
           full_track_name.clone(),
           context.server_config,
           TrackStatus::Confirmed {
-            subscribe_parameters: vec![],
+            upstream_parameters: vec![],
           },
           TrackOrigin::Publish,
         );
@@ -194,7 +195,7 @@ pub async fn handle(
           );
         }
 
-        for subscriber in subscribers {
+        for (subscriber, subscribe_tracks_params) in subscribers {
           // Never push a track back to its own publisher, and let an explicit
           // SUBSCRIBE take precedence over SUBSCRIBE_TRACKS for the same track.
           if subscriber.connection_id == context.connection_id
@@ -222,6 +223,11 @@ pub async fn handle(
 
           m_clone.request_id = relay_req_id;
           m_clone.track_alias = relay_track_id;
+          m_clone.parameters = parameters::downstream_publish(
+            &m.parameters,
+            &subscribe_tracks_params,
+            track_arc.read().await.largest_object().await,
+          );
 
           // Register the message in unified map for response tracking
           {

--- a/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
@@ -195,7 +195,7 @@ pub async fn handle(
         .get_namespace_subscribers(&target_namespace, SubscribeKind::Namespace)
         .await;
 
-      for session in downstream_sessions {
+      for (session, _) in downstream_sessions {
         if let Some(downstream_req_id) = session.get_outbound_announce_id(&target_namespace).await {
           let relay_update_id = crate::server::session::Session::get_next_relay_request_id(
             context.relay_next_request_id.clone(),

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -14,11 +14,11 @@
 
 use crate::server::client::MOQTClient;
 use crate::server::client::switch_context::SwitchStatus;
+use crate::server::message_handlers::parameters;
 use crate::server::session::Session;
 use crate::server::session_context::{PendingRequest, SessionContext};
 use crate::server::track::{Track, TrackOrigin, TrackStatus};
 use core::result::Result;
-use moqtail::model::common::location::Location;
 use moqtail::model::control::constant::PublishDoneStatusCode;
 use moqtail::model::control::publish_done::PublishDone;
 use moqtail::model::control::request_error::RequestError;
@@ -28,7 +28,6 @@ use moqtail::model::data::full_track_name::FullTrackName;
 use moqtail::model::error::RequestErrorCode;
 use moqtail::model::error::StreamResetCode;
 use moqtail::model::error::TerminationCode;
-use moqtail::model::parameter::constant::MessageParameterType;
 use moqtail::model::parameter::message_parameter::{
   MessageParameter, MessageParameterVecExt, apply_message_parameter_update,
 };
@@ -255,37 +254,6 @@ async fn end_upstream_subscription(
   }
 }
 
-/// The larger of what the upstream publisher reported and what the relay has observed
-/// itself. `None` when neither exists, which is how "no Objects yet" is expressed: the
-/// parameter is then omitted rather than sent as `{0,0}`.
-fn merge_largest_object(
-  upstream: Option<Location>,
-  observed: Option<Location>,
-) -> Option<Location> {
-  match (upstream, observed) {
-    (Some(u), Some(o)) => Some(if o > u { o } else { u }),
-    (u, o) => u.or(o),
-  }
-}
-
-/// The LARGEST_OBJECT to advertise downstream for a track.
-///
-/// A relay reports the larger of what its upstream told it and what it has seen itself,
-/// and omits the parameter entirely when neither exists — an absent parameter means no
-/// Objects, where `{0,0}` would claim one at the start of the track. `set_param` rather
-/// than a push, because a single-valued parameter must not appear twice.
-async fn apply_largest_object(params: &mut Vec<MessageParameter>, track: &Track) {
-  let upstream = match params.get_param(MessageParameterType::LargestObject) {
-    Some(MessageParameter::LargestObject { location }) => Some(location.clone()),
-    _ => None,
-  };
-  let observed = track.largest_object().await;
-
-  if let Some(largest) = merge_largest_object(upstream, observed) {
-    params.set_param(MessageParameter::new_largest_object(largest));
-  }
-}
-
 async fn handle_subscribe_message(
   client: Arc<MOQTClient>,
   stream_handler: &mut ControlStreamHandler,
@@ -422,13 +390,7 @@ async fn handle_subscribe_message(
     );
 
     let mut new_sub = sub.clone();
-    // Ensure forward=true in parameters
-    new_sub
-      .subscribe_parameters
-      .retain(|p| !matches!(p, MessageParameter::Forward { .. }));
-    new_sub
-      .subscribe_parameters
-      .push(MessageParameter::new_forward(true));
+    new_sub.subscribe_parameters = parameters::upstream_subscribe();
     new_sub.request_id =
       Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
 
@@ -467,15 +429,15 @@ async fn handle_subscribe_message(
 
     match status {
       TrackStatus::Confirmed {
-        subscribe_parameters,
+        upstream_parameters,
       } => {
         info!(
           "Track confirmed, sending SubscribeOk to subscriber {}",
           client.connection_id
         );
         let cached_properties = { track.track_properties.read().await.clone() };
-        let mut params = subscribe_parameters;
-        apply_largest_object(&mut params, &track).await;
+        let params =
+          parameters::downstream_subscribe_ok(&upstream_parameters, track.largest_object().await);
         let subscribe_ok = moqtail::model::control::subscribe_ok::SubscribeOk::new(
           track.relay_track_id,
           params,
@@ -622,13 +584,11 @@ async fn handle_subscribe_ok_message(
     )
     .await;
 
-  // What the relay advertises downstream is not necessarily what upstream sent: by the
-  // time this runs the relay may already have seen a later Object than upstream knew of.
+  // What the relay advertises downstream is not what upstream sent: by the time this
+  // runs the relay may already have seen a later Object than upstream knew of.
   let downstream_params = {
     let track = track_arc.read().await;
-    let mut params = msg.subscribe_parameters.clone();
-    apply_largest_object(&mut params, &track).await;
-    params
+    parameters::downstream_subscribe_ok(&msg.subscribe_parameters, track.largest_object().await)
   };
 
   // Send SubscribeOk to the FIRST subscriber (the creator)
@@ -1184,37 +1144,6 @@ pub async fn handle(
 #[cfg(test)]
 mod tests {
   use super::*;
-
-  #[test]
-  fn largest_object_takes_the_larger_of_the_two() {
-    let earlier = Location::new(4, 2);
-    let later = Location::new(4, 9);
-    let later_group = Location::new(5, 0);
-
-    // Whichever side is ahead wins, regardless of which side it is.
-    assert_eq!(
-      merge_largest_object(Some(earlier.clone()), Some(later.clone())),
-      Some(later.clone())
-    );
-    assert_eq!(
-      merge_largest_object(Some(later.clone()), Some(earlier.clone())),
-      Some(later.clone())
-    );
-    assert_eq!(
-      merge_largest_object(Some(later.clone()), Some(later_group.clone())),
-      Some(later_group)
-    );
-
-    // One side only.
-    assert_eq!(
-      merge_largest_object(Some(later.clone()), None),
-      Some(later.clone())
-    );
-    assert_eq!(merge_largest_object(None, Some(later.clone())), Some(later));
-
-    // Neither: the parameter is omitted, never sent as {0,0}.
-    assert_eq!(merge_largest_object(None, None), None);
-  }
 
   #[test]
   fn upstream_errors_map_to_a_publish_done_status() {

--- a/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::server::client::MOQTClient;
+use crate::server::message_handlers::parameters;
 use crate::server::message_handlers::subscribe_namespace_handler::{
   MAX_NAMESPACE_PREFIX_FIELDS, oversized_namespace_error,
 };
@@ -164,6 +165,11 @@ pub async fn handle_subscribe_tracks(
         Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
       original_publish_message.request_id = relay_publish_id;
       original_publish_message.track_alias = relay_track_id;
+      original_publish_message.parameters = parameters::downstream_publish(
+        &original_publish_message.parameters,
+        &sub_tracks.parameters,
+        track_arc.read().await.largest_object().await,
+      );
 
       {
         let mut map = context.relay_pending_requests.write().await;

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -56,9 +56,11 @@ pub enum TrackOrigin {
 pub enum TrackStatus {
   /// Track created, subscribe forwarded to publisher, awaiting response.
   Pending,
-  /// Publisher confirmed with SubscribeOk.
+  /// Publisher confirmed with SubscribeOk, with the parameters it sent. They were
+  /// addressed to the relay, so they are what a later SUBSCRIBE_OK is derived from,
+  /// never what it forwards.
   Confirmed {
-    subscribe_parameters: Vec<MessageParameter>,
+    upstream_parameters: Vec<MessageParameter>,
   },
   /// Publisher rejected with RequestError.
   Rejected {
@@ -283,7 +285,7 @@ impl Track {
     &mut self,
     publisher_connection_id: usize,
     publisher_track_alias: u64,
-    subscribe_parameters: Vec<MessageParameter>,
+    upstream_parameters: Vec<MessageParameter>,
     properties: Vec<TrackProperty>,
   ) {
     {
@@ -292,7 +294,7 @@ impl Track {
     }
     let mut status = self.status.write().await;
     *status = TrackStatus::Confirmed {
-      subscribe_parameters,
+      upstream_parameters,
     };
     drop(status);
     *self.track_properties.write().await = properties;

--- a/apps/relay/src/server/track_manager.rs
+++ b/apps/relay/src/server/track_manager.rs
@@ -357,7 +357,7 @@ impl TrackManager {
     &self,
     target_namespace: &Tuple,
     kind: SubscribeKind,
-  ) -> Vec<Arc<MOQTClient>> {
+  ) -> Vec<(Arc<MOQTClient>, Vec<MessageParameter>)> {
     let subs = self.namespace_subscribers.read().await;
     let mut interested_clients = Vec::new();
 
@@ -365,9 +365,11 @@ impl TrackManager {
     // Example: Target "meet.room1", Prefix "meet" -> Match.
     for (prefix, clients) in subs.iter() {
       if target_namespace.starts_with(prefix) {
-        for (client, k, _params, _tx) in clients {
+        for (client, k, params, _tx) in clients {
           if *k == kind {
-            interested_clients.push(client.clone());
+            // The parameters come along: what the relay sends a subscriber is derived
+            // from the request that asked for it, not from the publisher upstream.
+            interested_clients.push((client.clone(), params.clone()));
           }
         }
       }


### PR DESCRIPTION
Message Parameters address the peer on one hop. The relay is an endpoint on two, and it was building the messages it originates by cloning the list it had received and rewriting a field or two.

The worst of that is credentials. An AUTHORIZATION_TOKEN alias is scoped to the session it was registered on, and the two ends of a session have separate alias spaces, so an alias copied to another hop names nothing there -- and two subscribers who each register alias 1, both legally, collide on the relay's upstream session. Verified against a second implementation: a subscriber's token was reaching the publisher verbatim, and no longer does. The push direction was handing the publisher's own token to every subscriber.

It also produced messages a peer must reject. Only LARGEST_OBJECT and EXPIRES may appear in a SUBSCRIBE_OK, so anything else an upstream sent was forwarded into a message the subscriber must close the session over, blaming the relay.

Each originated message now states what it means, in one module:

- The upstream SUBSCRIBE stops inheriting the first subscriber's request. One subscription serves every subscriber, so adopting one of their filters lets whoever arrives first decide what the rest can be served; filter, priority and order are applied per subscriber on the way out. The filter is stated rather than omitted, because an omitted filter means unfiltered, which starts at {0,0} -- a demand for the whole history that a relay joining a live track neither wants nor uses. Earlier Objects reach a subscriber through FETCH, which has its own upstream path.
- SUBSCRIBE_OK carries only the merged LARGEST_OBJECT. EXPIRES is dropped: it says when the sender will end the subscription, and the relay promises nothing on the upstream's behalf.
- A pushed PUBLISH takes FORWARD from the SUBSCRIBE_TRACKS that asked for it rather than from the publisher, so a subscriber that asked for tracks without forwarding is offered them that way.

The track keeps the upstream's parameters rather than the one value read from them today, so the derivation stays in the parameters module rather than being half-encoded in the track's state.
