### PR TITLE
fix(relay): send SUBSCRIBE to every matching publisher

### DIFF
--- a/apps/relay/src/server/client_manager.rs
+++ b/apps/relay/src/server/client_manager.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::client::MOQTClient;
-use moqtail::model::{common::tuple::Tuple, data::full_track_name::FullTrackName};
+use moqtail::model::data::full_track_name::FullTrackName;
 use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::RwLock;
 use tracing::{debug, info};
@@ -50,55 +50,44 @@ impl ClientManager {
     clients.get(&connection_id).cloned()
   }
 
-  // returns the first publisher that matches the full_track_name
-  pub(crate) async fn get_publisher_by_full_track_name(
+  /// Every publisher a request for this Track must reach: those already publishing the
+  /// exact Track, and those that announced a namespace the Track falls under. Both are
+  /// matches, so this is their union rather than a preference between them, and a
+  /// publisher matching in both ways is returned once.
+  pub(crate) async fn get_publishers_for_track(
     &self,
     full_track_name: &FullTrackName,
-  ) -> Option<Arc<MOQTClient>> {
+  ) -> Vec<Arc<MOQTClient>> {
     let clients = self.clients.read().await;
+    let mut matched = Vec::new();
 
-    for client_ref in clients.iter() {
-      let client = client_ref.1;
-      if client
+    for (connection_id, client) in clients.iter() {
+      debug!("checking client: {:?}", connection_id);
+
+      let publishes_track = client
         .published_tracks
         .read()
         .await
         .values()
-        .any(|n| n == full_track_name)
-      {
-        return Some(client.clone());
+        .any(|n| n == full_track_name);
+
+      let announced_namespace = !publishes_track && {
+        let announced = client.announced_track_namespaces.read().await;
+        debug!(
+          "client announced track namespaces: {:?} track namespace: {:?}",
+          announced, full_track_name.namespace
+        );
+        // Equal to, or a prefix of, the Track's namespace.
+        announced
+          .iter()
+          .any(|ns| full_track_name.namespace.starts_with(ns))
+      };
+
+      if publishes_track || announced_namespace {
+        matched.push(client.clone());
       }
     }
-    None
-  }
-
-  // TODO: same namespace can be used by different publishers
-  // In our implementation, we expect a unique namespace is announced
-  // by every publisher such as /moqtail/my_room/user_1
-  // This can be solved by the Publish message.
-  pub(crate) async fn get_publisher_by_announced_track_namespace(
-    &self,
-    track_namespace: &Tuple,
-  ) -> Option<Arc<MOQTClient>> {
-    let clients = self.clients.read().await;
-    for client_ref in clients.iter() {
-      debug!("checking client: {:?}", client_ref.0);
-      let client = client_ref.1;
-
-      debug!(
-        "client announced track namespaces: {:?} track namespace: {:?}",
-        client.announced_track_namespaces, track_namespace
-      );
-      let announced_track_namespaces = client.announced_track_namespaces.read().await;
-
-      for announced_track_namespace in announced_track_namespaces.iter() {
-        // Check if track_namespace is equal to or a child of announced_track_namespace
-        if track_namespace.starts_with(announced_track_namespace) {
-          return Some(client_ref.1.clone());
-        }
-      }
-    }
-    None
+    matched
   }
 
   /// Diagnostic snapshot of every client's announced namespaces and published

--- a/apps/relay/src/server/config.rs
+++ b/apps/relay/src/server/config.rs
@@ -114,6 +114,11 @@ pub struct Cli {
   /// Timeout in seconds for upstream fetch responses
   #[arg(long, default_value_t = 10)]
   pub upstream_fetch_timeout_secs: u64,
+  /// How long a publisher has to answer the relay's SUBSCRIBE before it is treated as
+  /// declining. Without it a publisher that stays connected and never answers leaves
+  /// the subscriber waiting for a response that cannot arrive.
+  #[arg(long, default_value_t = 10)]
+  pub upstream_subscribe_timeout_secs: u64,
   /// How long a data stream waits for the control message that establishes its track
   /// alias before the stream is abandoned
   #[arg(long, default_value_t = 500)]
@@ -149,6 +154,9 @@ pub struct AppConfig {
   pub redirect_uri: Option<String>,
   pub max_upstream_fetch_gaps: u64,
   pub upstream_fetch_timeout: Duration,
+  /// How long a publisher has to answer the relay's SUBSCRIBE before it is treated as
+  /// declining.
+  pub upstream_subscribe_timeout: Duration,
   /// A data stream can arrive before the control message that establishes its track
   /// alias. The stream waits this long for it, then is abandoned.
   pub track_alias_resolution_timeout: Duration,
@@ -184,6 +192,7 @@ impl AppConfig {
         redirect_uri: cli.redirect_uri,
         max_upstream_fetch_gaps: cli.max_upstream_fetch_gaps,
         upstream_fetch_timeout: Duration::from_secs(cli.upstream_fetch_timeout_secs),
+        upstream_subscribe_timeout: Duration::from_secs(cli.upstream_subscribe_timeout_secs),
         track_alias_resolution_timeout: Duration::from_millis(
           cli.track_alias_resolution_timeout_ms,
         ),
@@ -308,6 +317,7 @@ mod tests {
       redirect_uri: None,
       max_upstream_fetch_gaps: 10,
       upstream_fetch_timeout: Duration::from_secs(10),
+      upstream_subscribe_timeout: Duration::from_secs(10),
       track_alias_resolution_timeout: Duration::from_millis(500),
       dedup_retained_groups: 30,
     }

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -752,18 +752,14 @@ async fn send_upstream_fetch_for_range(
   gap_start: u64,
   gap_end: u64,
 ) -> Option<(u64, Arc<MOQTClient>, mpsc::Receiver<UpstreamFetchEvent>)> {
+  // A FETCH goes to one publisher, unlike a SUBSCRIBE: any of the matching ones may
+  // serve the range, so the first will do.
   let publisher = {
     let m = context.client_manager.read().await;
-    match m
-      .get_publisher_by_full_track_name(&track_read.full_track_name)
+    m.get_publishers_for_track(&track_read.full_track_name)
       .await
-    {
-      Some(p) => Some(p),
-      None => {
-        m.get_publisher_by_announced_track_namespace(&track_read.full_track_name.namespace)
-          .await
-      }
-    }
+      .into_iter()
+      .next()
   };
   let publisher = match publisher {
     Some(p) => p,
@@ -913,13 +909,9 @@ async fn has_upstream_publisher(
 ) -> bool {
   let full_track_name = track.read().await.full_track_name.clone();
   let m = context.client_manager.read().await;
-  m.get_publisher_by_full_track_name(&full_track_name)
+  !m.get_publishers_for_track(&full_track_name)
     .await
-    .is_some()
-    || m
-      .get_publisher_by_announced_track_namespace(&full_track_name.namespace)
-      .await
-      .is_some()
+    .is_empty()
 }
 
 async fn send_request_error(

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -38,6 +38,7 @@ use moqtail::model::{
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use moqtail::transport::data_stream_handler::SubscribeRequest;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, warn};
 
@@ -94,8 +95,23 @@ async fn forward_subscribe_upstream(
   // resets this upstream stream and the publisher observes CANCELLED.
   let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
   if let Some(track) = context.track_manager.get_track(&full_track_name).await {
-    *track.read().await.upstream_cancel.lock().await = Some(cancel_tx);
+    track
+      .read()
+      .await
+      .upstream_subscribe_cancellers
+      .lock()
+      .await
+      .push(cancel_tx);
   }
+
+  // A publisher owes exactly one SUBSCRIBE_OK or REQUEST_ERROR. One that stays
+  // connected and sends neither would otherwise hold the subscriber's request stream
+  // open forever, and — where several publishers were asked — keep the others' answers
+  // from ever being acted on. The deadline only covers that first response; once it
+  // arrives the stream lives as long as the subscription does.
+  let answer_deadline = tokio::time::sleep(context.server_config.upstream_subscribe_timeout);
+  tokio::pin!(answer_deadline);
+  let mut answered = false;
 
   loop {
     tokio::select! {
@@ -110,7 +126,29 @@ async fn forward_subscribe_upstream(
         // (InternalError) emitted when the handler is dropped.
         break;
       }
+      _ = &mut answer_deadline, if !answered => {
+        warn!(
+          "Publisher {} did not answer the SUBSCRIBE for {:?} in time; treating it as declined",
+          publisher.connection_id, full_track_name
+        );
+        let err = RequestError::new(
+          RequestErrorCode::Timeout,
+          0,
+          ReasonPhrase::try_new("Publisher did not answer the subscribe".to_string()).unwrap(),
+        );
+        end_upstream_subscription(
+          relay_request_id,
+          publisher.connection_id,
+          &full_track_name,
+          err,
+          PublishDoneStatusCode::InternalError,
+          context.clone(),
+        )
+        .await;
+        break;
+      }
       msg = upstream.next_message() => {
+        answered = true;
         match msg {
           Ok(ControlMessage::SubscribeOk(m)) => {
             if let Err(e) =
@@ -125,6 +163,7 @@ async fn forward_subscribe_upstream(
             let status = publish_done_status_for(m.error_code);
             end_upstream_subscription(
               relay_request_id,
+              publisher.connection_id,
               &full_track_name,
               *m,
               status,
@@ -164,6 +203,7 @@ async fn forward_subscribe_upstream(
             // Nothing about the track changed; the pipeline misbehaved.
             end_upstream_subscription(
               relay_request_id,
+              publisher.connection_id,
               &full_track_name,
               err,
               PublishDoneStatusCode::InternalError,
@@ -182,6 +222,7 @@ async fn forward_subscribe_upstream(
             // The upstream stream is gone, so the track is no longer being published.
             end_upstream_subscription(
               relay_request_id,
+              publisher.connection_id,
               &full_track_name,
               err,
               PublishDoneStatusCode::TrackEnded,
@@ -220,35 +261,81 @@ fn publish_done_status_for(error_code: RequestErrorCode) -> PublishDoneStatusCod
 /// stream would be a protocol violation.
 async fn end_upstream_subscription(
   relay_request_id: u64,
+  publisher_connection_id: usize,
   full_track_name: &FullTrackName,
   error: RequestError,
   status_code: PublishDoneStatusCode,
   context: Arc<SessionContext>,
 ) {
   let track = context.track_manager.get_track(full_track_name).await;
-  let confirmed = match &track {
-    Some(track) => matches!(
-      *track.read().await.status.read().await,
-      TrackStatus::Confirmed { .. }
-    ),
-    None => false,
+  let (confirmed, others_may_still_accept) = match &track {
+    Some(track) => {
+      let track = track.read().await;
+      let confirmed = matches!(*track.status.read().await, TrackStatus::Confirmed { .. });
+      // This publisher has answered; whatever remains counted has not.
+      let remaining = track
+        .pending_upstream_subscribe_count
+        .fetch_sub(1, Ordering::SeqCst)
+        .saturating_sub(1);
+      (confirmed, remaining > 0)
+    }
+    None => (false, false),
   };
 
   if !confirmed {
+    // `handle_subscribe_error_message` marks the whole track Rejected and answers the
+    // subscriber's request stream, ending the subscription for everyone. One publisher
+    // declining is not grounds for that while others may still accept, and the stream
+    // takes exactly one response either way. Every publisher answers or times out, so
+    // the last one to do so reaches this with nothing outstanding and decides.
+    if others_may_still_accept {
+      info!(
+        "A publisher declined {:?}; others have yet to answer, so the subscriber waits",
+        full_track_name
+      );
+      // Nothing will answer this request now, and it is the relay's own bookkeeping.
+      context
+        .relay_pending_requests
+        .write()
+        .await
+        .remove(&relay_request_id);
+      return;
+    }
     let _ = handle_subscribe_error_message(relay_request_id, error, context).await;
     return;
   }
 
+  // The track was already accepted, so this publisher's failure ends its own upstream
+  // subscription rather than the request. Only when it was the last publisher serving
+  // the track is there nothing left to deliver, and the subscribers are told it is
+  // over; while another still serves it they carry on and must not hear PUBLISH_DONE.
+  let Some(track) = track else {
+    return;
+  };
+  let still_served = {
+    let track = track.read().await;
+    let mut aliases = track.publisher_aliases.write().await;
+    aliases.remove(&publisher_connection_id);
+    !aliases.is_empty()
+  };
+
+  if still_served {
+    info!(
+      "Upstream subscription for {:?} from publisher {} failed; other publishers still serve it",
+      full_track_name, publisher_connection_id
+    );
+    return;
+  }
+
   info!(
-    "Upstream subscription for {:?} failed after acceptance; ending downstream with PUBLISH_DONE",
+    "Last upstream subscription for {:?} failed after acceptance; ending downstream with PUBLISH_DONE",
     full_track_name
   );
-  if let Some(track) = track
-    && let Err(e) = track
-      .read()
-      .await
-      .notify_publish_done(status_code, error.reason_phrase.as_str().to_string())
-      .await
+  if let Err(e) = track
+    .read()
+    .await
+    .notify_publish_done(status_code, error.reason_phrase.as_str().to_string())
+    .await
   {
     error!("Failed to end downstream subscriptions: {:?}", e);
   }
@@ -279,39 +366,15 @@ async fn handle_subscribe_message(
     return Ok(());
   }
 
-  // find who is the publisher
-  // first we try with the full track name
-  // if not found, we try with the announced track namespace
-  // in both cases, the first publisher that satisfies the condition is returned
-  // TODO: support multiple publishers
-  let publisher = {
-    debug!("trying to get the publisher");
+  // Every publisher of the exact Track, plus every publisher that announced a namespace
+  // it falls under. A SUBSCRIBE goes to all of them, not to whichever matched first.
+  let publishers = {
+    debug!("trying to get the publishers");
     let m = context.client_manager.read().await;
-    debug!(
-      "client manager obtained, current client id: {}",
-      context.connection_id
-    );
-    match m.get_publisher_by_full_track_name(&full_track_name).await {
-      Some(p) => Some(p),
-      None => {
-        info!(
-          "no publisher found for full track name: {:?}",
-          &full_track_name
-        );
-        let m = context.client_manager.read().await;
-        debug!(
-          "client manager obtained, current client id: {}",
-          context.connection_id
-        );
-        m.get_publisher_by_announced_track_namespace(&track_namespace)
-          .await
-      }
-    }
+    m.get_publishers_for_track(&full_track_name).await
   };
 
-  let publisher = if let Some(publisher) = publisher {
-    publisher.clone()
-  } else {
+  if publishers.is_empty() {
     info!(
       "no publisher found for track namespace: {:?}",
       track_namespace
@@ -339,11 +402,15 @@ async fn handle_subscribe_message(
     return Ok(());
   };
 
-  publisher.add_subscriber(context.connection_id).await;
+  for publisher in &publishers {
+    publisher.add_subscriber(context.connection_id).await;
+  }
 
   info!(
-    "Subscriber ({}) added to the publisher ({})",
-    context.connection_id, publisher.connection_id
+    "Subscriber ({}) added to {} publisher(s) for {:?}",
+    context.connection_id,
+    publishers.len(),
+    full_track_name
   );
 
   let original_request_id = sub.request_id;
@@ -389,36 +456,48 @@ async fn handle_subscribe_message(
       &full_track_name
     );
 
-    let mut new_sub = sub.clone();
-    new_sub.subscribe_parameters = parameters::upstream_subscribe();
-    new_sub.request_id =
-      Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
-
-    // Store the relay subscribe request mapping before forwarding, so the
-    // upstream response can be routed back to this subscription.
-    // TODO: we need to add a timeout here or another loop to control expired requests
-    let req = SubscribeRequest::new(
-      original_request_id,
-      context.connection_id,
-      sub.clone(),
-      Some(new_sub.clone()),
-    );
+    // Counted before any request goes out, since a publisher can answer while the rest
+    // are still being sent.
     {
-      let mut requests = context.relay_pending_requests.write().await;
-      requests.insert(new_sub.request_id, PendingRequest::Subscribe(req.clone()));
+      let track = track_arc.read().await;
+      track
+        .pending_upstream_subscribe_count
+        .store(publishers.len(), Ordering::SeqCst);
     }
-    info!(
-      "inserted request into relay's pending requests: {:?} with relay's request id: {:?}",
-      req, new_sub.request_id
-    );
 
-    // Forward SUBSCRIBE upstream on its own bidirectional request stream and read
-    // the response there, per the request-stream model.
-    let publisher_fwd = publisher.clone();
-    let context_fwd = context.clone();
-    tokio::spawn(async move {
-      forward_subscribe_upstream(publisher_fwd, new_sub, context_fwd).await;
-    });
+    for publisher in &publishers {
+      let mut new_sub = sub.clone();
+      new_sub.subscribe_parameters = parameters::upstream_subscribe();
+      // Its own request id, which is what routes this publisher's response back.
+      new_sub.request_id =
+        Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
+
+      // Store the relay subscribe request mapping before forwarding, so the
+      // upstream response can be routed back to this subscription.
+      // TODO: we need to add a timeout here or another loop to control expired requests
+      let req = SubscribeRequest::new(
+        original_request_id,
+        context.connection_id,
+        sub.clone(),
+        Some(new_sub.clone()),
+      );
+      {
+        let mut requests = context.relay_pending_requests.write().await;
+        requests.insert(new_sub.request_id, PendingRequest::Subscribe(req.clone()));
+      }
+      info!(
+        "forwarding SUBSCRIBE for {:?} to publisher {} as relay request {}",
+        full_track_name, publisher.connection_id, new_sub.request_id
+      );
+
+      // Forward SUBSCRIBE upstream on its own bidirectional request stream and read
+      // the response there, per the request-stream model.
+      let publisher_fwd = publisher.clone();
+      let context_fwd = context.clone();
+      tokio::spawn(async move {
+        forward_subscribe_upstream(publisher_fwd, new_sub, context_fwd).await;
+      });
+    }
 
     // Do NOT send SubscribeOk yet -- wait for publisher confirmation
     Ok(())
@@ -561,9 +640,9 @@ async fn handle_subscribe_ok_message(
   };
 
   // Confirm the track with publisher's metadata; capture relay_track_id for SubscribeOk messages
-  let relay_track_id = {
+  let (relay_track_id, confirmed_now) = {
     let mut track = track_arc.write().await;
-    track
+    let confirmed_now = track
       .confirm(
         publisher.connection_id,
         msg.track_alias,
@@ -571,10 +650,16 @@ async fn handle_subscribe_ok_message(
         msg.track_properties.clone(),
       )
       .await;
-    track.relay_track_id
+    // This publisher has answered.
+    track
+      .pending_upstream_subscribe_count
+      .fetch_sub(1, Ordering::SeqCst);
+    (track.relay_track_id, confirmed_now)
   };
 
-  // Register the publisher's alias for data stream routing
+  // Register the publisher's alias for data stream routing. Every accepting publisher
+  // needs this, whether or not it was the one that confirmed the track, or its Objects
+  // arrive on a stream the relay cannot route.
   context
     .track_manager
     .add_track_alias(
@@ -583,6 +668,17 @@ async fn handle_subscribe_ok_message(
       full_track_name.clone(),
     )
     .await;
+
+  // Only the publisher that confirmed the track answers downstream. The others are now
+  // serving it too, but the subscribers were told once already and their request
+  // streams take exactly one response.
+  if !confirmed_now {
+    info!(
+      "Publisher {} also accepted {:?}; subscribers already answered",
+      publisher.connection_id, full_track_name
+    );
+    return Ok(());
+  }
 
   // What the relay advertises downstream is not what upstream sent: by the time this
   // runs the relay may already have seen a later Object than upstream knew of.
@@ -706,10 +802,10 @@ pub(crate) async fn cancel_subscription(
     let (is_last_subscriber, origin) = {
       let track = track_lock.read().await;
       track.remove_subscription(context.connection_id).await;
-      // When the last subscriber goes away, reset the upstream subscribe stream so
-      // the publisher observes the cancellation.
+      // When the last subscriber goes away, reset the upstream subscribe streams so
+      // the publishers observe the cancellation. One per publisher serving the track.
       let last = if track.subscriber_count().await == 0 {
-        if let Some(cancel) = track.upstream_cancel.lock().await.take() {
+        for cancel in track.upstream_subscribe_cancellers.lock().await.drain(..) {
           let _ = cancel.send(());
         }
         true

--- a/apps/relay/src/server/message_handlers/track_status_handler.rs
+++ b/apps/relay/src/server/message_handlers/track_status_handler.rs
@@ -57,18 +57,15 @@ pub async fn handle(
         return Ok(());
       }
 
-      // C. Find Upstream Publisher
-      // TODO: send to every interested publisher
+      // C. Find Upstream Publisher. One is enough: this asks for a track's status, and
+      // any publisher serving it can answer, where a SUBSCRIBE must reach all of them.
       let publisher = {
         debug!("Finding publisher for TrackStatus...");
         let m = context.client_manager.read().await;
-        match m.get_publisher_by_full_track_name(&full_track_name).await {
-          Some(p) => Some(p),
-          None => {
-            m.get_publisher_by_announced_track_namespace(&track_namespace)
-              .await
-          }
-        }
+        m.get_publishers_for_track(&full_track_name)
+          .await
+          .into_iter()
+          .next()
       };
 
       let publisher = if let Some(p) = publisher {

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -33,7 +33,7 @@ use moqtail::model::property::track_property::TrackProperty;
 use moqtail::transport::data_stream_handler::HeaderInfo;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio::sync::{Mutex, Notify, RwLock, oneshot};
 use tracing::{debug, error, info, warn};
 
@@ -144,16 +144,13 @@ pub struct Track {
   /// Inserted when the first object of a subgroup arrives; removed when the
   /// publisher's unistream closes (stream_closed signal).
   pub active_subgroup_headers: ActiveSubgroupHeaderMap,
-  /// Signals the relay's outbound SUBSCRIBE task to reset its stream when the
-  /// last downstream subscriber goes away.
-  ///
-  /// This is only set on the pull path: when a subscriber is the first to create
-  /// a track, the relay opens its OWN SUBSCRIBE stream to the publisher and
-  /// stores the signal here. It guards that relay-owned stream only — never a
-  /// publisher-initiated PUBLISH stream. A track created by a PUBLISH leaves this
-  /// None, so a subscriber leaving never cancels the publisher; the pushed track
-  /// stays alive as long as the publisher keeps publishing.
-  pub upstream_cancel: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+  /// One per publisher; firing it resets that relay-owned upstream SUBSCRIBE stream
+  /// when the last downstream subscriber goes away. Only the pull path fills this, so
+  /// a PUBLISH-created track leaves it empty and a subscriber leaving never cancels
+  /// the publisher.
+  pub upstream_subscribe_cancellers: Arc<Mutex<Vec<oneshot::Sender<()>>>>,
+  /// Upstream SUBSCRIBEs still awaiting a SUBSCRIBE_OK or REQUEST_ERROR.
+  pub pending_upstream_subscribe_count: Arc<AtomicUsize>,
   /// Forward State the relay last gave the upstream publisher of a
   /// PUBLISH-created track. A relay may answer PUBLISH with Forward State 0
   /// while nothing downstream wants the track; this records whether it has
@@ -193,7 +190,8 @@ impl Track {
       pending_subscribers: Arc::new(RwLock::new(Vec::new())),
       track_properties: Arc::new(RwLock::new(Vec::new())),
       active_subgroup_headers: Arc::new(RwLock::new(HashMap::new())),
-      upstream_cancel: Arc::new(Mutex::new(None)),
+      upstream_subscribe_cancellers: Arc::new(Mutex::new(Vec::new())),
+      pending_upstream_subscribe_count: Arc::new(AtomicUsize::new(0)),
       upstream_forward: Arc::new(AtomicBool::new(false)),
     }
   }
@@ -280,30 +278,39 @@ impl Track {
     record_location(&mut seen, location, retained)
   }
 
-  /// Transition from Pending to Confirmed. Adds publisher alias and notifies waiters.
+  /// Registers an accepting publisher. Returns true only for the one that took the
+  /// track out of Pending, since only it has a downstream response to send.
   pub async fn confirm(
     &mut self,
     publisher_connection_id: usize,
     publisher_track_alias: u64,
     upstream_parameters: Vec<MessageParameter>,
     properties: Vec<TrackProperty>,
-  ) {
+  ) -> bool {
     {
       let mut aliases = self.publisher_aliases.write().await;
       aliases.insert(publisher_connection_id, publisher_track_alias);
     }
-    let mut status = self.status.write().await;
-    *status = TrackStatus::Confirmed {
-      upstream_parameters,
-    };
-    drop(status);
     *self.track_properties.write().await = properties;
-    self.status_notify.notify_waiters();
+
+    let mut status = self.status.write().await;
+    let was_pending = matches!(*status, TrackStatus::Pending);
+    if was_pending {
+      *status = TrackStatus::Confirmed {
+        upstream_parameters,
+      };
+    }
+    drop(status);
+
+    if was_pending {
+      self.status_notify.notify_waiters();
+    }
 
     info!(
-      "Track confirmed: relay_track_id={} publisher_connection_id={} publisher_alias={}",
-      self.relay_track_id, publisher_connection_id, publisher_track_alias
+      "Track publisher accepted: relay_track_id={} publisher_connection_id={} publisher_alias={} confirmed_now={}",
+      self.relay_track_id, publisher_connection_id, publisher_track_alias, was_pending
     );
+    was_pending
   }
 
   /// Updates the cached track properties (per spec: most recent set replaces any previous).


### PR DESCRIPTION
A relay must send SUBSCRIBE to all publishers matching a Track, both those publishing it by name and those that announced a namespace it falls under. The lookup returned the first match of the first kind that hit, so a second publisher offering the same track was never asked, and the two kinds of match were a fallback chain rather than the union they are. Measured against two publishers of one track: one received the SUBSCRIBE, the other received nothing. Now both do.

Fanning out means several answers arrive for one downstream request, and the request stream takes exactly one response. `confirm` reports whether it was the caller that took the track out of Pending; only that publisher answers downstream, while every accepting publisher still registers its track alias or its Objects arrive on a stream that cannot be routed.

A rejection can no longer speak for publishers that have not replied. The track counts its unanswered upstream SUBSCRIBEs, and only the last one to fail rejects the subscriber; earlier failures drop their own bookkeeping and wait.

That count is only safe if every request is guaranteed to resolve, so a publisher now has a bounded time to answer. Without it one that stays connected and answers nothing would hold the subscriber's stream open forever and suppress the other publishers' answers with it. This also closes the same hang for a single publisher, which the TODO there described.

Cancellation became per publisher, since each upstream subscription has its own stream to reset -- previously one sender was overwritten by whichever subscribe ran last, which was harmless only while one publisher was consulted.

Testing with one publisher frozen mid-handshake caught the last of it: the timeout ended the whole subscription because any failure after acceptance sent PUBLISH_DONE downstream. That is right for the last publisher and wrong for the others, so a failing upstream now drops just its own entry and only the final one ends the subscription. The subscriber went from 5 objects to 15.

FETCH and TRACK_STATUS still use one publisher: any of them may serve a fetch, and a status answer needs only one.
