### PR TITLE
Refactor handling of namespace prefixes and  pending requests cleanup

### DIFF
--- a/apps/relay/src/server.rs
+++ b/apps/relay/src/server.rs
@@ -18,6 +18,7 @@ mod config;
 mod errors;
 mod message_handlers;
 mod object_logger;
+mod prefix_subscription;
 mod seen_objects;
 mod session;
 mod session_context;

--- a/apps/relay/src/server/message_handlers/fetch_handler.rs
+++ b/apps/relay/src/server/message_handlers/fetch_handler.rs
@@ -730,11 +730,6 @@ pub async fn handle(
                 .write()
                 .await
                 .remove(&relay_request_id);
-              context
-                .relay_pending_requests
-                .write()
-                .await
-                .remove(&relay_request_id);
               upstream_publisher
                 .outgoing_fetch_requests
                 .write()
@@ -959,12 +954,7 @@ async fn send_upstream_fetch_for_range(
       .outgoing_fetch_requests
       .write()
       .await
-      .insert(relay_request_id, req.clone());
-    context
-      .relay_pending_requests
-      .write()
-      .await
-      .insert(relay_request_id, PendingRequest::Fetch(req));
+      .insert(relay_request_id, req);
     context
       .upstream_fetch_senders
       .write()

--- a/apps/relay/src/server/message_handlers/mod.rs
+++ b/apps/relay/src/server/message_handlers/mod.rs
@@ -124,7 +124,8 @@ impl MessageHandler {
           Publish,
           PublishNamespace,
           Subscribe,
-          SubscribeNamespace,
+          /// SUBSCRIBE_NAMESPACE and SUBSCRIBE_TRACKS are updated the same way.
+          PrefixSubscription,
           NotFound,
         }
 
@@ -134,8 +135,8 @@ impl MessageHandler {
           Some(PendingRequest::Publish { .. }) => Route::Publish,
           Some(PendingRequest::PublishNamespace { .. }) => Route::PublishNamespace,
           Some(PendingRequest::Subscribe(_)) => Route::Subscribe,
-          Some(PendingRequest::SubscribeNamespace { .. }) => Route::SubscribeNamespace,
-          Some(PendingRequest::SubscribeTracks { .. }) => Route::SubscribeNamespace,
+          Some(PendingRequest::SubscribeNamespace { .. }) => Route::PrefixSubscription,
+          Some(PendingRequest::SubscribeTracks { .. }) => Route::PrefixSubscription,
           Some(PendingRequest::RequestUpdate { .. }) => Route::NotFound,
           None => Route::NotFound,
         };
@@ -187,8 +188,8 @@ impl MessageHandler {
             )
             .await
           }
-          Route::SubscribeNamespace => {
-            subscribe_namespace_handler::handle(
+          Route::PrefixSubscription => {
+            crate::server::prefix_subscription::handle(
               client.clone(),
               stream_handler,
               msg,

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -222,7 +222,6 @@ pub async fn handle(
             &track_arc,
             &m,
             &subscribe_tracks_params,
-            context.connection_id,
           )
           .await;
         }
@@ -521,13 +520,9 @@ pub(crate) async fn push_track_to_subscriber(
   track_arc: &Arc<RwLock<Track>>,
   publish: &Publish,
   subscribe_tracks_params: &[MessageParameter],
-  publisher_connection_id: usize,
 ) {
   let relay_request_id =
     Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
-
-  // Read before the rewrite: the incoming request id is the publisher's own.
-  let publisher_request_id = publish.request_id;
 
   let mut downstream = publish.clone();
   downstream.request_id = relay_request_id;
@@ -538,18 +533,6 @@ pub(crate) async fn push_track_to_subscriber(
       &publish.parameters,
       subscribe_tracks_params,
       track.largest_object().await,
-    );
-  }
-
-  {
-    let mut map = context.relay_pending_requests.write().await;
-    map.insert(
-      relay_request_id,
-      PendingRequest::Publish {
-        publisher_connection_id,
-        original_request_id: publisher_request_id,
-        message: downstream.clone(),
-      },
     );
   }
 

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -216,51 +216,15 @@ pub async fn handle(
             subscriber.connection_id
           );
 
-          let sub_clone = subscriber.clone();
-
-          let mut m_clone = m.clone();
-
-          let relay_req_id =
-            Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
-
-          m_clone.request_id = relay_req_id;
-          m_clone.track_alias = relay_track_id;
-          m_clone.parameters = parameters::downstream_publish(
-            &m.parameters,
+          push_track_to_subscriber(
+            &context,
+            subscriber,
+            &track_arc,
+            &m,
             &subscribe_tracks_params,
-            track_arc.read().await.largest_object().await,
-          );
-
-          // Register the message in unified map for response tracking
-          {
-            let mut map = context.relay_pending_requests.write().await;
-            map.insert(
-              relay_req_id,
-              PendingRequest::Publish {
-                publisher_connection_id: context.connection_id,
-                original_request_id: request_id,
-                message: (*m_clone).clone(),
-              },
-            );
-          }
-
-          let track_write = track_arc.read().await;
-          if let Err(e) = track_write
-            .add_subscription(subscriber.clone(), (*m_clone).clone(), false)
-            .await
-          {
-            warn!(
-              "Failed to auto-subscribe client {} to pushed track: {:?}",
-              subscriber.connection_id, e
-            );
-          }
-
-          // Push the PUBLISH on its own bidi stream and read PUBLISH_OK there.
-          let push_msg = *m_clone.clone();
-          let subscription = track_write.get_subscription(subscriber.connection_id).await;
-          tokio::spawn(async move {
-            forward_publish_downstream(sub_clone, push_msg, subscription).await;
-          });
+            context.connection_id,
+          )
+          .await;
         }
       } else {
         // Another publisher for the same track with a different alias.
@@ -544,6 +508,68 @@ pub(crate) async fn ensure_upstream_forwarding(
       warn!("No open PUBLISH request stream for publisher {connection_id} on {full_track_name:?}");
     }
   }
+}
+
+/// Send a PUBLISH for one track to one SUBSCRIBE_TRACKS subscriber, re-originated for
+/// this hop: the relay's own request id, its own track alias, and parameters it builds
+/// rather than forwards.
+///
+/// The caller decides whether this subscriber should be served, and owns any push limit.
+pub(crate) async fn push_track_to_subscriber(
+  context: &Arc<SessionContext>,
+  subscriber: Arc<MOQTClient>,
+  track_arc: &Arc<RwLock<Track>>,
+  publish: &Publish,
+  subscribe_tracks_params: &[MessageParameter],
+  publisher_connection_id: usize,
+) {
+  let relay_request_id =
+    Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
+
+  // Read before the rewrite: the incoming request id is the publisher's own.
+  let publisher_request_id = publish.request_id;
+
+  let mut downstream = publish.clone();
+  downstream.request_id = relay_request_id;
+  {
+    let track = track_arc.read().await;
+    downstream.track_alias = track.relay_track_id;
+    downstream.parameters = parameters::downstream_publish(
+      &publish.parameters,
+      subscribe_tracks_params,
+      track.largest_object().await,
+    );
+  }
+
+  {
+    let mut map = context.relay_pending_requests.write().await;
+    map.insert(
+      relay_request_id,
+      PendingRequest::Publish {
+        publisher_connection_id,
+        original_request_id: publisher_request_id,
+        message: downstream.clone(),
+      },
+    );
+  }
+
+  let track = track_arc.read().await;
+  if let Err(e) = track
+    .add_subscription(subscriber.clone(), downstream.clone(), false)
+    .await
+  {
+    warn!(
+      "Failed to auto-subscribe client {} to pushed track: {:?}",
+      subscriber.connection_id, e
+    );
+  }
+  let subscription = track.get_subscription(subscriber.connection_id).await;
+  drop(track);
+
+  // Each PUBLISH is a request on its own bidi stream.
+  tokio::spawn(async move {
+    forward_publish_downstream(subscriber, downstream, subscription).await;
+  });
 }
 
 /// Push a PUBLISH to a subscriber on its own bidirectional request stream and read the

--- a/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_namespace_handler.rs
@@ -207,18 +207,6 @@ pub async fn handle(
             update_msg.parameters.clone(),
           );
 
-          {
-            let mut map = context.relay_pending_requests.write().await;
-            map.insert(
-              relay_update_id,
-              PendingRequest::RequestUpdate {
-                client_connection_id: session.connection_id,
-                original_request_id: relay_update_id,
-                message: fanout_msg.clone(),
-              },
-            );
-          }
-
           // Goes on the namespace subscription's own request stream, which is
           // what names the request being updated.
           session

--- a/apps/relay/src/server/message_handlers/subscribe_namespace_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_namespace_handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::server::client::MOQTClient;
+use crate::server::prefix_subscription::{MAX_NAMESPACE_PREFIX_FIELDS, oversized_namespace_error};
 use crate::server::session_context::{PendingRequest, SessionContext};
 use crate::server::track_manager::SubscribeKind;
 use core::result::Result;
@@ -22,32 +23,12 @@ use moqtail::model::control::namespace::Namespace;
 use moqtail::model::control::request_error::RequestError;
 use moqtail::model::control::request_ok::RequestOk;
 use moqtail::model::control::subscribe_namespace::SubscribeNamespace;
+use moqtail::model::error::RequestErrorCode;
 use moqtail::model::error::TerminationCode;
-use moqtail::model::error::{RequestErrorCode, StreamResetCode};
-use moqtail::model::parameter::message_parameter::apply_message_parameter_update;
 use moqtail::transport::control_stream_handler::ControlStreamHandler;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{info, warn};
-
-/// The relay will not enumerate a namespace prefix broader than this many fields.
-pub(crate) const MAX_NAMESPACE_PREFIX_FIELDS: usize = 32;
-
-/// A NAMESPACE_TOO_LARGE error if the prefix exceeds what the relay will
-/// enumerate, otherwise `None`.
-pub(crate) fn oversized_namespace_error(
-  prefix: &moqtail::model::common::tuple::Tuple,
-) -> Option<RequestError> {
-  if prefix.fields.len() > MAX_NAMESPACE_PREFIX_FIELDS {
-    Some(RequestError::new(
-      RequestErrorCode::NamespaceTooLarge,
-      0,
-      ReasonPhrase::try_new("Namespace prefix is too large".to_string()).unwrap(),
-    ))
-  } else {
-    None
-  }
-}
 
 /// Handle an incoming SUBSCRIBE_NAMESPACE on a dedicated bi-stream.
 /// Called from `dispatch_request_stream_message()` in session.rs.
@@ -84,6 +65,7 @@ pub async fn handle_subscribe_namespace(
       client.connection_id,
       &sub_ns.track_namespace_prefix,
       SubscribeKind::Namespace,
+      None,
     )
     .await
   {
@@ -182,129 +164,4 @@ async fn send_namespace_catchup(
     }
   }
   Ok(())
-}
-
-/// Remove the namespace subscription when the subscriber closes or resets the bi-stream.
-pub async fn cancel(client: Arc<MOQTClient>, request_id: u64, context: &Arc<SessionContext>) {
-  let target = {
-    let mut map = client.inbound_requests.write().await;
-    match map.remove(&request_id) {
-      Some(PendingRequest::SubscribeNamespace { message, .. }) => {
-        Some((message.track_namespace_prefix, SubscribeKind::Namespace))
-      }
-      Some(PendingRequest::SubscribeTracks { message, .. }) => {
-        Some((message.track_namespace_prefix, SubscribeKind::Tracks))
-      }
-      _ => None,
-    }
-  };
-  if let Some((prefix, kind)) = target {
-    context
-      .track_manager
-      .remove_namespace_subscriber_by_prefix(&prefix, client.connection_id, kind)
-      .await;
-    info!(
-      "Cancelled {:?} subscription for prefix {:?} (connection {})",
-      kind, prefix, client.connection_id
-    );
-  }
-}
-
-/// Handle control-stream messages that route to the SUBSCRIBE_NAMESPACE handler.
-/// Currently handles RequestUpdate (parameter updates for existing subscriptions).
-pub async fn handle(
-  client: Arc<MOQTClient>,
-  handler: &mut ControlStreamHandler,
-  msg: ControlMessage,
-  context: Arc<SessionContext>,
-  opening_request_id: Option<u64>,
-) -> Result<(), TerminationCode> {
-  match msg {
-    ControlMessage::RequestUpdate(m) => {
-      let update_msg = *m;
-      let Some(target_request_id) = opening_request_id else {
-        return Err(TerminationCode::ProtocolViolation);
-      };
-      let existing_req_id = target_request_id;
-
-      let target_prefix = {
-        let mut map = client.inbound_requests.write().await;
-        match map.get_mut(&existing_req_id) {
-          Some(PendingRequest::SubscribeNamespace { message, .. }) => {
-            apply_message_parameter_update(&mut message.parameters, update_msg.parameters.clone());
-            message.track_namespace_prefix.clone()
-          }
-          Some(PendingRequest::SubscribeTracks { message, .. }) => {
-            apply_message_parameter_update(&mut message.parameters, update_msg.parameters.clone());
-            message.track_namespace_prefix.clone()
-          }
-          _ => {
-            warn!(
-              "REQUEST_UPDATE for prefix subscription request {} cannot be applied; closing the stream",
-              existing_req_id
-            );
-            handler.reset(StreamResetCode::Cancelled.to_u64());
-            return Ok(());
-          }
-        }
-      };
-
-      info!(
-        "Processing SUBSCRIBE_NAMESPACE update for prefix: {:?}",
-        target_prefix
-      );
-
-      context
-        .track_manager
-        .update_namespace_subscription_parameters(
-          &target_prefix,
-          client.connection_id,
-          update_msg.parameters.clone(),
-        )
-        .await;
-
-      let ok_msg = RequestOk::new(vec![]);
-      handler
-        .send(&ControlMessage::RequestOk(Box::new(ok_msg)))
-        .await?;
-    }
-
-    _ => {
-      warn!(
-        "Unexpected message in subscribe_namespace_handler: {:?}",
-        msg
-      );
-    }
-  }
-
-  Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use moqtail::model::common::tuple::{Tuple, TupleField};
-
-  #[test]
-  fn oversized_namespace_prefix_yields_namespace_too_large() {
-    let big = Tuple {
-      fields: (0..=MAX_NAMESPACE_PREFIX_FIELDS)
-        .map(|i| TupleField::from_utf8(&i.to_string()))
-        .collect(),
-    };
-    let err = oversized_namespace_error(&big).expect("over-long prefix must be rejected");
-    assert_eq!(err.error_code, RequestErrorCode::NamespaceTooLarge);
-    assert_eq!(u64::from(err.error_code), 0x31);
-  }
-
-  #[test]
-  fn normal_namespace_prefix_is_accepted() {
-    let small = Tuple {
-      fields: vec![
-        TupleField::from_utf8("moqtail"),
-        TupleField::from_utf8("demo"),
-      ],
-    };
-    assert!(oversized_namespace_error(&small).is_none());
-  }
 }

--- a/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
@@ -133,8 +133,7 @@ pub async fn handle_subscribe_tracks(
       continue;
     }
 
-    if let Some((publisher_connection_id, original_publish_message)) = original_publish_message_opt
-    {
+    if let Some(original_publish_message) = original_publish_message_opt {
       // Out of streams to initiate this subscription: send PUBLISH_BLOCKED on
       // the response stream and stop (no PUBLISH may follow it).
       if max_publish_streams > 0 && published >= max_publish_streams {
@@ -161,7 +160,6 @@ pub async fn handle_subscribe_tracks(
         &track_arc,
         &original_publish_message,
         &sub_tracks.parameters,
-        publisher_connection_id,
       )
       .await;
       published += 1;

--- a/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_tracks_handler.rs
@@ -13,12 +13,8 @@
 // limitations under the License.
 
 use crate::server::client::MOQTClient;
-use crate::server::message_handlers::parameters;
 use crate::server::message_handlers::publish_handler;
-use crate::server::message_handlers::subscribe_namespace_handler::{
-  MAX_NAMESPACE_PREFIX_FIELDS, oversized_namespace_error,
-};
-use crate::server::session::Session;
+use crate::server::prefix_subscription::{MAX_NAMESPACE_PREFIX_FIELDS, oversized_namespace_error};
 use crate::server::session_context::{PendingRequest, SessionContext};
 use crate::server::track_manager::SubscribeKind;
 use core::result::Result;
@@ -68,6 +64,7 @@ pub async fn handle_subscribe_tracks(
       client.connection_id,
       &sub_tracks.track_namespace_prefix,
       SubscribeKind::Tracks,
+      None,
     )
     .await
   {
@@ -136,7 +133,8 @@ pub async fn handle_subscribe_tracks(
       continue;
     }
 
-    if let Some(mut original_publish_message) = original_publish_message_opt {
+    if let Some((publisher_connection_id, original_publish_message)) = original_publish_message_opt
+    {
       // Out of streams to initiate this subscription: send PUBLISH_BLOCKED on
       // the response stream and stop (no PUBLISH may follow it).
       if max_publish_streams > 0 && published >= max_publish_streams {
@@ -157,49 +155,15 @@ pub async fn handle_subscribe_tracks(
 
       info!("Forwarding existing track to SUBSCRIBE_TRACKS subscriber: {full_track_name:?}");
 
-      let relay_track_id = {
-        let track = track_arc.read().await;
-        track.relay_track_id
-      };
-
-      let relay_publish_id =
-        Session::get_next_relay_request_id(context.relay_next_request_id.clone()).await;
-      original_publish_message.request_id = relay_publish_id;
-      original_publish_message.track_alias = relay_track_id;
-      original_publish_message.parameters = parameters::downstream_publish(
-        &original_publish_message.parameters,
+      publish_handler::push_track_to_subscriber(
+        &context,
+        client.clone(),
+        &track_arc,
+        &original_publish_message,
         &sub_tracks.parameters,
-        track_arc.read().await.largest_object().await,
-      );
-
-      {
-        let mut map = context.relay_pending_requests.write().await;
-        map.insert(
-          relay_publish_id,
-          PendingRequest::Publish {
-            publisher_connection_id: client.connection_id,
-            original_request_id: relay_publish_id,
-            message: original_publish_message.clone(),
-          },
-        );
-      }
-
-      let track_read = track_arc.read().await;
-      if let Err(e) = track_read
-        .add_subscription(client.clone(), original_publish_message.clone(), false)
-        .await
-      {
-        warn!("Failed retroactive auto-subscribe for track: {:?}", e);
-      }
-      let subscription = track_read.get_subscription(client.connection_id).await;
-      drop(track_read);
-
-      // Each PUBLISH is a request on its own bidi stream.
-      let sub = client.clone();
-      let push_msg = original_publish_message.clone();
-      tokio::spawn(async move {
-        publish_handler::forward_publish_downstream(sub, push_msg, subscription).await;
-      });
+        publisher_connection_id,
+      )
+      .await;
       published += 1;
     } else {
       warn!("The track has no associated publish message, track: {full_track_name:?}");

--- a/apps/relay/src/server/prefix_subscription.rs
+++ b/apps/relay/src/server/prefix_subscription.rs
@@ -1,0 +1,314 @@
+// Copyright 2026 The MOQtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! What SUBSCRIBE_NAMESPACE and SUBSCRIBE_TRACKS share.
+//!
+//! Both name a namespace prefix, both hold their request stream open for as long as
+//! the subscription lives, and both are updated and cancelled the same way. What they
+//! produce differs -- one sends NAMESPACE and NAMESPACE_DONE, the other PUBLISH -- and
+//! that part stays in `subscribe_namespace_handler` and `subscribe_tracks_handler`
+//! respectively, alongside the publisher-side fan-out that feeds it.
+//!
+//! Everything here is written once and parameterised by `SubscribeKind`, which selects
+//! the overlap space to check and the registry entry to act on. The two kinds never
+//! conflict with each other.
+
+use crate::server::client::MOQTClient;
+use crate::server::session_context::{PendingRequest, SessionContext};
+use crate::server::track_manager::SubscribeKind;
+use core::result::Result;
+use moqtail::model::common::reason_phrase::ReasonPhrase;
+use moqtail::model::common::tuple::Tuple;
+use moqtail::model::control::control_message::ControlMessage;
+use moqtail::model::control::request_error::RequestError;
+use moqtail::model::control::request_ok::RequestOk;
+use moqtail::model::error::TerminationCode;
+use moqtail::model::error::{RequestErrorCode, StreamResetCode};
+use moqtail::model::parameter::message_parameter::{
+  MessageParameter, apply_message_parameter_update,
+};
+use moqtail::transport::control_stream_handler::ControlStreamHandler;
+use std::sync::Arc;
+use tracing::{info, warn};
+
+/// The relay will not enumerate a namespace prefix broader than this many fields.
+pub(crate) const MAX_NAMESPACE_PREFIX_FIELDS: usize = 32;
+
+/// A NAMESPACE_TOO_LARGE error if the prefix exceeds what the relay will
+/// enumerate, otherwise `None`.
+pub(crate) fn oversized_namespace_error(prefix: &Tuple) -> Option<RequestError> {
+  if prefix.fields.len() > MAX_NAMESPACE_PREFIX_FIELDS {
+    Some(RequestError::new(
+      RequestErrorCode::NamespaceTooLarge,
+      0,
+      ReasonPhrase::try_new("Namespace prefix is too large".to_string()).unwrap(),
+    ))
+  } else {
+    None
+  }
+}
+
+/// Remove the subscription when the subscriber closes or resets the bi-stream.
+pub async fn cancel(client: Arc<MOQTClient>, request_id: u64, context: &Arc<SessionContext>) {
+  let target = {
+    let mut map = client.inbound_requests.write().await;
+    match map.remove(&request_id) {
+      Some(PendingRequest::SubscribeNamespace { message, .. }) => {
+        Some((message.track_namespace_prefix, SubscribeKind::Namespace))
+      }
+      Some(PendingRequest::SubscribeTracks { message, .. }) => {
+        Some((message.track_namespace_prefix, SubscribeKind::Tracks))
+      }
+      _ => None,
+    }
+  };
+  if let Some((prefix, kind)) = target {
+    context
+      .track_manager
+      .remove_namespace_subscriber_by_prefix(&prefix, client.connection_id, kind)
+      .await;
+    info!(
+      "Cancelled {:?} subscription for prefix {:?} (connection {})",
+      kind, prefix, client.connection_id
+    );
+  }
+}
+
+/// The prefix subscription a REQUEST_UPDATE targets: the prefix it currently holds
+/// and which kind it is.
+async fn target_subscription(
+  client: &Arc<MOQTClient>,
+  request_id: u64,
+) -> Option<(Tuple, SubscribeKind)> {
+  let map = client.inbound_requests.read().await;
+  match map.get(&request_id) {
+    Some(PendingRequest::SubscribeNamespace { message, .. }) => Some((
+      message.track_namespace_prefix.clone(),
+      SubscribeKind::Namespace,
+    )),
+    Some(PendingRequest::SubscribeTracks { message, .. }) => Some((
+      message.track_namespace_prefix.clone(),
+      SubscribeKind::Tracks,
+    )),
+    _ => None,
+  }
+}
+
+/// The new prefix a REQUEST_UPDATE asks the subscription to move to, if any.
+fn requested_prefix(parameters: &[MessageParameter]) -> Option<Tuple> {
+  parameters.iter().find_map(|p| match p {
+    MessageParameter::TrackNamespacePrefix { prefix } => Some(prefix.clone()),
+    _ => None,
+  })
+}
+
+/// The error to answer a prefix move with, or `None` to let it through. The
+/// subscription's own entry is excluded from the overlap check, since the prefix it
+/// is vacating always overlaps whatever replaces it.
+async fn prefix_move_rejection(
+  client: &Arc<MOQTClient>,
+  context: &Arc<SessionContext>,
+  current_prefix: &Tuple,
+  new_prefix: &Tuple,
+  kind: SubscribeKind,
+) -> Option<RequestError> {
+  if let Some(err) = oversized_namespace_error(new_prefix) {
+    warn!(
+      "REQUEST_UPDATE prefix has {} fields, maximum is {}",
+      new_prefix.fields.len(),
+      MAX_NAMESPACE_PREFIX_FIELDS
+    );
+    return Some(err);
+  }
+
+  let existing_prefix = context
+    .track_manager
+    .find_overlapping_namespace_subscription(
+      client.connection_id,
+      new_prefix,
+      kind,
+      Some(current_prefix),
+    )
+    .await?;
+
+  warn!(
+    "REQUEST_UPDATE prefix overlap: new={new_prefix:?} conflicts with existing={existing_prefix:?}"
+  );
+  Some(RequestError::new(
+    RequestErrorCode::PrefixOverlap,
+    0,
+    ReasonPhrase::try_new("Namespace prefix overlaps with existing subscription".to_string())
+      .unwrap(),
+  ))
+}
+
+/// Applies an accepted REQUEST_UPDATE to the stored request and to the registry,
+/// moving the subscription when the update asked for a new prefix. The prefix is the
+/// registry key that the ongoing fan-out and its suffixes are computed from, so moving
+/// the entry is what makes a new prefix take effect.
+async fn apply_subscription_update(
+  client: &Arc<MOQTClient>,
+  context: &Arc<SessionContext>,
+  request_id: u64,
+  current_prefix: &Tuple,
+  new_prefix: Option<Tuple>,
+  kind: SubscribeKind,
+  parameters: Vec<MessageParameter>,
+) {
+  {
+    let mut map = client.inbound_requests.write().await;
+    let stored = match map.get_mut(&request_id) {
+      Some(PendingRequest::SubscribeNamespace { message, .. }) => {
+        Some((&mut message.parameters, &mut message.track_namespace_prefix))
+      }
+      Some(PendingRequest::SubscribeTracks { message, .. }) => {
+        Some((&mut message.parameters, &mut message.track_namespace_prefix))
+      }
+      _ => None,
+    };
+    if let Some((stored_parameters, stored_prefix)) = stored {
+      apply_message_parameter_update(stored_parameters, parameters.clone());
+      if let Some(new_prefix) = &new_prefix {
+        *stored_prefix = new_prefix.clone();
+      }
+    }
+  }
+
+  context
+    .track_manager
+    .update_namespace_subscription_parameters(current_prefix, client.connection_id, parameters)
+    .await;
+
+  if let Some(new_prefix) = new_prefix {
+    info!(
+      "Moving {:?} subscription of connection {} from {:?} to {:?}",
+      kind, client.connection_id, current_prefix, new_prefix
+    );
+    context
+      .track_manager
+      .rekey_namespace_subscriber(current_prefix, new_prefix, client.connection_id, kind)
+      .await;
+  }
+}
+
+/// Handle a REQUEST_UPDATE arriving on a prefix subscription's own request stream.
+pub async fn handle(
+  client: Arc<MOQTClient>,
+  handler: &mut ControlStreamHandler,
+  msg: ControlMessage,
+  context: Arc<SessionContext>,
+  opening_request_id: Option<u64>,
+) -> Result<(), TerminationCode> {
+  match msg {
+    ControlMessage::RequestUpdate(m) => {
+      let update_msg = *m;
+      let Some(existing_req_id) = opening_request_id else {
+        return Err(TerminationCode::ProtocolViolation);
+      };
+
+      let Some((current_prefix, kind)) = target_subscription(&client, existing_req_id).await else {
+        warn!(
+          "REQUEST_UPDATE for prefix subscription request {} cannot be applied; closing the stream",
+          existing_req_id
+        );
+        handler.reset(StreamResetCode::Cancelled.to_u64());
+        return Ok(());
+      };
+
+      // A rejected prefix move leaves the parameters that arrived with it unapplied.
+      let new_prefix = requested_prefix(&update_msg.parameters);
+      if let Some(new_prefix) = &new_prefix
+        && let Some(err) =
+          prefix_move_rejection(&client, &context, &current_prefix, new_prefix, kind).await
+      {
+        handler
+          .send(&ControlMessage::RequestError(Box::new(err)))
+          .await?;
+        return Ok(());
+      }
+
+      info!("Processing {kind:?} update for prefix: {current_prefix:?}");
+
+      apply_subscription_update(
+        &client,
+        &context,
+        existing_req_id,
+        &current_prefix,
+        new_prefix,
+        kind,
+        update_msg.parameters,
+      )
+      .await;
+
+      let ok_msg = RequestOk::new(vec![]);
+      handler
+        .send(&ControlMessage::RequestOk(Box::new(ok_msg)))
+        .await?;
+    }
+
+    _ => {
+      warn!(
+        "Unexpected message in prefix_subscription handler: {:?}",
+        msg
+      );
+    }
+  }
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use moqtail::model::common::tuple::TupleField;
+
+  #[test]
+  fn oversized_namespace_prefix_yields_namespace_too_large() {
+    let big = Tuple {
+      fields: (0..=MAX_NAMESPACE_PREFIX_FIELDS)
+        .map(|i| TupleField::from_utf8(&i.to_string()))
+        .collect(),
+    };
+    let err = oversized_namespace_error(&big).expect("over-long prefix must be rejected");
+    assert_eq!(err.error_code, RequestErrorCode::NamespaceTooLarge);
+    assert_eq!(u64::from(err.error_code), 0x31);
+  }
+
+  #[test]
+  fn normal_namespace_prefix_is_accepted() {
+    let small = Tuple {
+      fields: vec![
+        TupleField::from_utf8("moqtail"),
+        TupleField::from_utf8("demo"),
+      ],
+    };
+    assert!(oversized_namespace_error(&small).is_none());
+  }
+
+  #[test]
+  fn a_prefix_move_is_read_from_the_update_parameters() {
+    let prefix = Tuple::from_utf8_path("meet/room1");
+    let parameters = vec![
+      MessageParameter::new_forward(true),
+      MessageParameter::new_track_namespace_prefix(prefix.clone()),
+    ];
+    assert_eq!(requested_prefix(&parameters), Some(prefix));
+
+    // An update that carries no prefix leaves the subscription where it is.
+    assert_eq!(
+      requested_prefix(&[MessageParameter::new_forward(true)]),
+      None
+    );
+  }
+}

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -45,7 +45,7 @@ use crate::server::{Server, stream_id::StreamId};
 
 use super::{
   client::MOQTClient,
-  message_handlers,
+  message_handlers, prefix_subscription,
   session_context::{RequestMaps, SessionContext},
   track::Track,
   utils,
@@ -584,7 +584,7 @@ impl Session {
                 Some(ns_msg) => {
                   if let Err(e) = stream_handler.send(&ns_msg).await {
                     warn!("Error writing NAMESPACE to bi-stream: {:?}", e);
-                    message_handlers::subscribe_namespace_handler::cancel(client, request_id, &context).await;
+                    prefix_subscription::cancel(client, request_id, &context).await;
                     return;
                   }
                 }
@@ -593,6 +593,22 @@ impl Session {
             }
             result = stream_handler.next_message() => {
               match result {
+                // A REQUEST_UPDATE travels on the stream of the request it updates,
+                // so this is where one for a prefix subscription arrives.
+                Ok(update @ ControlMessage::RequestUpdate(_)) => {
+                  if let Err(e) = message_handlers::MessageHandler::handle(
+                    client.clone(),
+                    &mut stream_handler,
+                    update,
+                    context.clone(),
+                    Some(request_id),
+                  )
+                  .await
+                  {
+                    Self::close_session(context, e, "Error handling prefix subscription update");
+                    return;
+                  }
+                }
                 Ok(extra) => {
                   warn!("Unexpected message {:?} on request bi-stream", extra.get_type());
                   Self::close_session(context, TerminationCode::ProtocolViolation, "Unexpected message on request bi-stream");
@@ -600,7 +616,7 @@ impl Session {
                 }
                 Err(_) => {
                   // FIN or RESET — subscriber cancelled
-                  message_handlers::subscribe_namespace_handler::cancel(client, request_id, &context).await;
+                  prefix_subscription::cancel(client, request_id, &context).await;
                   return;
                 }
               }

--- a/apps/relay/src/server/track_manager.rs
+++ b/apps/relay/src/server/track_manager.rs
@@ -521,7 +521,7 @@ impl TrackManager {
   pub async fn get_tracks_and_publishes_by_namespace_prefix(
     &self,
     prefix: &Tuple,
-  ) -> Vec<(FullTrackName, Arc<RwLock<Track>>, Option<(usize, Publish)>)> {
+  ) -> Vec<(FullTrackName, Arc<RwLock<Track>>, Option<Publish>)> {
     let tracks = self.tracks.read().await;
     let publishes = self.publishes.read().await;
     let mut matches = Vec::new();
@@ -534,15 +534,11 @@ impl TrackManager {
       );
 
       if is_match && let Some(pub_msg_map) = publishes.get(full_track_name) {
-        // The first publish message, with the connection it came from: a pushed
-        // PUBLISH has to record where the track originated, not who it went to.
+        // return the first publish message
         matches.push((
           full_track_name.clone(),
           track_arc.clone(),
-          pub_msg_map
-            .iter()
-            .next()
-            .map(|(connection_id, publish)| (*connection_id, publish.clone())),
+          pub_msg_map.values().next().cloned(),
         ));
       } else if is_match {
         warn!("No publish for track {}", full_track_name);

--- a/apps/relay/src/server/track_manager.rs
+++ b/apps/relay/src/server/track_manager.rs
@@ -521,7 +521,7 @@ impl TrackManager {
   pub async fn get_tracks_and_publishes_by_namespace_prefix(
     &self,
     prefix: &Tuple,
-  ) -> Vec<(FullTrackName, Arc<RwLock<Track>>, Option<Publish>)> {
+  ) -> Vec<(FullTrackName, Arc<RwLock<Track>>, Option<(usize, Publish)>)> {
     let tracks = self.tracks.read().await;
     let publishes = self.publishes.read().await;
     let mut matches = Vec::new();
@@ -534,11 +534,15 @@ impl TrackManager {
       );
 
       if is_match && let Some(pub_msg_map) = publishes.get(full_track_name) {
-        // return the first publish message
+        // The first publish message, with the connection it came from: a pushed
+        // PUBLISH has to record where the track originated, not who it went to.
         matches.push((
           full_track_name.clone(),
           track_arc.clone(),
-          pub_msg_map.values().nth(0).cloned(),
+          pub_msg_map
+            .iter()
+            .next()
+            .map(|(connection_id, publish)| (*connection_id, publish.clone())),
         ));
       } else if is_match {
         warn!("No publish for track {}", full_track_name);
@@ -553,14 +557,21 @@ impl TrackManager {
   /// A prefix already subscribed by this connection with the same kind that
   /// overlaps the new prefix. Overlap spaces are independent per kind, so a
   /// SUBSCRIBE_NAMESPACE never conflicts with a SUBSCRIBE_TRACKS.
+  ///
+  /// `exclude` names a prefix to skip, which is how a subscription being moved
+  /// avoids conflicting with the entry it is about to vacate.
   pub async fn find_overlapping_namespace_subscription(
     &self,
     connection_id: usize,
     new_prefix: &Tuple,
     kind: SubscribeKind,
+    exclude: Option<&Tuple>,
   ) -> Option<Tuple> {
     let subs = self.namespace_subscribers.read().await;
     for (existing_prefix, clients) in subs.iter() {
+      if exclude == Some(existing_prefix) {
+        continue;
+      }
       if clients
         .iter()
         .any(|(c, k, _, _)| c.connection_id == connection_id && *k == kind)
@@ -570,6 +581,37 @@ impl TrackManager {
       }
     }
     None
+  }
+
+  /// Moves this connection's prefix subscription of `kind` from `old_prefix` to
+  /// `new_prefix`, carrying its parameters and channel across so the subscriber
+  /// keeps receiving on the stream it already has. Returns false if there was no
+  /// such subscription to move.
+  pub async fn rekey_namespace_subscriber(
+    &self,
+    old_prefix: &Tuple,
+    new_prefix: Tuple,
+    connection_id: usize,
+    kind: SubscribeKind,
+  ) -> bool {
+    let mut subs = self.namespace_subscribers.write().await;
+
+    let Some(clients) = subs.get_mut(old_prefix) else {
+      return false;
+    };
+    let Some(position) = clients
+      .iter()
+      .position(|(c, k, _, _)| c.connection_id == connection_id && *k == kind)
+    else {
+      return false;
+    };
+    let subscriber = clients.remove(position);
+    if clients.is_empty() {
+      subs.remove(old_prefix);
+    }
+
+    subs.entry(new_prefix).or_default().push(subscriber);
+    true
   }
 
   pub async fn get_track_name_by_publisher(

--- a/libs/moqtail-rs/src/model/common/pair.rs
+++ b/libs/moqtail-rs/src/model/common/pair.rs
@@ -18,7 +18,7 @@ use std::convert::TryInto;
 use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::error::ParseError;
 
-const MAX_VALUE_LENGTH: usize = 65535; // 2^16-1
+pub const MAX_VALUE_LENGTH: usize = 65535; // 2^16-1
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum KeyValuePair {
@@ -121,37 +121,41 @@ impl KeyValuePair {
       let value = bytes.get_vi()?;
       Ok(KeyValuePair::VarInt { type_value, value })
     } else {
-      // Bytes variant
-      let len_u64 = bytes.get_vi()?;
-      let len: usize =
-        len_u64
-          .try_into()
-          .map_err(|e: std::num::TryFromIntError| ParseError::CastingError {
-            context: "KeyValuePair::deserialize length",
-            from_type: "u64",
-            to_type: "usize",
-            details: e.to_string(),
-          })?;
-
-      if len > MAX_VALUE_LENGTH {
-        return Err(ParseError::LengthExceedsMax {
-          context: "KeyValuePair::deserialize",
-          max: MAX_VALUE_LENGTH,
-          len,
-        });
-      }
-      if bytes.remaining() < len {
-        return Err(ParseError::NotEnoughBytes {
-          context: "KeyValuePair::deserialize value",
-          needed: len,
-          available: bytes.remaining(),
-        });
-      }
-
-      let value = bytes.copy_to_bytes(len);
-
-      Ok(KeyValuePair::Bytes { type_value, value })
+      Self::deserialize_bytes_value(bytes, type_value)
     }
+  }
+
+  /// Reads a length-prefixed byte-string Value, independent of Type parity.
+  pub fn deserialize_bytes_value(bytes: &mut Bytes, type_value: u64) -> Result<Self, ParseError> {
+    let len_u64 = bytes.get_vi()?;
+    let len: usize =
+      len_u64
+        .try_into()
+        .map_err(|e: std::num::TryFromIntError| ParseError::CastingError {
+          context: "KeyValuePair::deserialize length",
+          from_type: "u64",
+          to_type: "usize",
+          details: e.to_string(),
+        })?;
+
+    if len > MAX_VALUE_LENGTH {
+      return Err(ParseError::LengthExceedsMax {
+        context: "KeyValuePair::deserialize",
+        max: MAX_VALUE_LENGTH,
+        len,
+      });
+    }
+    if bytes.remaining() < len {
+      return Err(ParseError::NotEnoughBytes {
+        context: "KeyValuePair::deserialize value",
+        needed: len,
+        available: bytes.remaining(),
+      });
+    }
+
+    let value = bytes.copy_to_bytes(len);
+
+    Ok(KeyValuePair::Bytes { type_value, value })
   }
 
   pub fn is_same_type(&self, other: &KeyValuePair) -> bool {

--- a/libs/moqtail-rs/src/model/parameter/message_parameter.rs
+++ b/libs/moqtail-rs/src/model/parameter/message_parameter.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use crate::model::common::location::Location;
-use crate::model::common::pair::KeyValuePair;
+use crate::model::common::pair::{KeyValuePair, MAX_VALUE_LENGTH};
+use crate::model::common::tuple::Tuple;
 use crate::model::common::varint::{BufMutVarIntExt, BufVarIntExt};
 use crate::model::control::constant::{ControlMessageType, FilterType, GroupOrder};
 use crate::model::error::ParseError;
@@ -60,6 +61,9 @@ pub enum MessageParameter {
   },
   NewGroupRequest {
     group: u64,
+  },
+  TrackNamespacePrefix {
+    prefix: Tuple,
   },
 }
 
@@ -116,6 +120,10 @@ impl MessageParameter {
     }
   }
 
+  pub fn new_track_namespace_prefix(prefix: Tuple) -> Self {
+    Self::TrackNamespacePrefix { prefix }
+  }
+
   pub fn new_group_request(group: u64) -> Self {
     Self::NewGroupRequest { group }
   }
@@ -135,6 +143,7 @@ impl MessageParameter {
       Self::GroupOrder { .. } => MessageParameterType::GroupOrder as u64,
       Self::SubscriptionFilter { .. } => MessageParameterType::SubscriptionFilter as u64,
       Self::NewGroupRequest { .. } => MessageParameterType::NewGroupRequest as u64,
+      Self::TrackNamespacePrefix { .. } => MessageParameterType::TrackNamespacePrefix as u64,
     }
   }
 
@@ -222,6 +231,7 @@ impl MessageParameter {
           | ControlMessageType::Subscribe
           | ControlMessageType::RequestUpdate
       ),
+      Self::TrackNamespacePrefix { .. } => matches!(msg_type, ControlMessageType::RequestUpdate),
     }
   }
 
@@ -314,6 +324,16 @@ impl MessageParameter {
             let mut payload = value.clone();
             let location = Location::deserialize(&mut payload)?;
             Ok(Self::LargestObject { location })
+          }
+          MessageParameterType::TrackNamespacePrefix => {
+            let mut payload = value.clone();
+            let prefix = Tuple::deserialize(&mut payload)?;
+            if payload.has_remaining() {
+              return Err(ParseError::KeyValueFormattingError {
+                context: "MessageParameter::deserialize(TrackNamespacePrefix)",
+              });
+            }
+            Ok(Self::TrackNamespacePrefix { prefix })
           }
           MessageParameterType::SubscriptionFilter => {
             let mut payload = value.clone();
@@ -465,6 +485,21 @@ impl TryInto<KeyValuePair> for MessageParameter {
           buf.freeze(),
         )
       }
+      // A namespace tuple: length-prefixed, even though the Type is even.
+      Self::TrackNamespacePrefix { prefix } => {
+        let value = prefix.serialize()?;
+        if value.len() > MAX_VALUE_LENGTH {
+          return Err(ParseError::LengthExceedsMax {
+            context: "MessageParameter::try_into(TrackNamespacePrefix)",
+            max: MAX_VALUE_LENGTH,
+            len: value.len(),
+          });
+        }
+        Ok(KeyValuePair::Bytes {
+          type_value: MessageParameterType::TrackNamespacePrefix as u64,
+          value,
+        })
+      }
     }
   }
 }
@@ -517,6 +552,8 @@ pub fn deserialize_message_parameters(
       loc.put_vi(bytes.get_vi()?)?;
       loc.put_vi(bytes.get_vi()?)?;
       KeyValuePair::try_new_bytes(type_value, loc.freeze())?
+    } else if is_length_prefixed_message_param(type_value) {
+      KeyValuePair::deserialize_bytes_value(bytes, type_value)?
     } else {
       KeyValuePair::deserialize_value(bytes, type_value)?
     };
@@ -536,19 +573,23 @@ pub fn deserialize_message_parameters(
   Ok(params)
 }
 
-/// Message parameters whose Value is a single uint8 byte rather than the generic
-/// even-Type varint: FORWARD (0x10), SUBSCRIBER_PRIORITY (0x20) and GROUP_ORDER
-/// (0x22). All three have even Parameter Types, so the KVP parity rule would
-/// otherwise read them as varints and desync on any value >= 64.
+/// Parameters whose Value is a single uint8 byte rather than a varint, even
+/// though their Type is even. Reading them as varints desyncs on any value >= 64.
 const fn is_uint8_message_param(type_value: u64) -> bool {
-  matches!(type_value, 0x10 | 0x20 | 0x22)
+  type_value == MessageParameterType::Forward as u64
+    || type_value == MessageParameterType::SubscriberPriority as u64
+    || type_value == MessageParameterType::GroupOrder as u64
 }
 
-/// LARGEST_OBJECT (0x09) is a bare Location -- two consecutive varints with no
-/// length prefix. Its Type is odd, so without this the KVP parity rule would
-/// read a length prefix and desync.
+/// Parameters that are a bare Location -- two consecutive varints with no length
+/// prefix -- even though their Type is odd.
 const fn is_location_message_param(type_value: u64) -> bool {
-  matches!(type_value, 0x09)
+  type_value == MessageParameterType::LargestObject as u64
+}
+
+/// Parameters that are length-prefixed even though their Type is even.
+const fn is_length_prefixed_message_param(type_value: u64) -> bool {
+  type_value == MessageParameterType::TrackNamespacePrefix as u64
 }
 
 /// Serializes a slice of MessageParameters into delta-encoded wire bytes,
@@ -621,6 +662,7 @@ pub fn apply_message_parameter_update(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::model::common::tuple::TupleField;
 
   /// LARGEST_OBJECT is a bare Location: Type Delta 0x09 followed by the Group
   /// and Object varints, with no length prefix. These are the bytes another
@@ -830,6 +872,58 @@ mod tests {
     let mut bytes = serialize_message_parameters(&params).unwrap();
     let ok = deserialize_message_parameters(&mut bytes, 1, ControlMessageType::Subscribe).unwrap();
     assert_eq!(ok, vec![MessageParameter::new_object_delivery_timeout(0)]);
+  }
+
+  #[test]
+  fn test_track_namespace_prefix_round_trips_in_a_parameter_list() {
+    // Alongside a neighbour on each side, so a desync in the length-prefixed value
+    // shows up as a corrupted list rather than passing unnoticed.
+    let prefix = Tuple::from_utf8_path("meet/room1/sub");
+    let params = vec![
+      MessageParameter::new_subscriber_priority(200),
+      MessageParameter::new_track_namespace_prefix(prefix.clone()),
+    ];
+    let count = params.len() as u64;
+    let mut bytes = serialize_message_parameters(&params).unwrap();
+    let decoded =
+      deserialize_message_parameters(&mut bytes, count, ControlMessageType::RequestUpdate).unwrap();
+
+    assert!(!bytes.has_remaining(), "the list left trailing bytes");
+    assert_eq!(
+      decoded.get_param(MessageParameterType::TrackNamespacePrefix),
+      Some(&MessageParameter::new_track_namespace_prefix(prefix))
+    );
+    assert_eq!(
+      decoded.get_param(MessageParameterType::SubscriberPriority),
+      Some(&MessageParameter::new_subscriber_priority(200))
+    );
+  }
+
+  #[test]
+  fn test_track_namespace_prefix_rejected_outside_request_update() {
+    let params = vec![MessageParameter::new_track_namespace_prefix(
+      Tuple::from_utf8_path("meet"),
+    )];
+    let mut bytes = serialize_message_parameters(&params).unwrap();
+    let err = deserialize_message_parameters(&mut bytes, 1, ControlMessageType::SubscribeNamespace)
+      .unwrap_err();
+    assert!(matches!(err, ParseError::ProtocolViolation { .. }));
+  }
+
+  #[test]
+  fn test_track_namespace_prefix_rejects_a_short_field_count() {
+    // A count that leaves fields unread must not silently truncate the prefix.
+    let mut value = BytesMut::new();
+    value.put_vi(1u64).unwrap(); // claims one field
+    value.extend_from_slice(&TupleField::from_utf8("meet").serialize().unwrap());
+    value.extend_from_slice(&TupleField::from_utf8("room1").serialize().unwrap());
+
+    let kvp = KeyValuePair::Bytes {
+      type_value: MessageParameterType::TrackNamespacePrefix as u64,
+      value: value.freeze(),
+    };
+    let err = MessageParameter::deserialize(&kvp).unwrap_err();
+    assert!(matches!(err, ParseError::KeyValueFormattingError { .. }));
   }
 
   #[test]


### PR DESCRIPTION
This is a refactor for cleaning up unnecessary code pieces that uses relay_pending_requests data structure. Since the introduction of request control streams, the need for this data structure for some messages became unnecessary. This PR aims to fix this.

Also, handling of namespace prefixes for SUBSCRIBE_TRACKS and SUBSCRIBE_TRACKS is optimized in this PR.