### PR TITLE
Check id gaps for malformed tracks

### DIFF
--- a/.changeset/two-ravens-show.md
+++ b/.changeset/two-ravens-show.md
@@ -1,0 +1,5 @@
+---
+'moqtail-rs': patch
+---
+
+Check prior id gaps for malformed track

--- a/libs/moqtail-rs/src/model/property/object_property.rs
+++ b/libs/moqtail-rs/src/model/property/object_property.rs
@@ -126,6 +126,32 @@ pub fn deserialize_object_properties(bytes: &mut Bytes) -> Result<Vec<ObjectProp
     .collect()
 }
 
+pub fn validate_prior_gaps(
+  group_id: u64,
+  object_id: u64,
+  properties: Option<&[ObjectProperty]>,
+) -> Result<(), ParseError> {
+  let Some(properties) = properties else {
+    return Ok(());
+  };
+
+  for property in properties {
+    let (gap, id, scope) = match property {
+      ObjectProperty::PriorGroupIdGap { gap } => (*gap, group_id, "Group"),
+      ObjectProperty::PriorObjectIdGap { gap } => (*gap, object_id, "Object"),
+      _ => continue,
+    };
+    if gap > id {
+      return Err(ParseError::ProtocolViolation {
+        context: "validate_prior_gaps",
+        details: format!("Prior {scope} ID Gap {gap} is larger than the {scope} ID {id}"),
+      });
+    }
+  }
+
+  Ok(())
+}
+
 fn kvp_varint_value(kvp: &KeyValuePair, context: &'static str) -> Result<u64, ParseError> {
   match kvp {
     KeyValuePair::VarInt { value, .. } => Ok(*value),
@@ -203,6 +229,17 @@ mod tests {
       ObjectProperty::deserialize(outer).unwrap_err(),
       ParseError::ProtocolViolation { .. }
     ));
+  }
+
+  #[test]
+  fn test_prior_gap_larger_than_id_is_error() {
+    let props = [ObjectProperty::PriorObjectIdGap { gap: 8 }];
+    assert!(matches!(
+      validate_prior_gaps(3, 5, Some(&props)).unwrap_err(),
+      ParseError::ProtocolViolation { .. }
+    ));
+    // A gap reaching back exactly to zero is legal.
+    assert!(validate_prior_gaps(3, 8, Some(&props)).is_ok());
   }
 
   #[test]

--- a/libs/moqtail-rs/src/transport/data_stream_handler.rs
+++ b/libs/moqtail-rs/src/transport/data_stream_handler.rs
@@ -31,6 +31,7 @@ use crate::model::data::object::Object;
 use crate::model::data::subgroup_header::SubgroupHeader;
 use crate::model::data::subgroup_object::SubgroupObject;
 use crate::model::error::ParseError;
+use crate::model::property::object_property::validate_prior_gaps;
 use crate::transport::connection::{TransportReadError, TransportRecvStream, TransportSendStream};
 use tracing::{debug, error, info, trace};
 
@@ -552,7 +553,17 @@ impl RecvDataStream {
             let new_ctx = fetch_obj.context();
             match fetch_obj {
               FetchObject::Object(payload) => {
-                if let Err(e) = fetch_state.subgroup_priorities.validate(&payload) {
+                let validated = fetch_state
+                  .subgroup_priorities
+                  .validate(&payload)
+                  .and_then(|()| {
+                    validate_prior_gaps(
+                      payload.group_id,
+                      payload.object_id,
+                      payload.properties.as_deref(),
+                    )
+                  });
+                if let Err(e) = validated {
                   malformed_track.store(true, Ordering::Relaxed);
                   return Err(e);
                 }


### PR DESCRIPTION
The spec says a track is considered malformed if "An Object has a Prior Group ID Gap larger than the Group ID." See section 12.8.
