### PR TITLE
fix(relay): hold PUBLISH_DONE until its data streams have arrived

### DIFF
--- a/apps/relay/src/server/config.rs
+++ b/apps/relay/src/server/config.rs
@@ -140,6 +140,12 @@ pub struct Cli {
   /// queue meanwhile; once it elapses they are forwarded regardless.
   #[arg(long, default_value_t = 3000)]
   pub downstream_alias_timeout_ms: u64,
+  /// How long a PUBLISH_DONE waits for the data streams it accounts for to finish
+  /// arriving before the track is torn down anyway. The message rides the request
+  /// stream and overtakes them, so forwarding it straight through would cut objects
+  /// still in flight.
+  #[arg(long, default_value_t = 2000)]
+  pub publish_done_stream_timeout_ms: u64,
   /// How many recent groups of Object ids are remembered per track, to drop duplicates
   /// when several publishers serve the same Track. 0 turns duplicate detection off.
   /// Capped, because the memory this costs also scales with the size of a group
@@ -181,6 +187,10 @@ pub struct AppConfig {
   /// A subscriber cannot place a data stream until it has the track alias. Forwarding
   /// waits this long for the control message carrying it, then proceeds regardless.
   pub downstream_alias_timeout: Duration,
+  /// A publisher's PUBLISH_DONE is held until the data streams it accounts for have
+  /// finished arriving. This bounds that wait, so a stream that never ends cannot
+  /// keep the track alive forever.
+  pub publish_done_stream_timeout: Duration,
   /// Groups of Object ids retained per track for duplicate detection. Bounds what that
   /// costs; a publisher more than this many groups behind can slip a duplicate through.
   pub dedup_retained_groups: usize,
@@ -219,6 +229,7 @@ impl AppConfig {
           cli.track_alias_resolution_timeout_ms,
         ),
         downstream_alias_timeout: Duration::from_millis(cli.downstream_alias_timeout_ms),
+        publish_done_stream_timeout: Duration::from_millis(cli.publish_done_stream_timeout_ms),
         dedup_retained_groups: cli.dedup_retained_groups as usize,
       }
     })
@@ -377,6 +388,7 @@ mod tests {
       upstream_subscribe_timeout: Duration::from_secs(10),
       track_alias_resolution_timeout: Duration::from_millis(500),
       downstream_alias_timeout: Duration::from_millis(3000),
+      publish_done_stream_timeout: Duration::from_millis(2000),
       dedup_retained_groups: 30,
     }
   }

--- a/apps/relay/src/server/message_handlers/publish_handler.rs
+++ b/apps/relay/src/server/message_handlers/publish_handler.rs
@@ -18,7 +18,7 @@ use crate::server::session::Session;
 use crate::server::session_context::PendingRequest;
 use crate::server::session_context::SessionContext;
 use crate::server::subscription::Subscription;
-use crate::server::track::{Track, TrackOrigin, TrackStatus};
+use crate::server::track::{Track, TrackOrigin, TrackStatus, await_publisher_streams};
 use crate::server::track_manager::SubscribeKind;
 use core::result::Result;
 use moqtail::model::common::reason_phrase::ReasonPhrase;
@@ -312,6 +312,13 @@ pub async fn handle(
         "Received PublishDone message for request ID: {} with status: {:?}",
         publisher_req_id, m.status_code
       );
+
+      // PUBLISH_DONE rides the request stream, which overtakes the data streams it
+      // accounts for. Tearing the track down now would close the downstream streams
+      // out from under objects still arriving, and would hand subscribers a Stream
+      // Count for streams the relay has yet to open. Its own Stream Count says how
+      // many the publisher opened, so wait for that many to finish first.
+      wait_for_publisher_streams(&client, publisher_req_id, m.stream_count, &context).await;
 
       // Clean up the published track
       cleanup_published_track(&client, publisher_req_id, &context).await;
@@ -706,6 +713,38 @@ async fn validate_publish_authorization(
 
   // For now, allow all publishes (this should be replaced with actual auth logic)
   true
+}
+
+/// Resolves the track this PUBLISH_DONE ends, then waits for the data streams it
+/// accounts for to finish arriving.
+async fn wait_for_publisher_streams(
+  client: &Arc<MOQTClient>,
+  request_id: u64,
+  stream_count: u64,
+  context: &Arc<SessionContext>,
+) {
+  if stream_count == 0 {
+    return;
+  }
+
+  let full_track_name = {
+    let published_tracks = client.published_tracks.read().await;
+    published_tracks.get(&request_id).cloned()
+  };
+  let Some(full_track_name) = full_track_name else {
+    return;
+  };
+  let Some(track_arc) = context.track_manager.get_track(&full_track_name).await else {
+    return;
+  };
+
+  await_publisher_streams(
+    &track_arc,
+    client.connection_id,
+    stream_count,
+    context.server_config.publish_done_stream_timeout,
+  )
+  .await;
 }
 
 /// Cleans up resources associated with a published track.

--- a/apps/relay/src/server/message_handlers/subscribe_handler.rs
+++ b/apps/relay/src/server/message_handlers/subscribe_handler.rs
@@ -17,7 +17,7 @@ use crate::server::client::switch_context::SwitchStatus;
 use crate::server::message_handlers::parameters;
 use crate::server::session::Session;
 use crate::server::session_context::{PendingRequest, SessionContext};
-use crate::server::track::{Track, TrackOrigin, TrackStatus};
+use crate::server::track::{Track, TrackOrigin, TrackStatus, await_publisher_streams};
 use core::result::Result;
 use moqtail::model::control::constant::PublishDoneStatusCode;
 use moqtail::model::control::publish_done::PublishDone;
@@ -200,14 +200,27 @@ async fn upstream_subscribe_exchange(
               m.status_code,
               m.reason_phrase.as_str()
             );
-            if let Some(track) = context.track_manager.get_track(&full_track_name).await
-              && let Err(e) = track
+            if let Some(track) = context.track_manager.get_track(&full_track_name).await {
+              // The message overtakes the data streams it accounts for, so hold it
+              // until its Stream Count of them has finished arriving. Passing it on
+              // first closes the downstream streams mid-object and understates the
+              // Stream Count the relay reports in turn.
+              await_publisher_streams(
+                &track,
+                publisher.connection_id,
+                m.stream_count,
+                context.server_config.publish_done_stream_timeout,
+              )
+              .await;
+
+              if let Err(e) = track
                 .read()
                 .await
                 .notify_publish_done(m.status_code, m.reason_phrase.as_str().to_string())
                 .await
-            {
-              error!("Failed to relay upstream PUBLISH_DONE downstream: {:?}", e);
+              {
+                error!("Failed to relay upstream PUBLISH_DONE downstream: {:?}", e);
+              }
             }
             return;
           }

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -862,6 +862,9 @@ impl Session {
     let mut track_alias = 0u64;
     let mut stream_id: Option<StreamId> = None;
     let mut current_track: Option<Arc<RwLock<Track>>> = None;
+    // Only subgroup streams count toward the Stream Count a publisher reports in
+    // PUBLISH_DONE; a fetch stream answers a request of the relay's own.
+    let mut is_subgroup_stream = false;
     // Used if this stream is a response to an upstream fetch the relay issued.
     let mut upstream_sender: Option<
       tokio::sync::mpsc::Sender<super::session_context::UpstreamFetchEvent>,
@@ -892,6 +895,7 @@ impl Session {
               HeaderInfo::Subgroup { header } => {
                 debug!("received Subgroup header: {:?}", header);
                 track_alias = header.track_alias;
+                is_subgroup_stream = true;
               }
               HeaderInfo::Fetch {
                 header,
@@ -979,7 +983,7 @@ impl Session {
           object_count += 1;
           first_object = false; // reset the first object flag after processing the header
         }
-        (_, None) => {
+        (handler, None) => {
           // error!("Failed to receive object: {:?}", e);
           info!(
             "no more objects in the stream client: {} track: {} stream_id: {:?} objects: {}",
@@ -996,13 +1000,36 @@ impl Session {
               .await;
           }
 
+          // A subgroup stream that carried no object never resolved its track above,
+          // yet its publisher still counts it. Resolve it from the header so the
+          // count a PUBLISH_DONE is waiting on can reach the number it names.
+          if current_track.is_none()
+            && let Some(HeaderInfo::Subgroup { header }) = handler.get_header_info().await
+          {
+            is_subgroup_stream = true;
+            track_alias = header.track_alias;
+            current_track = context
+              .track_manager
+              .resolve_track_by_alias(
+                context.connection_id,
+                track_alias,
+                context.server_config.track_alias_resolution_timeout,
+              )
+              .await;
+          }
+
           // Close the stream for all subscribers
           if let Some(track_lock) = &current_track {
-            return track_lock
-              .read()
-              .await
-              .stream_closed(&stream_id.unwrap())
-              .await;
+            let track = track_lock.read().await;
+            if is_subgroup_stream {
+              track
+                .publisher_stream_progress
+                .stream_closed(context.connection_id)
+                .await;
+            }
+            if let Some(stream_id) = &stream_id {
+              return track.stream_closed(stream_id).await;
+            }
           }
           break;
         }

--- a/apps/relay/src/server/track.rs
+++ b/apps/relay/src/server/track.rs
@@ -36,10 +36,81 @@ use moqtail::transport::data_stream_handler::HeaderInfo;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
 use tokio::sync::{Mutex, Notify, RwLock, oneshot};
 use tracing::{debug, error, info, warn};
 
 pub type ActiveSubgroupHeaderMap = Arc<RwLock<HashMap<StreamId, HeaderInfo>>>;
+
+/// How many data streams each publisher has finished sending for one track.
+///
+/// A PUBLISH_DONE carries the number of data streams its sender opened, and it
+/// travels on the request stream, which overtakes those streams. Ending the
+/// downstream subscriptions the moment it lands would cut off objects still
+/// arriving, so the relay waits here for the streams to be accounted for first.
+#[derive(Debug, Default)]
+pub struct PublisherStreamProgress {
+  /// publisher_connection_id -> data streams finished for this track.
+  closed: RwLock<HashMap<usize, u64>>,
+  changed: Notify,
+}
+
+impl PublisherStreamProgress {
+  /// Record one finished data stream from this publisher.
+  pub async fn stream_closed(&self, publisher_connection_id: usize) {
+    {
+      let mut closed = self.closed.write().await;
+      *closed.entry(publisher_connection_id).or_insert(0) += 1;
+    }
+    self.changed.notify_waiters();
+  }
+
+  pub async fn closed_count(&self, publisher_connection_id: usize) -> u64 {
+    self
+      .closed
+      .read()
+      .await
+      .get(&publisher_connection_id)
+      .copied()
+      .unwrap_or(0)
+  }
+
+  /// Drop a publisher's count once it no longer publishes the track.
+  pub async fn forget(&self, publisher_connection_id: usize) {
+    self.closed.write().await.remove(&publisher_connection_id);
+  }
+
+  /// Wait for `stream_count` of this publisher's data streams to finish, giving up
+  /// after `timeout`. Returns how many had finished when the wait ended; a result
+  /// below `stream_count` means it timed out.
+  pub async fn wait_for(
+    &self,
+    publisher_connection_id: usize,
+    stream_count: u64,
+    timeout: Duration,
+  ) -> u64 {
+    let wait = async {
+      loop {
+        // Registered before the count is read, so a stream finishing between the
+        // two still wakes this loop rather than leaving it to time out.
+        let changed = self.changed.notified();
+        tokio::pin!(changed);
+        changed.as_mut().enable();
+
+        let closed = self.closed_count(publisher_connection_id).await;
+        if closed >= stream_count {
+          return closed;
+        }
+        changed.await;
+      }
+    };
+
+    match tokio::time::timeout(timeout, wait).await {
+      Ok(closed) => closed,
+      Err(_) => self.closed_count(publisher_connection_id).await,
+    }
+  }
+}
 
 /// What created a track. Decides whether it survives its last subscriber.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -120,6 +191,9 @@ pub struct Track {
   /// Inserted when the first object of a subgroup arrives; removed when the
   /// publisher's unistream closes (stream_closed signal).
   pub active_subgroup_headers: ActiveSubgroupHeaderMap,
+  /// Data streams each publisher has finished sending, so a PUBLISH_DONE can be
+  /// held until the streams it accounts for have been taken in.
+  pub publisher_stream_progress: Arc<PublisherStreamProgress>,
   /// One per publisher; firing it resets that relay-owned upstream SUBSCRIBE stream
   /// when the last downstream subscriber goes away. Only the pull path fills this, so
   /// a PUBLISH-created track leaves it empty and a subscriber leaving never cancels
@@ -166,6 +240,7 @@ impl Track {
       pending_subscribers: Arc::new(RwLock::new(Vec::new())),
       track_properties: Arc::new(RwLock::new(Vec::new())),
       active_subgroup_headers: Arc::new(RwLock::new(HashMap::new())),
+      publisher_stream_progress: Arc::new(PublisherStreamProgress::default()),
       upstream_subscribe_cancellers: Arc::new(Mutex::new(Vec::new())),
       pending_upstream_subscribe_count: Arc::new(AtomicUsize::new(0)),
       upstream_forward: Arc::new(AtomicBool::new(false)),
@@ -201,6 +276,7 @@ impl Track {
     };
 
     if let Some(alias) = removed_alias {
+      self.publisher_stream_progress.forget(connection_id).await;
       let has_publishers = !self.publisher_aliases.read().await.is_empty();
       info!(
         "Removed publisher {}@alias={} from relay_track_id={} | publishers_remaining={}",
@@ -608,5 +684,125 @@ impl Track {
       .await?;
 
     Ok(())
+  }
+}
+
+/// Holds a PUBLISH_DONE back until `stream_count` of that publisher's data streams
+/// for the track have finished arriving, or `timeout` elapses. A publisher that names
+/// more streams than it opens must not stall the subscription's end, so a short count
+/// is logged and the caller carries on.
+pub async fn await_publisher_streams(
+  track: &Arc<RwLock<Track>>,
+  publisher_connection_id: usize,
+  stream_count: u64,
+  timeout: Duration,
+) {
+  if stream_count == 0 {
+    return;
+  }
+
+  // Taken out of the track before waiting: holding the track lock for the length of
+  // the wait would stall every other publisher and subscriber on it.
+  let (progress, full_track_name) = {
+    let track = track.read().await;
+    (
+      track.publisher_stream_progress.clone(),
+      track.full_track_name.clone(),
+    )
+  };
+
+  let closed = progress
+    .wait_for(publisher_connection_id, stream_count, timeout)
+    .await;
+
+  if closed < stream_count {
+    warn!(
+      "PUBLISH_DONE from publisher {} for {:?} named {} streams, {} finished within {:?}; ending the subscription anyway",
+      publisher_connection_id, full_track_name, stream_count, closed, timeout
+    );
+  } else {
+    debug!(
+      "PUBLISH_DONE from publisher {} for {:?}: all {} streams finished",
+      publisher_connection_id, full_track_name, stream_count
+    );
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  const PUBLISHER: usize = 7;
+  const OTHER_PUBLISHER: usize = 9;
+
+  #[tokio::test]
+  async fn wait_returns_at_once_when_the_streams_already_finished() {
+    let progress = PublisherStreamProgress::default();
+    for _ in 0..3 {
+      progress.stream_closed(PUBLISHER).await;
+    }
+
+    let closed = progress
+      .wait_for(PUBLISHER, 3, Duration::from_millis(50))
+      .await;
+
+    assert_eq!(closed, 3);
+  }
+
+  #[tokio::test]
+  async fn wait_is_released_by_a_stream_finishing_later() {
+    let progress = Arc::new(PublisherStreamProgress::default());
+    let writer = progress.clone();
+    tokio::spawn(async move {
+      for _ in 0..2 {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        writer.stream_closed(PUBLISHER).await;
+      }
+    });
+
+    let closed = progress
+      .wait_for(PUBLISHER, 2, Duration::from_secs(5))
+      .await;
+
+    assert_eq!(closed, 2);
+  }
+
+  #[tokio::test]
+  async fn wait_gives_up_and_reports_the_short_count() {
+    let progress = PublisherStreamProgress::default();
+    progress.stream_closed(PUBLISHER).await;
+
+    let closed = progress
+      .wait_for(PUBLISHER, 4, Duration::from_millis(20))
+      .await;
+
+    assert_eq!(closed, 1);
+  }
+
+  #[tokio::test]
+  async fn each_publisher_is_counted_on_its_own() {
+    let progress = PublisherStreamProgress::default();
+    progress.stream_closed(PUBLISHER).await;
+    progress.stream_closed(PUBLISHER).await;
+    progress.stream_closed(OTHER_PUBLISHER).await;
+
+    assert_eq!(progress.closed_count(PUBLISHER).await, 2);
+    assert_eq!(progress.closed_count(OTHER_PUBLISHER).await, 1);
+    // One publisher's streams must not release another's PUBLISH_DONE.
+    assert_eq!(
+      progress
+        .wait_for(OTHER_PUBLISHER, 2, Duration::from_millis(20))
+        .await,
+      1
+    );
+  }
+
+  #[tokio::test]
+  async fn forgetting_a_publisher_clears_its_count() {
+    let progress = PublisherStreamProgress::default();
+    progress.stream_closed(PUBLISHER).await;
+    progress.forget(PUBLISHER).await;
+
+    assert_eq!(progress.closed_count(PUBLISHER).await, 0);
   }
 }


### PR DESCRIPTION
PUBLISH_DONE travels on the request stream, which overtakes the data streams it accounts for. The relay acted on it the moment it landed: cleanup_published_track removed the publisher, which notified subscribers and finished their subscriptions, closing every downstream send stream out from under objects still arriving. It also snapshotted the relay's own Stream Count before it had opened the streams it still had to open, so subscribers were told to expect fewer than they would receive.

The message names how many data streams its sender opened, so wait for that many to finish before ending the subscriptions. Track now carries a per-publisher count of finished data streams with a signal to wait on; subgroup streams record themselves as they close, and both the push path (publish_handler) and the pull path (an upstream PUBLISH_DONE on a relay-issued SUBSCRIBE) wait on it.

A publisher that names more streams than it opens must not stall the subscription's end, so --publish-done-stream-timeout-ms (default 2000) bounds the wait and a short count is logged before carrying on.

A subgroup stream carrying only a header never resolved its track, since that happened on the first object. It now resolves from the header at stream end, otherwise a count including such a stream could never be reached.
