### PR TITLE
feat: properly handle empty FETCHes

### DIFF
--- a/.changeset/sunny-hotels-flow.md
+++ b/.changeset/sunny-hotels-flow.md
@@ -1,0 +1,5 @@
+---
+'relay': patch
+---
+
+Report stream closed for empty FETCHes

--- a/apps/relay/src/server/session.rs
+++ b/apps/relay/src/server/session.rs
@@ -992,6 +992,19 @@ impl Session {
             stream_id.clone(),
             object_count
           );
+
+          // Resolve an empty FETCH stream's sender from its parsed header.
+          if upstream_sender.is_none()
+            && let Some(HeaderInfo::Fetch { header, .. }) = handler.get_header_info().await
+          {
+            upstream_sender = context
+              .upstream_fetch_senders
+              .read()
+              .await
+              .get(&header.request_id)
+              .cloned();
+          }
+
           // A relay-initiated fetch ends when its stream does. Without this the loop
           // waiting on those Objects has nothing to end it but its own timeout.
           if let Some(ref sender) = upstream_sender {


### PR DESCRIPTION
Fixes empty upstream FETCH responses by immediately signaling when their stream closes, instead of waiting for a timeout.